### PR TITLE
Improve secret update process

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -10,20 +10,34 @@ The configuration for this application is stored in the [aws secret manager](htt
 
 The configuration can be updated using the aws console as follows:
 
-- Log into the aws console using the 'membership' profile via [janus](https://janus.gutools.co.uk/)
-- Navigate to Services > Security, Identity, & Compliance > Secrets Manager
-- Search for price-migration-engine-<STAGE> and click on the result
-- Click 'Retrieve Secret Value' button
-- Click 'Edit' 
-- Add/Edit the key value pairs
-- Click 'Save'
-
-Cloudformation seems reluctant to reapply the updated configuration to the lambda environment variables. This 
-can be done by deleting the lambda stack and redeploying it with riffraff.
-
-You can delete the stack as follows:
-- Log into the aws console using the 'membership' profile via [janus](https://janus.gutools.co.uk/)
-- Navigate to Services > Management & Governance > Cloudformation
-- Search for membership-<STAGE>-price-migration-engine-lambda and click on the result
-- Click the 'delete' button
-- Click the 'delete stack' button 
+- You can either update the secrets using the aws console
+  - Log into the aws console using the 'membership' profile via [janus](https://janus.gutools.co.uk/)
+  - Navigate to Services > Security, Identity, & Compliance > Secrets Manager
+  - Search for price-migration-engine-<STAGE> and click on the result
+  - Click 'Retrieve Secret Value' button
+  - Click 'Edit' 
+  - Add/Edit the key value pairs
+  - Click 'Save'
+- Or use the AWS CLI
+  - Get the 'membership' aws credentials from [janus](https://janus.gutools.co.uk/) and add them to your local environment
+  - Get the existing configuration 
+  - get the current secrets 
+    ```bash
+    aws --region eu-west-1 --profile membership secretsmanager get-secret-value --version-stage AWSCURRENT --secret-id price-migration-engine-lambda-<STAGE>
+    ```
+  - The existing string is returned in the "SecretString" element of the json response, you will need to json string unescape
+    this value, and then make the changes/addtions to the result
+  - Create a new version of the secrets with the new secret string:
+    ```$bash
+    aws --region eu-west-1 --profile membership secretsmanager update-secret --secret-id price-migration-engine-lambda-<STAGE> --secret-string  '{"zuoraApiHost":"http://rest.apisandbox.zuora.com","zuoraClientId":"xxx","zuoraClientSecret":"xxx"}'
+    ```      
+- Update the secrect version in the cloudformation templates. The cloudformation templates contains mappings for the
+  version of the secrets in each environment. The new version of the configuration will not be used until those mappings
+  are updated. You can do that as follows:
+  - Get the latest secret values using the aws cli:
+    ```bash
+    aws --region eu-west-1 --profile membership secretsmanager get-secret-value --version-stage AWSCURRENT --secret-id price-migration-engine-lambda-<STAGE>
+    ```
+  - Take the UUID from the value of the "VersionId" field in the response from the above.
+  - Update the Mappings > StageMap > <Stage> > SecretsVersion field in this projects [cloudformation template](cfn.yaml)
+  - Build and deploy the changes using riffraff  

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -26,7 +26,7 @@ The configuration can be updated using the aws console as follows:
     aws --region eu-west-1 --profile membership secretsmanager get-secret-value --version-stage AWSCURRENT --secret-id price-migration-engine-lambda-<STAGE>
     ```
   - The existing string is returned in the "SecretString" element of the json response, you will need to json string unescape
-    this value, and then make the changes/addtions to the result
+    this value, and then make the changes/additions to the result
   - Create a new version of the secrets with the new secret string:
     ```$bash
     aws --region eu-west-1 --profile membership secretsmanager update-secret --secret-id price-migration-engine-lambda-<STAGE> --secret-string  '{"zuoraApiHost":"http://rest.apisandbox.zuora.com","zuoraClientId":"xxx","zuoraClientSecret":"xxx"}'

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -31,7 +31,7 @@ The configuration can be updated using the aws console as follows:
     ```$bash
     aws --region eu-west-1 --profile membership secretsmanager update-secret --secret-id price-migration-engine-lambda-<STAGE> --secret-string  '{"zuoraApiHost":"http://rest.apisandbox.zuora.com","zuoraClientId":"xxx","zuoraClientSecret":"xxx"}'
     ```      
-- Update the secrect version in the cloudformation templates. The cloudformation templates contains mappings for the
+- Update the secret version in the cloudformation templates. The cloudformation templates contains mappings for the
   version of the secrets in each environment. The new version of the configuration will not be used until those mappings
   are updated. You can do that as follows:
   - Get the latest secret values using the aws cli:

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -68,7 +68,7 @@ Resources:
       Handler: pricemigrationengine.handlers.EstimationHandler::handleRequest
       Environment:
         Variables:
-          Stage: !Ref Stage
+          stage: !Ref Stage
           zuoraApiHost:
             !Sub
               - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraApiHost::${SecretsVersion}}}'

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -14,7 +14,7 @@ Parameters:
 Mappings:
   StageMap:
     DEV:
-      SecretsVersion: "78e58134-92b1-40d5-ab3f-958c0942be65"
+      SecretsVersion: "a98f33b0-1db0-4462-bc53-5faabb42b097"
     CODE:
       SecretsVersion: "3137cb2d-629e-48d2-aefa-b966301f7667"
     PROD:

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -11,6 +11,16 @@ Parameters:
       - DEV
     Default: CODE
 
+Mappings:
+  StageMap:
+    DEV:
+      SecretsVersion: "78e58134-92b1-40d5-ab3f-958c0942be65"
+    CODE:
+      SecretsVersion: "3137cb2d-629e-48d2-aefa-b966301f7667"
+    PROD:
+      SecretsVersion: "4351dd97-033d-464e-bea6-f9112c5a2a23"
+
+
 Resources:
   PriceMigrationEngineLambdaRole:
     Type: AWS::IAM::Role
@@ -58,10 +68,19 @@ Resources:
       Handler: pricemigrationengine.handlers.EstimationHandler::handleRequest
       Environment:
         Variables:
-          stage: !Ref Stage
-          zuoraApiHost: !Sub '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraApiHost}}'
-          zuoraClientId: !Sub '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientId}}'
-          zuoraClientSecret: !Sub '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientSecret}}'
+          Stage: !Ref Stage
+          zuoraApiHost:
+            - !Sub
+              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraApiHost:${SecretsVersion}}}'
+              - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+          zuoraClientId:
+            - !Sub
+              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientId:${SecretsVersion}}}'
+              - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+          zuoraClientSecret:
+            - !Sub
+              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientSecret:${SecretsVersion}}}'
+              - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           earliestStartDate: 2020-05-15
           batchSize: 100
       Role:

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -70,16 +70,16 @@ Resources:
         Variables:
           Stage: !Ref Stage
           zuoraApiHost:
