### PR TITLE
Create price rise in salesforce

### DIFF
--- a/dynamoDb/README.md
+++ b/dynamoDb/README.md
@@ -49,3 +49,15 @@ aws dynamodb delete-table \
     --table-name PriceMigrationEngineDEV \
 ```
 
+Update and item in the cohort table:
+```$bash
+aws dynamodb update-item \
+    --region eu-west-1 \
+    --endpoint-url http://localhost:8000 \
+    --table-name PriceMigrationEngineDEV \
+    --key '{"subscriptionNumber":{"S":"A-S00063981"}}' \
+    --update-expression "SET stage = :stage" \
+    --expression-attribute-values '{":stage":{"S":"EstimationComplete"}}'
+```
+
+

--- a/dynamoDb/README.md
+++ b/dynamoDb/README.md
@@ -24,8 +24,9 @@ do
 echo "Inserting sub-$i"
 aws dynamodb put-item \
     --region eu-west-1 \
+    --endpoint-url http://localhost:8000 \
     --table-name PriceMigrationEngineDEV \
-    --item "{\"subscriptionNumber\":{\"S\":\"A-S00068733\"},\"processingStage\":{\"S\":\"ReadyForEstimation\"}}"
+    --item "{\"subscriptionNumber\":{\"S\":\"sub-$i\"},\"processingStage\":{\"S\":\"ReadyForEstimation\"}}"
 done || exit 1
 ```
 

--- a/dynamoDb/README.md
+++ b/dynamoDb/README.md
@@ -13,7 +13,7 @@ aws dynamodb create-table \
     --table-name PriceMigrationEngineDEV \
     --attribute-definitions AttributeName=subscriptionNumber,AttributeType=S AttributeName=processingStage,AttributeType=S \
     --key-schema AttributeName=subscriptionNumber,KeyType=HASH \
-    --global-secondary-indexes IndexName=ProcessingStageIndex,KeySchema=["{AttributeName=processingStage,KeyType=HASH}"],Projection="{ProjectionType=KEYS_ONLY}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}" \
+    --global-secondary-indexes IndexName=ProcessingStageIndexV2,KeySchema=["{AttributeName=processingStage,KeyType=HASH}"],Projection="{ProjectionType=KEYS_ONLY}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}" \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 
 ```
 
@@ -36,7 +36,7 @@ aws dynamodb query \
     --region eu-west-1 \
     --endpoint-url http://localhost:8000 \
     --table-name PriceMigrationEngineDEV \
-    --index-name ProcessingStageIndex \
+    --index-name ProcessingStageIndexV2 \
     --key-condition-expression "processingStage = :stage" \
     --expression-attribute-values '{":stage":{"S":"ReadyForEstimation"}}'
 ```

--- a/dynamoDb/cfn/cfn.yaml
+++ b/dynamoDb/cfn/cfn.yaml
@@ -28,11 +28,11 @@ Resources:
           KeyType: "HASH"
       GlobalSecondaryIndexes:
         - IndexName: "ProcessingStageIndex"
-              KeySchema:
-                - AttributeName: "processingStage"
-                  KeyType: "HASH"
-              Projection:
-                ProjectionType: "KEYS_ONLY"
+          KeySchema:
+            - AttributeName: "processingStage"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: "KEYS_ONLY"
         - IndexName: "ProcessingStageIndexV2"
           KeySchema:
             - AttributeName: "processingStage"

--- a/dynamoDb/cfn/cfn.yaml
+++ b/dynamoDb/cfn/cfn.yaml
@@ -27,7 +27,7 @@ Resources:
         - AttributeName: "subscriptionNumber"
           KeyType: "HASH"
       GlobalSecondaryIndexes:
-        - IndexName: "ProcessingStageIndex"
+        - IndexName: "ProcessingStageIndexV2"
           KeySchema:
             - AttributeName: "processingStage"
               KeyType: "HASH"

--- a/dynamoDb/cfn/cfn.yaml
+++ b/dynamoDb/cfn/cfn.yaml
@@ -32,4 +32,4 @@ Resources:
             - AttributeName: "processingStage"
               KeyType: "HASH"
           Projection:
-            ProjectionType: "KEYS_ONLY"
+            ProjectionType: "ALL"

--- a/dynamoDb/cfn/cfn.yaml
+++ b/dynamoDb/cfn/cfn.yaml
@@ -27,6 +27,12 @@ Resources:
         - AttributeName: "subscriptionNumber"
           KeyType: "HASH"
       GlobalSecondaryIndexes:
