### PR TITLE
Create id upload lambda

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -119,6 +119,31 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/price-migration-engine-amendment-lambda-${Stage}:log-stream:*"
 
+  PriceMigrationEngineSubscriptionIdUploadLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: LambdaPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/price-migration-engine-subscription-id-upload-lambda-${Stage}:log-stream:*"
+
   PriceMigrationEngineEstimationLambda:
     Type: AWS::Lambda::Function
     Properties:
@@ -240,3 +265,27 @@ Resources:
       Timeout: 300
     DependsOn:
       - PriceMigrationEngineAmendmentLambdaRole
+
+  PriceMigrationEngineSubscriptionIdUploadLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Uploads subscription id CSV files into price migration engine.
+      FunctionName:
+        !Sub price-migration-engine-subscription-id-upload-lambda-${Stage}
+      Code:
+        S3Bucket: membership-dist
+        S3Key: !Sub membership/${Stage}/price-migration-engine-lambda/price-migration-engine-lambda.jar
+      Handler: pricemigrationengine.handlers.SubscriptionIdUploadHandler::handleRequest
+      Environment:
+        Variables:
+          stage: !Ref Stage
+          batchSize: 100
+      Role:
+        Fn::GetAtt:
+          - PriceMigrationEngineSubscriptionIdUploadLambdaRole
+          - Arn
+      MemorySize: 1536
+      Runtime: java8
+      Timeout: 300
+    DependsOn:
+      - PriceMigrationEngineSubscriptionIdUploadLambdaRole

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -16,13 +16,15 @@ Mappings:
     DEV:
       SecretsVersion: "e159cf84-2ae6-4600-8444-d8c4c74531d5"
       EarliestStartDate: 2020-05-15
+      BucketName: price-migration-engine-dev
     CODE:
       SecretsVersion: "a0df5201-f2d9-4699-a704-805e7c1df2ee"
       EarliestStartDate: 2020-05-15
+      BucketName: price-migration-engine-code
     PROD:
       SecretsVersion: "0ef81375-18ec-4a94-b4b9-eb4c399e3455"
       EarliestStartDate: 2020-12-25
-
+      BucketName: price-migration-engine-prod
 
 Resources:
 
@@ -150,14 +152,16 @@ Resources:
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub "arn:aws:s3:::price-migration-engine-${Stage}"
+                  - !Sub
+                    - "arn:aws:s3:::${BucketName}"
+                    - {BucketName: !FindInMap [StageMap, !Ref Stage, BucketName]}
     DependsOn:
       - S3Bucket
 
   S3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "price-migration-engine-${Stage}"
+      BucketName: !FindInMap [StageMap, !Ref Stage, BucketName]
 
   PriceMigrationEngineEstimationLambda:
     Type: AWS::Lambda::Function

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -154,7 +154,6 @@ Resources:
 
   S3Bucket:
     Type: AWS::S3::Bucket
-    DependsOn: BucketPermission
     Properties:
       BucketName: !Sub "price-migration-engine-${Stage}"
 

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -151,6 +151,8 @@ Resources:
                   - s3:GetObject
                 Resource:
                   - !Sub "arn:aws:s3:::price-migration-engine-${Stage}"
+    DependsOn:
+      - S3Bucket
 
   S3Bucket:
     Type: AWS::S3::Bucket

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -143,6 +143,20 @@ Resources:
                   - lambda:InvokeFunction
                 Resource:
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/price-migration-engine-subscription-id-upload-lambda-${Stage}:log-stream:*"
+        - PolicyName: S3BucketPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - !Sub "arn:aws:s3:::price-migration-engine-${Stage}"
+
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    DependsOn: BucketPermission
+    Properties:
+      BucketName: !Sub "price-migration-engine-${Stage}"
 
   PriceMigrationEngineEstimationLambda:
     Type: AWS::Lambda::Function
@@ -289,3 +303,4 @@ Resources:
       Timeout: 300
     DependsOn:
       - PriceMigrationEngineSubscriptionIdUploadLambdaRole
+      - S3Bucket

--- a/lambda/riff-raff.yaml
+++ b/lambda/riff-raff.yaml
@@ -20,4 +20,5 @@ deployments:
       - price-migration-engine-estimation-lambda-
       - price-migration-engine-salesforce-price-rise-lambda-
       - price-migration-engine-amendment-lambda-
+      - price-migration-engine-subscription-id-upload-lambda-
     dependencies: [cfn]

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
@@ -1,0 +1,44 @@
+package pricemigrationengine.handlers
+
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import pricemigrationengine.model.CohortTableFilter.SalesforcePriceRiceCreationComplete
+import pricemigrationengine.model._
+import pricemigrationengine.services._
+import zio.console.Console
+import zio.{App, Runtime, ZEnv, ZIO, ZLayer, console}
+
+object SubscriptionIdUploadHandler extends App with RequestHandler[Unit, Unit] {
+
+  val main: ZIO[Logging with CohortTable, Failure, Unit] = ???
+
+  private def env(
+      loggingLayer: ZLayer[Any, Nothing, Logging]
+  ) = {
+    val cohortTableLayer =
+      loggingLayer ++ EnvConfiguration.dynamoDbImpl >>>
+      DynamoDBClient.dynamoDB ++ loggingLayer >>>
+      DynamoDBZIOLive.impl ++ loggingLayer ++ EnvConfiguration.cohortTableImp >>>
+      CohortTableLive.impl
+    loggingLayer ++ EnvConfiguration.amendmentImpl ++ cohortTableLayer
+  }
+
+  private val runtime = Runtime.default
+
+  def run(args: List[String]): ZIO[ZEnv, Nothing, Int] =
+    main
+      .provideSomeLayer(
+        env(Console.live >>> ConsoleLogging.impl)
+      )
+      // output any failures in service construction - there's probably a better way to do this
+      .foldM(
+        e => console.putStrLn(s"Failed: $e") *> ZIO.succeed(1),
+        _ => console.putStrLn("Succeeded!") *> ZIO.succeed(0)
+      )
+
+  def handleRequest(unused: Unit, context: Context): Unit =
+    runtime.unsafeRun(
+      main.provideSomeLayer(
+        env(LambdaLogging.impl(context))
+      )
+    )
+}

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
@@ -1,7 +1,6 @@
 package pricemigrationengine.handlers
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
-import pricemigrationengine.model.CohortTableFilter.SalesforcePriceRiceCreationComplete
 import pricemigrationengine.model._
 import pricemigrationengine.services._
 import zio.console.Console
@@ -19,7 +18,7 @@ object SubscriptionIdUploadHandler extends App with RequestHandler[Unit, Unit] {
       DynamoDBClient.dynamoDB ++ loggingLayer >>>
       DynamoDBZIOLive.impl ++ loggingLayer ++ EnvConfiguration.cohortTableImp >>>
       CohortTableLive.impl
-    loggingLayer ++ EnvConfiguration.amendmentImpl ++ cohortTableLayer
+    loggingLayer ++ cohortTableLayer
   }
 
   private val runtime = Runtime.default


### PR DESCRIPTION
This PR adds the skeleton code for the subscription id upload lambda.

This includes:
- Lambda cloudformation
- S3 bucket for subscription id files
- Riff-raff config
- Stub lambda handler with dynamodb/cohort table services.