### PR TITLE
Add lambda infrastructure and logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       zio,
       upickle,
+      lambda,
       munit % Test
     ),
     testFrameworks += new TestFramework("munit.Framework")
@@ -20,11 +21,9 @@ lazy val dynamoDb = (project in file("dynamoDb"))
   .settings(
     name := "price-migration-engine",
     name := "price-migration-engine-dynamo-db",
-    description:= "Cloudformation for price-migration-engine-dynamo-db",
+    description := "Cloudformation for price-migration-engine-dynamo-db",
     riffRaffPackageType := (baseDirectory.value / "cfn"),
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffManifestProjectName := "MemSub::Subscriptions::DynamoDb::PriceMigrationEngine"
   )
-
-

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,5 +3,6 @@ import sbt._
 object Dependencies {
   lazy val zio = "dev.zio" %% "zio" % "1.0.0-RC18-2"
   lazy val upickle = "com.lihaoyi" %% "upickle" % "1.1.0"
+  lazy val lambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val munit = "org.scalameta" %% "munit" % "0.7.5"
 }

--- a/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -5,17 +5,15 @@ import java.time.LocalDate
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import pricemigrationengine.model.CohortTableFilter.ReadyForEstimation
 import pricemigrationengine.model._
-import pricemigrationengine.services.{CohortTable, CohortTableTest, Zuora, ZuoraTest}
+import pricemigrationengine.services._
 import zio.console.Console