+        - IndexName: "ProcessingStageIndex"
+              KeySchema:
+                - AttributeName: "processingStage"
+                  KeyType: "HASH"
+              Projection:
+                ProjectionType: "KEYS_ONLY"
         - IndexName: "ProcessingStageIndexV2"
           KeySchema:
             - AttributeName: "processingStage"

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -25,17 +25,18 @@ object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, 
       updateResponse <- updateSalesforce(item)
         .tapBoth(
           e => Logging.error(s"Failed to write create Price_Rise in salesforce: $e"),
-          result => Logging.info(s"Estimated result: $result")
+          result => Logging.info(s"SalesforcePriceRise result: $result")
         )
       time <- clock.currentDateTime
         .mapError { error =>
           SalesforcePriceRiseCreationFailure(s"Failed to get currentTime: $error")
         }
+      salesforcePriceRiseCreationDetails = SalesforcePriceRiseCreationDetails(updateResponse.id, time.toInstant)
       _ <- CohortTable
-        .update(item.subscriptionName, SalesforcePriceRiseCreationDetails(updateResponse.id, time.toInstant))
+        .update(item.subscriptionName, salesforcePriceRiseCreationDetails)
         .tapBoth(
           e => Logging.error(s"Failed to update Cohort table: $e"),
-          _ => Logging.info(s"Wrote $updateResponse to Cohort table")
+          _ => Logging.info(s"Wrote $salesforcePriceRiseCreationDetails to Cohort table")
         )
     } yield ()
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -27,7 +27,7 @@ object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, 
           result => Logging.info(s"Estimated result: $result")
         )
       _ <- CohortTable
