### PR TITLE
using capitalised case in naming convention for dynamodb config

### DIFF
--- a/dynamoDb/cfn/cfn.yaml
+++ b/dynamoDb/cfn/cfn.yaml
@@ -16,20 +16,20 @@ Resources:
   PriceMigrationEngineDynamoTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub price-migration-engine-${Stage}
+      TableName: !Sub PriceMigrationEngine${Stage}
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
-        - AttributeName: "subscription-number"
+        - AttributeName: "SubscriptionNumber"
           AttributeType: "S"
-        - AttributeName: "processing-stage"
+        - AttributeName: "ProcessingStage"
           AttributeType: "S"
       KeySchema:
-        - AttributeName: "subscription-number"
+        - AttributeName: "SubscriptionNumber"
           KeyType: "HASH"
       GlobalSecondaryIndexes:
-        - IndexName: "processing-stage-index"
+        - IndexName: "ProcessingStageIndex"
           KeySchema:
-            - AttributeName: "processing-stage"
+            - AttributeName: "ProcessingStage"
               KeyType: "HASH"
           Projection:
             ProjectionType: "KEYS_ONLY"


### PR DESCRIPTION
This seems to be the convention and - in key names seems to cause problems in the cli.