### PR TITLE
Read subscription from salesforce

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -15,4 +15,4 @@ case class ZuoraUpdateFailure(reason: String) extends Failure
 case class AmendmentDataFailure(reason: String) extends Failure
 case class SalesforceFailure(reason: String) extends Failure
 
-case class SalesforceClientFailure(reason: String)
+case class SalesforceClientFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforceSubscription.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforceSubscription.scala
@@ -1,0 +1,3 @@
+package pricemigrationengine.model
+
+case class SalesforceSubscription(Id: String, Name: String, Buyer__c: String)

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -61,8 +61,8 @@ object CohortTableLive {
       }
   }
 
-  val impl: ZLayer[DynamoDBZIO with CohortTableConfiguration, Nothing, CohortTable] =
-    ZLayer.fromFunction { dependencies: DynamoDBZIO with CohortTableConfiguration =>
+  val impl: ZLayer[DynamoDBZIO with CohortTableConfiguration with Logging, Nothing, CohortTable] =
+    ZLayer.fromFunction { dependencies: DynamoDBZIO with CohortTableConfiguration with Logging =>
       new Service {
         override def fetch(
             filter: CohortTableFilter
@@ -95,7 +95,11 @@ object CohortTableLive {
           } yield result
         }.provide(dependencies)
 
-        override def update(result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        override def update(result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit] = {
+          Logging
+            .info(s"Update for $result not implemented")
+            .provide(dependencies)
+        }
       }
     }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
@@ -1,10 +1,15 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.model.{SalesforceClientFailure, SalesforceSubscription}
-import zio.IO
+import pricemigrationengine.model.{CohortUpdateFailure, EstimationResult, SalesforceClientFailure, SalesforceSubscription}
+import zio.{IO, ZIO}
 
 object SalesforceClient {
   trait Service {
     def getSubscriptionByName(subscrptionName: String): IO[SalesforceClientFailure, SalesforceSubscription]
   }
+
+  def getSubscriptionByName(
+    subscrptionName: String
+  ): ZIO[SalesforceClient, SalesforceClientFailure, SalesforceSubscription] =
+    ZIO.accessM(_.get.getSubscriptionByName(subscrptionName))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
@@ -1,6 +1,10 @@
 package pricemigrationengine.services
 
+import pricemigrationengine.model.{SalesforceClientError, SalesforceSubscription}
+import zio.IO
+
 object SalesforceClient {
   trait Service {
+    def getSubscriptionByName(subscrptionName: String): IO[SalesforceClientError, SalesforceSubscription]
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
@@ -66,11 +66,8 @@ object SalesforceClientLive {
       ): IO[SalesforceClientFailure, SalesforceSubscription] =
         sendRequest[SalesforceSubscription](
           Http(s"${auth.instance_url}/services/data/v43.0/sobjects/SF_Subscription__c/Name/${subscriptionName}")
-            .postForm(
-              Seq(
-                "Authorization" -> s"Bearer ${auth.access_token}"
-              )
-            )
+            .header("Authorization", s"Bearer ${auth.access_token}")
+            .method("GET")
         ).tap( subscription =>
           logging.info(s"Successfully loaded: ${subscription}")
         )

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -28,7 +28,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
           filter: CohortTableFilter
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
           assertEquals(filter, EstimationComplete)
-          IO.succeed(ZStream.empty)
+          IO.succeed(ZStream(CohortItem("Sub-0001"), CohortItem("Sub-0002")))
         }
 
         override def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
@@ -40,7 +40,13 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
     val stubSalesforceClient = ZLayer.succeed(
       new SalesforceClient.Service {
-        override def getSubscriptionByName(subscrptionName: String): IO[SalesforceClientFailure, SalesforceSubscription] = ???
+        override def getSubscriptionByName(
+          subscrptionName: String
+        ): IO[SalesforceClientFailure, SalesforceSubscription] = {
+          IO.effect(
+            SalesforceSubscription(s"SubscritionId-$subscrptionName", subscrptionName, s"Buyer-$subscrptionName")
+          ).mapError(_ => SalesforceClientFailure(""))
+        }
       }
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -3,8 +3,8 @@ package pricemigrationengine.handlers
 import java.time.LocalDate
 
 import pricemigrationengine.model.CohortTableFilter.EstimationComplete
-import pricemigrationengine.model.{CohortFetchFailure, CohortItem, CohortTableFilter, CohortUpdateFailure, EstimationHandlerConfig, ConfigurationFailure, EstimationResult}
-import pricemigrationengine.services.{CohortTable, EstimationHandlerConfiguration, ConsoleLogging}
+import pricemigrationengine.model.{CohortFetchFailure, CohortItem, CohortTableFilter, CohortUpdateFailure, ConfigurationFailure, EstimationHandlerConfig, EstimationResult, SalesforceClientFailure, SalesforceSubscription}
+import pricemigrationengine.services.{CohortTable, ConsoleLogging, EstimationHandlerConfiguration, SalesforceClient}
 import zio.Exit.Success
 import zio.Runtime.default
 import zio.stream.ZStream
@@ -38,12 +38,18 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
       }
     )
 
+    val stubSalesforceClient = ZLayer.succeed(
+      new SalesforceClient.Service {
+        override def getSubscriptionByName(subscrptionName: String): IO[SalesforceClientFailure, SalesforceSubscription] = ???
+      }
+    )
+
     assertEquals(
       default.unsafeRunSync(
         SalesforcePriceRiseCreationHandler
           .main
           .provideLayer(
-            stubLogging ++ stubConfiguration ++ stubCohortTable
+            stubLogging ++ stubConfiguration ++ stubCohortTable ++ stubSalesforceClient
           )
       ),
       Success(())

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -48,7 +48,7 @@ class CohortTableLiveTest extends munit.FunSuite {
         for {
           result <- CohortTable
             .fetch(ReadyForEstimation)
-            .provideLayer(stubConfiguration ++ stubDynamoDBZIO >>> CohortTableLive.impl)
+            .provideLayer(stubConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>> CohortTableLive.impl)
           resultList <- result.run(Sink.collectAll[CohortItem])
           _ = assertEquals(resultList, List(item1, item2))
         } yield ()
@@ -113,7 +113,7 @@ class CohortTableLiveTest extends munit.FunSuite {
       Runtime.default.unsafeRunSync(
         CohortTable
           .update(estimationResult)
-          .provideLayer(stubConfiguration ++ stubDynamoDBZIO >>> CohortTableLive.impl)
+          .provideLayer(stubConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>> CohortTableLive.impl)
       ),
       Success(())
     )


### PR DESCRIPTION
This PR implements reading of Subscriptions by subscription number from salesforce in the Price Rise Creation handler.

This is required as it provides the subscription id and the buyer id, required for the creation of the Price_Rise__c object.