### PR TITLE
Add handler to do price-rise amendments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ Set up a run configuration for the lambda, using the following environment varia
 and also the specific environment variables for the lambda you are running.
 
 ### Specific environment variables per lambda
+
 #### EstimationHandler
+* earliestStartDate=`earliestStartDate`
+* batchSize=`batchSize`
+* zuoraApiHost=`host`
+* zuoraClientId=`personal clientId`
+* zuoraClientSecret=`personal clientSecret`
+
+#### AmendmentHandler
 * earliestStartDate=`earliestStartDate`
 * batchSize=`batchSize`
 * zuoraApiHost=`host`

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
@@ -1,0 +1,10 @@
+package pricemigrationengine.model
+
+import java.time.LocalDate
+
+case class AmendmentResult(
+    subscriptionName: String,
+    startDate: LocalDate,
+    newPrice: BigDecimal,
+    newSubscriptionId: ZuoraSubscriptionId
+)

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -8,4 +8,11 @@ object CohortTableFilter {
   case object SalesforcePriceRiceCreationComplete extends CohortTableFilter {
     override val value: String = "SalesforcePriceRiceCreationComplete"
   }
+  case object AmendmentComplete extends CohortTableFilter { override val value: String = "AmendmentComplete" }
+
+  /*
+   * Status of a sub that has been cancelled since the price migration process began,
+   * so is ineligible for further processing.
+   */
+  case object Cancelled extends CohortTableFilter { override val value: String = "Cancelled" }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerConfig.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerConfig.scala
@@ -2,12 +2,17 @@ package pricemigrationengine.model
 
 import java.time.LocalDate
 
-case class EstimationHandlerConfig(
+case class AmendmentConfig(
     // earliest date that price migration can take place
-    earliestStartDate: LocalDate,
+    earliestStartDate: LocalDate
 )
 
-case class ZuoraConfig(apiHost: String, clientId: String, clientSecret: String, yearInFuture: LocalDate = LocalDate.now.plusYears(1))
+case class ZuoraConfig(
+    apiHost: String,
+    clientId: String,
+    clientSecret: String,
+    yearInFuture: LocalDate = LocalDate.now.plusYears(1)
+)
 
 case class DynamoDBConfig(endpoint: Option[DynamoDBEndpointConfig])
 
@@ -15,4 +20,11 @@ case class DynamoDBEndpointConfig(serviceEndpoint: String, signingRegion: String
 
 case class CohortTableConfig(stage: String, batchSize: Int = 100)
 
-case class SalesforceConfig(authUrl: String, clientId: String, clientSecret: String, userName: String, password: String, token: String)
+case class SalesforceConfig(
+    authUrl: String,
+    clientId: String,
+    clientSecret: String,
+    userName: String,
+    password: String,
+    token: String
+)

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraInvoiceList.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraInvoiceList.scala
@@ -14,4 +14,7 @@ case class ZuoraInvoiceItem(serviceStartDate: LocalDate, chargeAmount: BigDecima
 
 object ZuoraInvoiceItem {
   implicit val rw: ReadWriter[ZuoraInvoiceItem] = macroRW
+
+  def items(invoiceList: ZuoraInvoiceList, serviceStartDate: LocalDate): Seq[ZuoraInvoiceItem] =
+    invoiceList.invoiceItems.filter(_.serviceStartDate == serviceStartDate)
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
@@ -19,7 +19,9 @@ object ZuoraSubscription {
 }
 
 case class ZuoraRatePlan(
+    id: String,
     productName: String,
+    productRatePlanId: String,
     ratePlanName: String,
     ratePlanCharges: List[ZuoraRatePlanCharge],
     lastChangeType: Option[String] = None
@@ -27,6 +29,9 @@ case class ZuoraRatePlan(
 
 object ZuoraRatePlan {
   implicit val rw: ReadWriter[ZuoraRatePlan] = macroRW
+
+  def ratePlan(subscription: ZuoraSubscription, ratePlanChargeNumber: String): Option[ZuoraRatePlan] =
+    subscription.ratePlans.find(_.ratePlanCharges.exists(_.number == ratePlanChargeNumber))
 }
 
 case class ZuoraRatePlanCharge(

--- a/lambda/src/main/scala/pricemigrationengine/model/package.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/package.scala
@@ -7,6 +7,7 @@ import upickle.default._
 
 package object model {
 
+  type ZuoraSubscriptionId = String
   type ZuoraProductRatePlanChargeId = String
   type ZuoraPricingData = Map[ZuoraProductRatePlanChargeId, ZuoraPricing]
 

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -10,15 +10,16 @@ case class CohortTableKey(subscriptionNumber: String)
 object CohortTable {
   trait Service {
     def fetch(
-      filter: CohortTableFilter
+        filter: CohortTableFilter
     ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
 
     def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit]
     def update(result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit]
+    def update(result: AmendmentResult): ZIO[Any, CohortUpdateFailure, Unit]
   }
 
   def fetch(
-    filter: CohortTableFilter
+      filter: CohortTableFilter
   ): ZIO[CohortTable, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
     ZIO.accessM(_.get.fetch(filter))
 
@@ -26,5 +27,8 @@ object CohortTable {
     ZIO.accessM(_.get.update(result))
 
   def update(result: SalesforcePriceRiseCreationResult): ZIO[CohortTable, CohortUpdateFailure, Unit] =
+    ZIO.accessM(_.get.update(result))
+
+  def update(result: AmendmentResult): ZIO[CohortTable, CohortUpdateFailure, Unit] =
     ZIO.accessM(_.get.update(result))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableTest.scala
@@ -27,6 +27,8 @@ object CohortTableTest {
           } yield ()
 
         def update(result: SalesforcePriceRiseCreationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
-      }
+
+        def update(result: AmendmentResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
+    }
   )
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
@@ -1,14 +1,14 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.model.{CohortTableConfig, ConfigurationFailure, DynamoDBConfig, EstimationHandlerConfig, SalesforceConfig, ZuoraConfig}
+import pricemigrationengine.model._
 import zio.{IO, ZIO}
 
-object EstimationHandlerConfiguration {
+object AmendmentConfiguration {
   trait Service {
-    val config: IO[ConfigurationFailure, EstimationHandlerConfig]
+    val config: IO[ConfigurationFailure, AmendmentConfig]
   }
 
-  val estimationHandlerConfig: ZIO[EstimationHandlerConfiguration, ConfigurationFailure, EstimationHandlerConfig] =
+  val amendmentConfig: ZIO[AmendmentConfiguration, ConfigurationFailure, AmendmentConfig] =
     ZIO.accessM(_.get.config)
 }
 

--- a/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.services
 import java.lang.System.getenv
 import java.time.LocalDate
 
-import pricemigrationengine.model.{CohortTableConfig, ConfigurationFailure, DynamoDBConfig, DynamoDBEndpointConfig, EstimationHandlerConfig, SalesforceConfig, ZuoraConfig}
+import pricemigrationengine.model._
 import zio.{IO, ZIO, ZLayer}
 
 object EnvConfiguration {
@@ -18,16 +18,11 @@ object EnvConfiguration {
       .effect(Option(getenv(name)))
       .mapError(e => ConfigurationFailure(e.getMessage))
 
-  val estimationImpl: ZLayer[Any, Nothing, EstimationHandlerConfiguration] = ZLayer.succeed {
-    new EstimationHandlerConfiguration.Service {
-      val config: IO[ConfigurationFailure, EstimationHandlerConfig] = for {
-        stage <- env("stage")
+  val amendmentImpl: ZLayer[Any, Nothing, AmendmentConfiguration] = ZLayer.succeed {
+    new AmendmentConfiguration.Service {
+      val config: IO[ConfigurationFailure, AmendmentConfig] = for {
         earliestStartDate <- env("earliestStartDate").map(LocalDate.parse)
-        batchSize <- env("batchSize").map(_.toInt)
-      } yield
-        EstimationHandlerConfig(
-          earliestStartDate,
-        )
+      } yield AmendmentConfig(earliestStartDate)
     }
   }
 
@@ -38,11 +33,11 @@ object EnvConfiguration {
         zuoraClientId <- env("zuoraClientId")
         zuoraClientSecret <- env("zuoraClientSecret")
       } yield
-          ZuoraConfig(
-            zuoraApiHost,
-            zuoraClientId,
-            zuoraClientSecret
-          )
+        ZuoraConfig(
+          zuoraApiHost,
+          zuoraClientId,
+          zuoraClientSecret
+        )
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
@@ -16,7 +16,7 @@ object Zuora {
     def updateSubscription(
         subscription: ZuoraSubscription,
         update: ZuoraSubscriptionUpdate
-    ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscription]
+    ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId]
   }
 
   def fetchSubscription(subscriptionNumber: String): ZIO[Zuora, ZuoraFetchFailure, ZuoraSubscription] =
@@ -31,6 +31,6 @@ object Zuora {
   def updateSubscription(
       subscription: ZuoraSubscription,
       update: ZuoraSubscriptionUpdate
-  ): ZIO[Zuora, ZuoraUpdateFailure, ZuoraSubscription] =
+  ): ZIO[Zuora, ZuoraUpdateFailure, ZuoraSubscriptionId] =
     ZIO.accessM(_.get.updateSubscription(subscription, update))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/package.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/package.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import zio.Has
 
 package object services {
-  type EstimationHandlerConfiguration = Has[EstimationHandlerConfiguration.Service]
+  type AmendmentConfiguration = Has[AmendmentConfiguration.Service]
   type ZuoraConfiguration = Has[ZuoraConfiguration.Service]
   type DynamoDBConfiguration = Has[DynamoDBConfiguration.Service]
   type CohortTableConfiguration = Has[CohortTableConfiguration.Service]

--- a/lambda/src/test/resources/Monthly2.json
+++ b/lambda/src/test/resources/Monthly2.json
@@ -59,7 +59,7 @@
   "CancellationReason__c": null,
   "ratePlans": [
     {
-      "id": "id",
+      "id": "rp1",
       "productId": "2c92a0ff5345f9200153559c6d2a3385",
       "productName": "Discounts",
       "productSku": "ABC-00000012",
@@ -128,7 +128,7 @@
       "subscriptionProductFeatures": []
     },
     {
-      "id": "id",
+      "id": "rp2",
       "productId": "2c92a0fc55a0dc530155dfa5b8dd56c0",
       "productName": "Newspaper Voucher",
       "productSku": "ABC-00000014",

--- a/lambda/src/test/resources/MonthlyDiscounted3.json
+++ b/lambda/src/test/resources/MonthlyDiscounted3.json
@@ -59,7 +59,7 @@
   "CancellationReason__c": null,
   "ratePlans": [
     {
-      "id": "id",
+      "id": "rp1",
       "lastChangeType": "Add",
       "productId": "2c92a0ff5345f9200153559c6d2a3385",
       "productName": "Discounts",
@@ -129,7 +129,7 @@
       "subscriptionProductFeatures": []
     },
     {
-      "id": "id",
+      "id": "rp2",
       "productId": "2c92a0fc55a0dc530155dfa5b8dd56c0",
       "productName": "Newspaper Voucher",
       "productSku": "ABC-00000014",

--- a/lambda/src/test/scala/pricemigrationengine/Fixtures.scala
+++ b/lambda/src/test/scala/pricemigrationengine/Fixtures.scala
@@ -1,0 +1,23 @@
+package pricemigrationengine
+
+import pricemigrationengine.model.{ZuoraInvoiceList, ZuoraProductCatalogue, ZuoraSubscription}
+import upickle.default._
+
+import scala.io.Source
+
+object Fixtures {
+
+  private def instanceFromJson[A: Reader](resource: String): A = {
+    val json = Source.fromResource(resource).mkString
+    read[A](json)
+  }
+
+  def productCatalogueFromJson(resource: String): ZuoraProductCatalogue =
+    instanceFromJson[ZuoraProductCatalogue](resource)
+
+  def subscriptionFromJson(resource: String): ZuoraSubscription =
+    instanceFromJson[ZuoraSubscription](resource)
+
+  def invoiceListFromJson(resource: String): ZuoraInvoiceList =
+    instanceFromJson[ZuoraInvoiceList](resource)
+}

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -2,41 +2,25 @@ package pricemigrationengine.model
 
 import java.time.LocalDate
 
+import pricemigrationengine.Fixtures._
 import pricemigrationengine.model.ZuoraProductCatalogue.productPricingMap
-import upickle.default._
-
-import scala.io.Source
 
 class AmendmentDataTest extends munit.FunSuite {
 
   private def migrationStartDate = LocalDate.of(2020, 12, 25)
 
-  private def instanceFromJson[A: Reader](resource: String): A = {
-    val json = Source.fromResource(resource).mkString
-    read[A](json)
-  }
-
-  private def productCatalogueFromJson(resource: String): ZuoraProductCatalogue =
-    instanceFromJson[ZuoraProductCatalogue](resource)
-
-  private def subscriptionFromJson(resource: String): ZuoraSubscription =
-    instanceFromJson[ZuoraSubscription](resource)
-
-  private def invoiceListFromJson(resource: String): ZuoraInvoiceList =
-    instanceFromJson[ZuoraInvoiceList](resource)
-
   test("nextBillingDate: billing date is first after migration start date") {
     val invoiceList = invoiceListFromJson("InvoicePreview.json")
-    val billingDate = AmendmentData.nextBillingDate(invoiceList, after = migrationStartDate)
+    val billingDate = AmendmentData.nextBillingDate(invoiceList, onOrAfter = migrationStartDate)
     assertEquals(billingDate, Right(LocalDate.of(2021, 1, 8)))
   }
 
   test("nextBillingDate: calculation fails if there are no invoices after migration start date") {
     val invoiceList = invoiceListFromJson("InvoicePreviewTermEndsBeforeMigration.json")
-    val billingDate = AmendmentData.nextBillingDate(invoiceList, after = migrationStartDate)
+    val billingDate = AmendmentData.nextBillingDate(invoiceList, onOrAfter = migrationStartDate)
     assertEquals(
-      billingDate.left.map(_.reason.take(73)),
-      Left("Cannot determine next billing date after 2020-12-25 from ZuoraInvoiceList")
+      billingDate.left.map(_.reason.take(79)),
+      Left("Cannot determine next billing date on or after 2020-12-25 from ZuoraInvoiceList")
     )
   }
 

--- a/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
@@ -1,0 +1,52 @@
+package pricemigrationengine.model
+
+import java.time.LocalDate
+
+import pricemigrationengine.Fixtures
+
+class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
+
+  test("updateOfRatePlansToCurrent: updates correct rate plans on a standard monthly voucher sub") {
+    val date = LocalDate.of(2020, 5, 28)
+    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+      subscription = Fixtures.subscriptionFromJson("Monthly2.json"),
+      invoiceList = Fixtures.invoiceListFromJson("InvoicePreview2.json"),
+      date
+    )
+    assertEquals(
+      update,
+      Right(
+        ZuoraSubscriptionUpdate(
+          add = List(
+            AddZuoraRatePlan(productRatePlanId = "2c92a0fd56fe270b0157040dd79b35da", contractEffectiveDate = date)
+          ),
+          remove = List(
+            RemoveZuoraRatePlan(ratePlanId = "rp2", contractEffectiveDate = date)
+          )
+        )
+      )
+    )
+  }
+
+  test("updateOfRatePlansToCurrent: updates correct rate plans on a discounted monthly voucher sub") {
+    val date = LocalDate.of(2020, 6, 15)
+    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+      subscription = Fixtures.subscriptionFromJson("MonthlyDiscounted3.json"),
+      invoiceList = Fixtures.invoiceListFromJson("InvoicePreview3.json"),
+      date
+    )
+    assertEquals(
+      update,
+      Right(
+        ZuoraSubscriptionUpdate(
+          add = List(
+            AddZuoraRatePlan(productRatePlanId = "2c92a0ff56fe33f00157040f9a537f4b", contractEffectiveDate = date)
+          ),
+          remove = List(
+            RemoveZuoraRatePlan(ratePlanId = "rp2", contractEffectiveDate = date)
+          )
+        )
+      )
+    )
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   private val zioVersion = "1.0.0-RC19-2"
 
-  lazy val awsDynamoDb = "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.786"
+  lazy val awsDynamoDb = "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.787"
   lazy val zio = "dev.zio" %% "zio" % zioVersion
   lazy val zioStreams = "dev.zio" %% "zio-streams" % zioVersion
   lazy val upickle = "com.lihaoyi" %% "upickle" % "1.1.0"


### PR DESCRIPTION
The main logic for this is in [AmendmentHandler.amend](https://github.com/guardian/price-migration-engine/compare/kc-amend-2?expand=1#diff-7e7faab75b94ac20b1e6efd5d0f2b264R21-R43) and [ZuoraSubscriptionUpdate](https://github.com/guardian/price-migration-engine/compare/kc-amend-2?expand=1#diff-6d0cd61b33a2be0f84ace32874a73482R15-R42).

For each sub, we recalculate the start date, and replace the product rate plans that are active on that date with the current equivalent rate plans.  This has the effect of updating the price of all the rate plan charges to their values in the product catalogue.  This should also take into account any tax applicable to the rate plan charges.  Discounts will be unaffected so will continue at their current rate.

This should do the amendment correctly for all products, but the result we record in the cohort table will be inaccurate for '+' products which are taxable.  So these products will need more consideration.  Tax doesn't work properly in Zuora invoice previews.