-            !Sub:
-              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraApiHost:${SecretsVersion}}}'
+            !Sub
+              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraApiHost::${SecretsVersion}}}'
               - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           zuoraClientId:
-            !Sub:
-              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientId:${SecretsVersion}}}'
+            !Sub
+              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientId::${SecretsVersion}}}'
               - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           zuoraClientSecret:
-            !Sub:
-              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientSecret:${SecretsVersion}}}'
+            !Sub
+              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientSecret::${SecretsVersion}}}'
               - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           earliestStartDate: 2020-05-15
           batchSize: 100

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -70,15 +70,15 @@ Resources:
         Variables:
           Stage: !Ref Stage
           zuoraApiHost:
-            - !Sub
+            !Sub:
               - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraApiHost:${SecretsVersion}}}'
               - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           zuoraClientId:
-            - !Sub
+            !Sub:
               - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientId:${SecretsVersion}}}'
               - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           zuoraClientSecret:
-            - !Sub
+            !Sub:
               - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientSecret:${SecretsVersion}}}'
               - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           earliestStartDate: 2020-05-15


### PR DESCRIPTION
This change improves the process for updating values stored in the secretsmanager.

Cloudformation will not update a resource if there are no changes to the resource in the cloudformation template.

Updating the secrets in the [secretsmanager](https://eu-west-1.console.aws.amazon.com/secretsmanager/home?region=eu-west-1#/secret?name=price-migration-engine-lambda-DEV) would not updated the values in the environment variables of the lambda, even after a redeploy of the app via riffraff.

This change adds the secrets version number to the dynamic references used to access the secrets which when changed force cloudformation  to update the resource with the values from the new version of the secrets.
 
For more info see:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
