### PR TITLE
Add configuration service

### DIFF
--- a/src/main/scala/pricemigrationengine/model/Config.scala
+++ b/src/main/scala/pricemigrationengine/model/Config.scala
@@ -1,0 +1,5 @@
+package pricemigrationengine.model
+
+case class Config(zuora: ZuoraConfig)
+
+case class ZuoraConfig(baseUrl: String, clientId: String, clientSecret: String)

--- a/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -4,6 +4,8 @@ sealed trait Failure {
   val reason: String
 }
 
+case class ConfigurationFailure(reason: String) extends Failure
+
 case class CohortFetchFailure(reason: String) extends Failure
 case class CohortUpdateFailure(reason: String) extends Failure
 

--- a/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
+++ b/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
@@ -5,7 +5,7 @@ import zio.console.Console
 import zio.{ZIO, ZLayer}
 
 object CohortTableTest {
-  val impl: ZLayer[Console, Throwable, CohortTable] = ZLayer.fromService(
+  val impl: ZLayer[Console, Nothing, CohortTable] = ZLayer.fromService(
     console =>
       new CohortTable.Service {
 

--- a/src/main/scala/pricemigrationengine/services/Configuration.scala
+++ b/src/main/scala/pricemigrationengine/services/Configuration.scala
@@ -1,0 +1,14 @@
+package pricemigrationengine.services
+
+import pricemigrationengine.model.{Config, ConfigurationFailure}
+import zio.{IO, ZIO}
+
+object Configuration {
+
+  trait Service {
+    val config: IO[ConfigurationFailure, Config]
+  }
+
+  val config: ZIO[Configuration, ConfigurationFailure, Config] =
+    ZIO.accessM(_.get.config)
+}

--- a/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
+++ b/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
@@ -1,0 +1,31 @@
+package pricemigrationengine.services
+
+import java.lang.System.getenv
+
+import pricemigrationengine.model.{Config, ConfigurationFailure, ZuoraConfig}
+import zio.{IO, ZIO, ZLayer}
+
+object EnvConfiguration {
+  val impl: ZLayer[Any, Nothing, Configuration] = ZLayer.succeed {
+    def env(name: String): IO[ConfigurationFailure, String] =
+      ZIO
+        .effect(getenv(name))
+        .mapError(e => ConfigurationFailure(e.getMessage))
+        .filterOrFail(Option(_).nonEmpty)(ConfigurationFailure(s"No value for '$name' in environment"))
+
+    new Configuration.Service {
+      val config: IO[ConfigurationFailure, Config] = for {
+        baseUrl <- env("zuora.baseUrl")
+        clientId <- env("zuora.clientId")
+        clientSecret <- env("zuora.clientSecret")
+      } yield
+        Config(
+          ZuoraConfig(
+            baseUrl,
+            clientId,
+            clientSecret
+          )
+        )
+    }
+  }
+}

--- a/src/main/scala/pricemigrationengine/services/ZuoraTest.scala
+++ b/src/main/scala/pricemigrationengine/services/ZuoraTest.scala
@@ -6,7 +6,7 @@ import pricemigrationengine.model._
 import zio.{ZIO, ZLayer}
 
 object ZuoraTest {
-  val impl: ZLayer[Any, Throwable, Zuora] = ZLayer.succeed(
+  val impl: ZLayer[Any, Nothing, Zuora] = ZLayer.succeed(
     new Zuora.Service {
 
       def fetchSubscription(name: String): ZIO[Any, ZuoraFetchFailure, ZuoraSubscription] =

--- a/src/main/scala/pricemigrationengine/services/package.scala
+++ b/src/main/scala/pricemigrationengine/services/package.scala
@@ -3,6 +3,7 @@ package pricemigrationengine
 import zio.Has
 
 package object services {
+  type Configuration = Has[Configuration.Service]
   type CohortTable = Has[CohortTable.Service]
   type Zuora = Has[Zuora.Service]
   type Logging = Has[Logging.Service]


### PR DESCRIPTION
This adds a [configuration service](https://github.com/guardian/price-migration-engine/blob/185441c75f5191dc24be40979e94cd9b863935a0/src/main/scala/pricemigrationengine/services/Configuration.scala) and an [env implementation](https://github.com/guardian/price-migration-engine/blob/185441c75f5191dc24be40979e94cd9b863935a0/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala).

My aim is to provide the config in a lambda environment through the param store, something like the [invoicing-api](https://github.com/guardian/invoicing-api/blob/master/cfn.yaml#L62) does it.