-        .update(result)
+        .update(item.subscriptionName, result)
         .tapBoth(
           e => Logging.error(s"Failed to update Cohort table: $e"),
           _ => Logging.info(s"Wrote $result to Cohort table")

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -1,3 +1,12 @@
 package pricemigrationengine.model
 
-case class CohortItem(subscriptionName: String)
+import java.time.LocalDate
+
+case class CohortItem(
+  subscriptionName: String,
+  expectedStartDate: Option[LocalDate] = None,
+  currency: Option[String] = None,
+  oldPrice: Option[BigDecimal] = None,
+  estimatedNewPrice: Option[BigDecimal] = None,
+  billingPeriod: Option[String] = None
+)

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -15,4 +15,6 @@ case class ZuoraUpdateFailure(reason: String) extends Failure
 case class AmendmentDataFailure(reason: String) extends Failure
 case class SalesforceFailure(reason: String) extends Failure
 
+case class SalesforcePriceRiseCreationFailure(reason: String) extends Failure
+
 case class SalesforceClientFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
@@ -1,0 +1,11 @@
+package pricemigrationengine.model
+
+import java.time.LocalDate
+
+case class SalesforcePriceRise(
+  Buyer__c: String,
+  Current_Price_Today__c: BigDecimal,
+  Guardian_Weekly_New_Price__c: BigDecimal,
+  Price_Rise_Date__c: LocalDate,
+  SF_Subscription__c: String
+)

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRiseCreationDetails.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRiseCreationDetails.scala
@@ -1,0 +1,3 @@
+package pricemigrationengine.model
+
+case class SalesforcePriceRiseCreationDetails(id: String)

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRiseCreationDetails.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRiseCreationDetails.scala
@@ -1,3 +1,5 @@
 package pricemigrationengine.model
 
-case class SalesforcePriceRiseCreationDetails(id: String)
+import java.time.Instant
+
+case class SalesforcePriceRiseCreationDetails(id: String, whenSfShowEstimate: Instant)

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRiseCreationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRiseCreationResult.scala
@@ -1,0 +1,3 @@
+package pricemigrationengine.model
+
+case class SalesforcePriceRiseCreationResult(id: String)

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRiseCreationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRiseCreationResult.scala
@@ -1,3 +1,0 @@
-package pricemigrationengine.model
-
-case class SalesforcePriceRiseCreationResult(id: String)

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -13,7 +13,7 @@ object CohortTable {
     ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
 
     def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit]
-    def update(result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit]
+    def update(subscriptionName: String, result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit]
   }
 
   def fetch(
@@ -24,6 +24,9 @@ object CohortTable {
   def update(result: EstimationResult): ZIO[CohortTable, CohortUpdateFailure, Unit] =
     ZIO.accessM(_.get.update(result))
 
-  def update(result: SalesforcePriceRiseCreationResult): ZIO[CohortTable, CohortUpdateFailure, Unit] =
-    ZIO.accessM(_.get.update(result))
+  def update(
+    subscriptionName: String,
+    result: SalesforcePriceRiseCreationResult
+  ): ZIO[CohortTable, CohortUpdateFailure, Unit] =
+    ZIO.accessM(_.get.update(subscriptionName, result))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.model.{SalesforcePriceRiseCreationResult, _}
+import pricemigrationengine.model.{SalesforcePriceRiseCreationDetails, _}
 import zio.stream.ZStream
 import zio.{IO, ZIO}
 
@@ -13,7 +13,7 @@ object CohortTable {
     ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
 
     def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit]
-    def update(subscriptionName: String, result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit]
+    def update(subscriptionName: String, result: SalesforcePriceRiseCreationDetails): ZIO[Any, CohortUpdateFailure, Unit]
   }
 
   def fetch(
@@ -26,7 +26,7 @@ object CohortTable {
 
   def update(
     subscriptionName: String,
-    result: SalesforcePriceRiseCreationResult
+    result: SalesforcePriceRiseCreationDetails
   ): ZIO[CohortTable, CohortUpdateFailure, Unit] =
     ZIO.accessM(_.get.update(subscriptionName, result))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -1,7 +1,6 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.handlers.SalesforcePriceRiseCreationResult
-import pricemigrationengine.model._
+import pricemigrationengine.model.{SalesforcePriceRiseCreationResult, _}
 import zio.stream.ZStream
 import zio.{IO, ZIO}
 

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.services
 
 import java.time.format.DateTimeFormatter
-import java.time.{Instant, LocalDate}
+import java.time.{Instant, LocalDate, ZoneOffset}
 import java.util
 
 import com.amazonaws.services.dynamodbv2.model.{AttributeAction, AttributeValue, AttributeValueUpdate, QueryRequest}
@@ -48,7 +48,8 @@ object CohortTableLive {
     estimationResult =>
       Map(
         stringFieldUpdate("processingStage", SalesforcePriceRiceCreationComplete.value),
-        stringFieldUpdate("salesforcePriceRiseId", estimationResult.id)
+        stringFieldUpdate("salesforcePriceRiseId", estimationResult.id),
+        instantFieldUpdate("whenSfShowEstimate", estimationResult.whenSfShowEstimate)
       ).asJava
 
   private implicit val cohortTableKeySerialiser: DynamoDBSerialiser[CohortTableKey] =
@@ -60,6 +61,12 @@ object CohortTableLive {
   private def dateFieldUpdate(fieldName: String, dateValue: LocalDate) =
     fieldName -> new AttributeValueUpdate(
       new AttributeValue().withS(dateValue.format(DateTimeFormatter.ISO_LOCAL_DATE)),
+      AttributeAction.PUT
+    )
+
+  private def instantFieldUpdate(fieldName: String, instant: Instant) =
+    fieldName -> new AttributeValueUpdate(
+      new AttributeValue().withS(DateTimeFormatter.ISO_DATE_TIME.format(instant.atZone(ZoneOffset.UTC))),
       AttributeAction.PUT
     )
 

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -133,7 +133,7 @@ object CohortTableLive {
               .query(
                 new QueryRequest()
                   .withTableName(s"PriceMigrationEngine${config.stage}")
-                  .withIndexName("ProcessingStageIndex")
+                  .withIndexName("ProcessingStageIndexV2")
                   .withKeyConditionExpression("processingStage = :processingStage")
                   .withExpressionAttributeValues(
                     Map(":processingStage" -> new AttributeValue(filter.value)).asJava

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -90,11 +90,11 @@ object CohortTableLive {
       .asScala
       .get(fieldName)
       .fold[IO[DynamoDBZIOError, Option[String]]](ZIO.succeed(None)) { attributeValue =>
-      ZIO
-        .fromOption(Option(attributeValue.getS))
-        .orElseFail(DynamoDBZIOError(s"The '$fieldName' field was not a string in the record '$result'"))
-        .map(Some.apply)
-    }
+        ZIO
+          .fromOption(Option(attributeValue.getS))
+          .orElseFail(DynamoDBZIOError(s"The '$fieldName' field was not a string in the record '$result'"))
+          .map(Some.apply)
+      }
   }
 
   private def getOptionalNumberStringFromResults(result: util.Map[String, AttributeValue], fieldName: String): IO[DynamoDBZIOError, Option[String]] = {
@@ -102,11 +102,11 @@ object CohortTableLive {
       .asScala
       .get(fieldName)
       .fold[IO[DynamoDBZIOError, Option[String]]](ZIO.succeed(None)) { attributeValue =>
-      ZIO
-        .fromOption(Option(attributeValue.getN))
-        .orElseFail(DynamoDBZIOError(s"The '$fieldName' field was not a number in the record '$result'"))
-        .map(Some.apply)
-    }
+        ZIO
+          .fromOption(Option(attributeValue.getN))
+          .orElseFail(DynamoDBZIOError(s"The '$fieldName' field was not a number in the record '$result'"))
+          .map(Some.apply)
+      }
   }
 
   private def getOptionalDateFromResults(result: util.Map[String, AttributeValue], fieldName: String): IO[DynamoDBZIOError, Option[LocalDate]] =
@@ -118,19 +118,18 @@ object CohortTableLive {
             .effect(Some(LocalDate.parse(string)))
             .mapError(ex => DynamoDBZIOError(s"The '$fieldName' has value '$string' which is not a valid date yyyy-MM-dd"))
         }
-
     } yield optionalDate
 
   private def getOptionalBigDecimalFromResults(result: util.Map[String, AttributeValue], fieldName: String): IO[DynamoDBZIOError, Option[BigDecimal]] =
     for {
-      optionalString <- getOptionalNumberStringFromResults(result, fieldName)
-      optionalDate <-
-        optionalString.fold[IO[DynamoDBZIOError, Option[BigDecimal]]](ZIO.succeed(None)) { string =>
+      optionalNumberString <- getOptionalNumberStringFromResults(result, fieldName)
+      optionalDecimal <-
+        optionalNumberString.fold[IO[DynamoDBZIOError, Option[BigDecimal]]](ZIO.succeed(None)) { string =>
           ZIO
             .effect(Some(BigDecimal(string)))
             .mapError(ex => DynamoDBZIOError(s"The '$fieldName' has value '$string' which is not a valid number"))
         }
-    } yield optionalDate
+    } yield optionalDecimal
 
   val impl: ZLayer[DynamoDBZIO with CohortTableConfiguration with Logging, Nothing, CohortTable] =
     ZLayer.fromFunction { dependencies: DynamoDBZIO with CohortTableConfiguration with Logging =>

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -81,7 +81,7 @@ object CohortTableLive {
       optionalString <- getOptionalStringFromResults(result, fieldName)
       string <- ZIO
         .fromOption(optionalString)
-        .orElseFail(DynamoDBZIOError(s"The '$fieldName' field did not exist in the record $result"))
+        .orElseFail(DynamoDBZIOError(s"The '$fieldName' field did not exist in the record '$result''"))
     } yield string
   }
 
@@ -92,10 +92,11 @@ object CohortTableLive {
       .fold[IO[DynamoDBZIOError, Option[String]]](ZIO.succeed(None)) { attributeValue =>
       ZIO
         .fromOption(Option(attributeValue.getS))
-        .orElseFail(DynamoDBZIOError(s"The '$fieldName' field was not a string in the record $result"))
+        .orElseFail(DynamoDBZIOError(s"The '$fieldName' field was not a string in the record '$result'"))
         .map(Some.apply)
     }
   }
+
   private def getOptionalDateFromResults(result: util.Map[String, AttributeValue], fieldName: String): IO[DynamoDBZIOError, Option[LocalDate]] =
     for {
       optionalString <- getOptionalStringFromResults(result, fieldName)
@@ -107,6 +108,7 @@ object CohortTableLive {
         }
 
     } yield optionalDate
+
   private def getOptionalBigDecimalFromResults(result: util.Map[String, AttributeValue], fieldName: String): IO[DynamoDBZIOError, Option[BigDecimal]] =
     for {
       optionalString <- getOptionalStringFromResults(result, fieldName)

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
@@ -25,7 +25,7 @@ object CohortTableTest {
             _ <- console.putStrLn(s"Updating cohort table with result: $result")
           } yield ()
 
-        def update(result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        def update(subscriptionName: String, result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
       }
   )
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
@@ -1,7 +1,6 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.handlers.SalesforcePriceRiseCreationResult
-import pricemigrationengine.model._
+import pricemigrationengine.model.{SalesforcePriceRiseCreationResult, _}
 import zio.console.Console
 import zio.stream.ZStream
 import zio.{UIO, ZIO, ZLayer}

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.model.{SalesforcePriceRiseCreationResult, _}
+import pricemigrationengine.model.{SalesforcePriceRiseCreationDetails, _}
 import zio.console.Console
 import zio.stream.ZStream
 import zio.{UIO, ZIO, ZLayer}
@@ -25,7 +25,7 @@ object CohortTableTest {
             _ <- console.putStrLn(s"Updating cohort table with result: $result")
           } yield ()
 
-        def update(subscriptionName: String, result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        def update(subscriptionName: String, result: SalesforcePriceRiseCreationDetails): ZIO[Any, CohortUpdateFailure, Unit] = ???
       }
   )
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
@@ -1,15 +1,21 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.model.{CohortUpdateFailure, EstimationResult, SalesforceClientFailure, SalesforceSubscription}
+import pricemigrationengine.model.{CohortUpdateFailure, EstimationResult, SalesforceClientFailure, SalesforcePriceRise, SalesforcePriceRiseCreationResult, SalesforceSubscription}
 import zio.{IO, ZIO}
 
 object SalesforceClient {
   trait Service {
     def getSubscriptionByName(subscrptionName: String): IO[SalesforceClientFailure, SalesforceSubscription]
+    def createPriceRise(priceRise: SalesforcePriceRise): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResult]
   }
 
   def getSubscriptionByName(
     subscrptionName: String
   ): ZIO[SalesforceClient, SalesforceClientFailure, SalesforceSubscription] =
     ZIO.accessM(_.get.getSubscriptionByName(subscrptionName))
+
+  def createPriceRise(
+    priceRise: SalesforcePriceRise
+  ): ZIO[SalesforceClient, SalesforceClientFailure, SalesforcePriceRiseCreationResult] =
+    ZIO.accessM(_.get.createPriceRise(priceRise))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
@@ -1,12 +1,14 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.model.{SalesforceClientFailure, SalesforcePriceRise, SalesforcePriceRiseCreationResult, SalesforceSubscription}
+import pricemigrationengine.model.{SalesforceClientFailure, SalesforcePriceRise, SalesforcePriceRiseCreationDetails, SalesforceSubscription}
 import zio.{IO, ZIO}
+
+case class SalesforcePriceRiseCreationResponse(id: String)
 
 object SalesforceClient {
   trait Service {
     def getSubscriptionByName(subscrptionName: String): IO[SalesforceClientFailure, SalesforceSubscription]
-    def createPriceRise(priceRise: SalesforcePriceRise): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResult]
+    def createPriceRise(priceRise: SalesforcePriceRise): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResponse]
   }
 
   def getSubscriptionByName(
@@ -16,6 +18,6 @@ object SalesforceClient {
 
   def createPriceRise(
     priceRise: SalesforcePriceRise
-  ): ZIO[SalesforceClient, SalesforceClientFailure, SalesforcePriceRiseCreationResult] =
+  ): ZIO[SalesforceClient, SalesforceClientFailure, SalesforcePriceRiseCreationResponse] =
     ZIO.accessM(_.get.createPriceRise(priceRise))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.model.{CohortUpdateFailure, EstimationResult, SalesforceClientFailure, SalesforcePriceRise, SalesforcePriceRiseCreationResult, SalesforceSubscription}
+import pricemigrationengine.model.{SalesforceClientFailure, SalesforcePriceRise, SalesforcePriceRiseCreationResult, SalesforceSubscription}
 import zio.{IO, ZIO}
 
 object SalesforceClient {

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
@@ -2,7 +2,7 @@ package pricemigrationengine.services
 
 import java.time.LocalDate
 
-import pricemigrationengine.model.{SalesforceClientFailure, SalesforceConfig, SalesforcePriceRise, SalesforcePriceRiseCreationResult, SalesforceSubscription}
+import pricemigrationengine.model.{SalesforceClientFailure, SalesforceConfig, SalesforcePriceRise, SalesforcePriceRiseCreationDetails, SalesforceSubscription}
 import scalaj.http.{Http, HttpRequest, HttpResponse}
 import upickle.default._
 import zio.{IO, ZIO, ZLayer}
@@ -19,7 +19,7 @@ object SalesforceClientLive {
     implicit val salesforceAuthDetailsRW: ReadWriter[SalesforceAuthDetails] = macroRW
     implicit val salesforceSubscriptionRW: ReadWriter[SalesforceSubscription] = macroRW
     implicit val salesforcePriceRiseRW: ReadWriter[SalesforcePriceRise] = macroRW
-    implicit val salesforcePriceIdRiseRW: ReadWriter[SalesforcePriceRiseCreationResult] = macroRW
+    implicit val salesforcePriceIdRiseRW: ReadWriter[SalesforcePriceRiseCreationResponse] = macroRW
 
     def requestAsMessage(request: HttpRequest) = {
       s"${request.method} ${request.url}"
@@ -77,8 +77,8 @@ object SalesforceClientLive {
           logging.info(s"Successfully loaded: ${subscription}")
         )
 
-      override def createPriceRise(priceRise: SalesforcePriceRise): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResult] =
-        sendRequest[SalesforcePriceRiseCreationResult](
+      override def createPriceRise(priceRise: SalesforcePriceRise): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResponse] =
+        sendRequest[SalesforcePriceRiseCreationResponse](
           Http(s"${auth.instance_url}/services/data/v43.0/sobjects/Price_Rise__c/")
             .postData(write(priceRise))
             .header("Authorization", s"Bearer ${auth.access_token}")

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
@@ -33,7 +33,7 @@ object SalesforceClientLive {
       for {
         response <- IO.effect(request.asString)
           .mapError(ex => SalesforceClientFailure(s"Request for ${requestAsMessage(request)} failed: $ex"))
-        valid200Response <- if (response.code == 200) {
+        valid200Response <- if ((response.code / 100) == 2) {
           IO.succeed(response)
         } else {
           IO.fail(SalesforceClientFailure(failureMessage(request, response)))

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
@@ -82,6 +82,7 @@ object SalesforceClientLive {
           Http(s"${auth.instance_url}/services/data/v43.0/sobjects/Price_Rise__c/")
             .postData(write(priceRise))
             .header("Authorization", s"Bearer ${auth.access_token}")
+            .header("Content-Type", "application/json")
         ).tap( priceRiseId =>
           logging.info(s"Successfully created Price_Rise__c object: ${priceRiseId.id}")
         )

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -50,7 +50,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
         override def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
 
-        override def update(result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit] = {
+        override def update(subscriptionName: String, result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)
           IO.succeed(())
         }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -28,7 +28,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
           filter: CohortTableFilter
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
           assertEquals(filter, EstimationComplete)
-          IO.succeed(ZStream.empty)
+          IO.succeed(ZStream(CohortItem("Sub-0001"), CohortItem("Sub-0002")))
         }
 
         override def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
@@ -40,7 +40,13 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
     val stubSalesforceClient = ZLayer.succeed(
       new SalesforceClient.Service {
-        override def getSubscriptionByName(subscrptionName: String): IO[SalesforceClientFailure, SalesforceSubscription] = ???
+        override def getSubscriptionByName(
+          subscrptionName: String
+        ): IO[SalesforceClientFailure, SalesforceSubscription] = {
+          IO.effect(
+            SalesforceSubscription(s"SubscritionId-$subscrptionName", subscrptionName, s"Buyer-$subscrptionName")
+          ).mapError(_ => SalesforceClientFailure(""))
+        }
       }
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -3,12 +3,14 @@ package pricemigrationengine.handlers
 import java.time.LocalDate
 
 import pricemigrationengine.model.CohortTableFilter.EstimationComplete
-import pricemigrationengine.model.{CohortFetchFailure, CohortItem, CohortTableFilter, CohortUpdateFailure, ConfigurationFailure, EstimationHandlerConfig, EstimationResult, SalesforceClientFailure, SalesforceSubscription}
+import pricemigrationengine.model.{CohortFetchFailure, CohortItem, CohortTableFilter, CohortUpdateFailure, ConfigurationFailure, EstimationHandlerConfig, EstimationResult, SalesforceClientFailure, SalesforcePriceRise, SalesforcePriceRiseCreationResult, SalesforceSubscription}
 import pricemigrationengine.services.{CohortTable, ConsoleLogging, EstimationHandlerConfiguration, SalesforceClient}
 import zio.Exit.Success
 import zio.Runtime.default
 import zio.stream.ZStream
 import zio.{IO, ZIO, ZLayer, console}
+
+import scala.collection.mutable.ArrayBuffer
 
 class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
   test("SalesforcePriceRiseCreateHandler should get estimated prices from ") {
@@ -22,13 +24,27 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
     val stubLogging = console.Console.live >>> ConsoleLogging.impl
 
+    val expectedSubscriptionName = "Sub-0001"
+    val expectedStartDate = LocalDate.of(2020, 1, 1)
+    val expectedCurrency = "GBP"
+    val expectedOldPrice = BigDecimal(11.11)
+    val expectedEstimatedNewPrice = BigDecimal(22.22)
+
     val stubCohortTable = ZLayer.succeed(
       new CohortTable.Service {
         override def fetch(
           filter: CohortTableFilter
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
           assertEquals(filter, EstimationComplete)
-          IO.succeed(ZStream(CohortItem("Sub-0001"), CohortItem("Sub-0002")))
+          IO.succeed(ZStream(
+            CohortItem(
+              subscriptionName = expectedSubscriptionName,
+              expectedStartDate = Some(expectedStartDate),
+              currency = Some(expectedCurrency),
+              oldPrice = Some(expectedOldPrice),
+              estimatedNewPrice = Some(expectedEstimatedNewPrice)
+            ),
+          ))
         }
 
         override def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
@@ -38,14 +54,21 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
       }
     )
 
+    val createdPriceRises = ArrayBuffer[SalesforcePriceRise]()
+
     val stubSalesforceClient = ZLayer.succeed(
       new SalesforceClient.Service {
         override def getSubscriptionByName(
-          subscrptionName: String
+          subscriptionName: String
         ): IO[SalesforceClientFailure, SalesforceSubscription] = {
           IO.effect(
-            SalesforceSubscription(s"SubscritionId-$subscrptionName", subscrptionName, s"Buyer-$subscrptionName")
+            SalesforceSubscription(s"SubscritionId-$subscriptionName", subscriptionName, s"Buyer-$subscriptionName")
           ).mapError(_ => SalesforceClientFailure(""))
+        }
+
+        override def createPriceRise(priceRise: SalesforcePriceRise): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResult] = {
+          createdPriceRises.addOne(priceRise)
+          ZIO.succeed(SalesforcePriceRiseCreationResult(s"${priceRise.SF_Subscription__c}-price-rise-id"))
         }
       }
     )
@@ -60,5 +83,12 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
       ),
       Success(())
     )
+
+    assertEquals(createdPriceRises.size, 1)
+    assertEquals(createdPriceRises(0).SF_Subscription__c, s"SubscritionId-$expectedSubscriptionName")
+    assertEquals(createdPriceRises(0).Buyer__c, s"Buyer-$expectedSubscriptionName")
+    assertEquals(createdPriceRises(0).Current_Price_Today__c, expectedOldPrice)
+    assertEquals(createdPriceRises(0).Guardian_Weekly_New_Price__c, expectedEstimatedNewPrice)
+    assertEquals(createdPriceRises(0).Price_Rise_Date__c, expectedStartDate)
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -3,8 +3,8 @@ package pricemigrationengine.handlers
 import java.time.LocalDate
 
 import pricemigrationengine.model.CohortTableFilter.EstimationComplete
-import pricemigrationengine.model.{CohortFetchFailure, CohortItem, CohortTableFilter, CohortUpdateFailure, ConfigurationFailure, EstimationHandlerConfig, EstimationResult, SalesforceClientFailure, SalesforcePriceRise, SalesforcePriceRiseCreationResult, SalesforceSubscription}
-import pricemigrationengine.services.{CohortTable, ConsoleLogging, EstimationHandlerConfiguration, SalesforceClient}
+import pricemigrationengine.model.{CohortFetchFailure, CohortItem, CohortTableFilter, CohortUpdateFailure, ConfigurationFailure, EstimationHandlerConfig, EstimationResult, SalesforceClientFailure, SalesforcePriceRise, SalesforcePriceRiseCreationDetails, SalesforceSubscription}
+import pricemigrationengine.services.{CohortTable, ConsoleLogging, EstimationHandlerConfiguration, SalesforceClient, SalesforcePriceRiseCreationResponse}
 import zio.Exit.Success
 import zio.Runtime.default
 import zio.stream.ZStream
@@ -29,7 +29,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     val expectedOldPrice = BigDecimal(11.11)
     val expectedEstimatedNewPrice = BigDecimal(22.22)
 
-    val updatedResultsWrittenToCohortTable = ArrayBuffer[SalesforcePriceRiseCreationResult]()
+    val updatedResultsWrittenToCohortTable = ArrayBuffer[SalesforcePriceRiseCreationDetails]()
 
     val stubCohortTable = ZLayer.succeed(
       new CohortTable.Service {
@@ -50,7 +50,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
         override def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
 
-        override def update(subscriptionName: String, result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit] = {
+        override def update(subscriptionName: String, result: SalesforcePriceRiseCreationDetails): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)
           IO.succeed(())
         }
@@ -69,9 +69,9 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
           ).mapError(_ => SalesforceClientFailure(""))
         }
 
-        override def createPriceRise(priceRise: SalesforcePriceRise): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResult] = {
+        override def createPriceRise(priceRise: SalesforcePriceRise): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResponse] = {
           createdPriceRises.addOne(priceRise)
-          ZIO.succeed(SalesforcePriceRiseCreationResult(s"${priceRise.SF_Subscription__c}-price-rise-id"))
+          ZIO.succeed(SalesforcePriceRiseCreationResponse(s"${priceRise.SF_Subscription__c}-price-rise-id"))
         }
       }
     )

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -193,6 +193,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
 
     val expectedTimestamp = "2020-05-21T15:16:37Z"
+
     val salesforcePriceRiseCreationResult = SalesforcePriceRiseCreationDetails(
       id = "price-rise-id",
       Instant.parse(expectedTimestamp)

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -57,7 +57,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
 
     assertEquals(receivedRequest.get.getTableName, "PriceMigrationEngineDEV")
-    assertEquals(receivedRequest.get.getIndexName, "ProcessingStageIndex")
+    assertEquals(receivedRequest.get.getIndexName, "ProcessingStageIndexV2")
     assertEquals(receivedRequest.get.getKeyConditionExpression, "processingStage = :processingStage")
     assertEquals(
       receivedRequest.get.getExpressionAttributeValues,

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -192,8 +192,10 @@ class CohortTableLiveTest extends munit.FunSuite {
       }
     )
 
+    val expectedTimestamp = "2020-05-21T15:16:37Z"
     val salesforcePriceRiseCreationResult = SalesforcePriceRiseCreationDetails(
-      id = "price-rise-id"
+      id = "price-rise-id",
+      Instant.parse(expectedTimestamp)
     )
 
     assertEquals(
@@ -222,6 +224,11 @@ class CohortTableLiveTest extends munit.FunSuite {
     assertEquals(
       update.get("salesforcePriceRiseId"),
       new AttributeValueUpdate(new AttributeValue().withS("price-rise-id"), AttributeAction.PUT),
+      "salesforcePriceRiseId"
+    )
+    assertEquals(
+      update.get("whenSfShowEstimate"),
+      new AttributeValueUpdate(new AttributeValue().withS(expectedTimestamp), AttributeAction.PUT),
       "salesforcePriceRiseId"
     )
   }

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -168,9 +168,9 @@ class CohortTableLiveTest extends munit.FunSuite {
   test("Update the PriceMigrationEngine table and serialise the price rise update correctly") {
     var tableUpdated: Option[String] = None
     var receivedKey: Option[CohortTableKey] = None
-    var receivedUpdate: Option[SalesforcePriceRiseCreationResult] = None
+    var receivedUpdate: Option[SalesforcePriceRiseCreationDetails] = None
     var receivedKeySerialiser: Option[DynamoDBSerialiser[CohortTableKey]] = None
-    var receivedValueSerialiser: Option[DynamoDBUpdateSerialiser[SalesforcePriceRiseCreationResult]] = None
+    var receivedValueSerialiser: Option[DynamoDBUpdateSerialiser[SalesforcePriceRiseCreationDetails]] = None
 
     val stubDynamoDBZIO = ZLayer.succeed(
       new DynamoDBZIO.Service {
@@ -184,15 +184,15 @@ class CohortTableLiveTest extends munit.FunSuite {
         ): IO[DynamoDBZIOError, Unit] = {
           tableUpdated = Some(table)
           receivedKey = Some(key.asInstanceOf[CohortTableKey])
-          receivedUpdate = Some(value.asInstanceOf[SalesforcePriceRiseCreationResult])
+          receivedUpdate = Some(value.asInstanceOf[SalesforcePriceRiseCreationDetails])
           receivedKeySerialiser = Some(keySerializer.asInstanceOf[DynamoDBSerialiser[CohortTableKey]])
-          receivedValueSerialiser = Some(valueSerializer.asInstanceOf[DynamoDBUpdateSerialiser[SalesforcePriceRiseCreationResult]])
+          receivedValueSerialiser = Some(valueSerializer.asInstanceOf[DynamoDBUpdateSerialiser[SalesforcePriceRiseCreationDetails]])
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
       }
     )
 
-    val salesforcePriceRiseCreationResult = SalesforcePriceRiseCreationResult(
+    val salesforcePriceRiseCreationResult = SalesforcePriceRiseCreationDetails(
       id = "price-rise-id"
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
@@ -1,6 +1,5 @@
 package pricemigrationengine.model
 
-import java.time.LocalDate
 import java.util
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
@@ -9,7 +8,7 @@ import pricemigrationengine.services._
 import zio.Exit.Success
 import zio.Runtime.default
 import zio.stream.Sink
-import zio.{IO, ZIO, ZLayer, console}
+import zio.{ZIO, ZLayer, console}
 
 import scala.jdk.CollectionConverters._
 


### PR DESCRIPTION
This PR contains the creation of the PriceRise__c object in salesforce during the execution of the SalesForcePriceRiseCreationHandler phase of the Price Migration Engine.

This includes:
- Building the price rise object out of the salesforce subscrption object and existing fields in the CohortTable.
- Implementation of the createPriceRise method in the Salesforce client
- Implementation of the CohortTable update method that writes the price rise id back to the table 