-import zio.{App, Runtime, ZEnv, ZIO, console}
+import zio.{App, Runtime, ZEnv, ZIO, ZLayer}
 
 object EstimationHandler extends App with RequestHandler[Unit, Unit] {
 
   // TODO: configuration
   val batchSize = 100
   val earliestStartDate = LocalDate.now
-
-  private val runtime = Runtime.default
 
   def estimation(item: CohortItem, earliestStartDate: LocalDate): ZIO[Zuora, Failure, EstimationResult] = {
     val result = for {
@@ -25,20 +23,46 @@ object EstimationHandler extends App with RequestHandler[Unit, Unit] {
     result.absolve
   }
 
-  val main: ZIO[Console with CohortTable with Zuora, Failure, Unit] =
+  val main: ZIO[Logging with CohortTable with Zuora, Failure, Unit] =
     for {
-      cohortItems <- CohortTable.fetch(ReadyForEstimation, batchSize)
-      results <- ZIO.foreach(cohortItems)(item => estimation(item, earliestStartDate))
-      _ <- ZIO.foreach(results)(CohortTable.update)
+      cohortItems <- CohortTable
+        .fetch(ReadyForEstimation, batchSize)
+        .tapBoth(
+          e => Logging.error(s"Failed to fetch from Cohort table: $e"),
+          items => Logging.info(s"Fetched ${items.size} subs from Cohort table: $items")
+        )
+      results <- ZIO.foreach(cohortItems)(
+        item =>
+          estimation(item, earliestStartDate).tapBoth(
+            e => Logging.error(s"Failed to estimate amendment data: $e"),
+            result => Logging.info(s"Estimated result: $result")
+        )
+      )
+      _ <- ZIO.foreach(results)(
+        result =>
+          CohortTable
+            .update(result)
+            .tapBoth(
+              e => Logging.error(s"Failed to update Cohort table: $e"),
+              _ => Logging.info(s"Wrote $result to Cohort table")
+          )
+      )
     } yield ()
+
+  private val env = CohortTableTest.impl ++ ZuoraTest.impl
+  private val runtime = Runtime.default
 
   def run(args: List[String]): ZIO[ZEnv, Nothing, Int] =
     main
-      .provideCustomLayer(CohortTableTest.impl ++ ZuoraTest.impl)
-      .foldM(
-        e => console.putStrLn(s"Failed: $e") *> ZIO.succeed(1),
-        _ => ZIO.succeed(0)
+      .provideCustomLayer(
+        env ++ ConsoleLogging.impl
       )
+      .fold(_ => 1, _ => 0)
 
-  def handleRequest(unused: Unit, context: Context): Unit = runtime.unsafeRun(run(Nil))
+  def handleRequest(unused: Unit, context: Context): Unit =
+    runtime.unsafeRun(
+      main.provideCustomLayer(
+        env ++ LambdaLogging.impl(context)
+      )
+    )
 }

--- a/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -2,24 +2,20 @@ package pricemigrationengine.handlers
 
 import java.time.LocalDate
 
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import pricemigrationengine.model.CohortTableFilter.ReadyForEstimation
 import pricemigrationengine.model._
 import pricemigrationengine.services.{CohortTable, CohortTableTest, Zuora, ZuoraTest}
 import zio.console.Console
-import zio.{App, ZEnv, ZIO, console}
+import zio.{App, Runtime, ZEnv, ZIO, console}
 
-object EstimationHandler extends App {
+object EstimationHandler extends App with RequestHandler[Unit, Unit] {
 
   // TODO: configuration
   val batchSize = 100
   val earliestStartDate = LocalDate.now
 
-  val main: ZIO[Console with CohortTable with Zuora, Failure, Unit] =
-    for {
-      cohortItems <- CohortTable.fetch(ReadyForEstimation, batchSize)
-      results <- ZIO.foreach(cohortItems)(item => estimation(item, earliestStartDate))
-      _ <- ZIO.foreach(results)(CohortTable.update)
-    } yield ()
+  private val runtime = Runtime.default
 
   def estimation(item: CohortItem, earliestStartDate: LocalDate): ZIO[Zuora, Failure, EstimationResult] = {
     val result = for {
@@ -29,13 +25,20 @@ object EstimationHandler extends App {
     result.absolve
   }
 
+  val main: ZIO[Console with CohortTable with Zuora, Failure, Unit] =
+    for {
+      cohortItems <- CohortTable.fetch(ReadyForEstimation, batchSize)
+      results <- ZIO.foreach(cohortItems)(item => estimation(item, earliestStartDate))
+      _ <- ZIO.foreach(results)(CohortTable.update)
+    } yield ()
+
   def run(args: List[String]): ZIO[ZEnv, Nothing, Int] =
     main
-      .provideCustomLayer(
-        CohortTableTest.impl ++ ZuoraTest.impl
-      )
+      .provideCustomLayer(CohortTableTest.impl ++ ZuoraTest.impl)
       .foldM(
         e => console.putStrLn(s"Failed: $e") *> ZIO.succeed(1),
         _ => ZIO.succeed(0)
       )
+
+  def handleRequest(unused: Unit, context: Context): Unit = runtime.unsafeRun(run(Nil))
 }

--- a/src/main/scala/pricemigrationengine/services/ConsoleLogging.scala
+++ b/src/main/scala/pricemigrationengine/services/ConsoleLogging.scala
@@ -1,0 +1,14 @@
+package pricemigrationengine.services
+
+import zio.console.Console
+import zio.{UIO, ZLayer}
+
+object ConsoleLogging {
+  val impl: ZLayer[Console, Nothing, Logging] = ZLayer.fromService(
+    console =>
+      new Logging.Service {
+        def info(s: String): UIO[Unit] = console.putStrLn(s"INFO: $s")
+        def error(s: String): UIO[Unit] = console.putStrLn(s"ERROR: $s")
+    }
+  )
+}

--- a/src/main/scala/pricemigrationengine/services/LambdaLogging.scala
+++ b/src/main/scala/pricemigrationengine/services/LambdaLogging.scala
@@ -1,0 +1,14 @@
+package pricemigrationengine.services
+
+import com.amazonaws.services.lambda.runtime.Context
+import zio.{UIO, ZIO, ZLayer}
+
+object LambdaLogging {
+  def impl(context: Context): ZLayer[Any, Nothing, Logging] = ZLayer.succeed(
+    new Logging.Service {
+      val logger = context.getLogger
+      def info(s: String): UIO[Unit] = ZIO.succeed(logger.log(s"INFO: $s"))
+      def error(s: String): UIO[Unit] = ZIO.succeed(logger.log(s"ERROR: $s"))
+    }
+  )
+}

--- a/src/main/scala/pricemigrationengine/services/Logging.scala
+++ b/src/main/scala/pricemigrationengine/services/Logging.scala
@@ -1,0 +1,17 @@
+package pricemigrationengine.services
+
+import zio.{UIO, ZIO}
+
+object Logging {
+
+  trait Service {
+    def info(s: String): UIO[Unit]
+    def error(s: String): UIO[Unit]
+  }
+
+  def info(s: String): ZIO[Logging, Nothing, Unit] =
+    ZIO.accessM(_.get.info(s))
+
+  def error(s: String): ZIO[Logging, Nothing, Unit] =
+    ZIO.accessM(_.get.error(s))
+}

--- a/src/main/scala/pricemigrationengine/services/package.scala
+++ b/src/main/scala/pricemigrationengine/services/package.scala
@@ -5,4 +5,5 @@ import zio.Has
 package object services {
   type CohortTable = Has[CohortTable.Service]
   type Zuora = Has[Zuora.Service]
+  type Logging = Has[Logging.Service]
 }


### PR DESCRIPTION
This is an attempt at lightweight logging without bringing in intermediary logging libraries.
The handler should now be able to run as a lambda and as a standalone script, in principle.
