### PR TITLE
Update status of a cancelled subscription in the cohort table

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -6,7 +6,7 @@ object CohortTableFilter {
   case object ReadyForEstimation extends CohortTableFilter { override val value: String = "ReadyForEstimation" }
   case object EstimationComplete extends CohortTableFilter { override val value: String = "EstimationComplete" }
   case object SalesforcePriceRiceCreationComplete extends CohortTableFilter {
-    override val value: String = "SalesforcePriceRiceCreationComplete"
+    override val value: String = "SalesforcePriceRiseCreationComplete"
   }
   case object AmendmentComplete extends CohortTableFilter { override val value: String = "AmendmentComplete" }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -13,10 +13,10 @@ case class ZuoraFetchFailure(reason: String) extends Failure
 case class ZuoraUpdateFailure(reason: String) extends Failure
 
 case class AmendmentDataFailure(reason: String) extends Failure
+case class CancelledSubscriptionFailure(reason: String) extends Failure
+
 case class SalesforceFailure(reason: String) extends Failure
-
 case class SalesforcePriceRiseCreationFailure(reason: String) extends Failure
-
 case class SalesforceClientFailure(reason: String) extends Failure
 
 case class S3Failure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
@@ -11,7 +11,8 @@ case class ZuoraSubscription(
     contractEffectiveDate: LocalDate,
     ratePlans: List[ZuoraRatePlan],
     accountNumber: String,
-    accountId: String
+    accountId: String,
+    status: String
 )
 
 object ZuoraSubscription {

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -14,8 +14,13 @@ object CohortTable {
 
     def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit]
     def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit]
-    def update(subscriptionName: String, result: SalesforcePriceRiseCreationDetails): ZIO[Any, CohortUpdateFailure, Unit]
+    def update(
+        subscriptionName: String,
+        result: SalesforcePriceRiseCreationDetails
+    ): ZIO[Any, CohortUpdateFailure, Unit]
     def update(result: AmendmentResult): ZIO[Any, CohortUpdateFailure, Unit]
+
+    def updateToCancelled(item: CohortItem): ZIO[Any, CohortUpdateFailure, Unit]
   }
 
   def fetch(
@@ -30,11 +35,14 @@ object CohortTable {
     ZIO.accessM(_.get.update(result))
 
   def update(
-    subscriptionName: String,
-    result: SalesforcePriceRiseCreationDetails
+      subscriptionName: String,
+      result: SalesforcePriceRiseCreationDetails
   ): ZIO[CohortTable, CohortUpdateFailure, Unit] =
     ZIO.accessM(_.get.update(subscriptionName, result))
 
   def update(result: AmendmentResult): ZIO[CohortTable, CohortUpdateFailure, Unit] =
     ZIO.accessM(_.get.update(result))
+
+  def updateToCancelled(item: CohortItem): ZIO[CohortTable, CohortUpdateFailure, Unit] =
+    ZIO.accessM(_.get.updateToCancelled(item))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -5,7 +5,13 @@ import java.time.{Instant, LocalDate, ZoneOffset}
 import java.util
 
 import com.amazonaws.services.dynamodbv2.model.{AttributeAction, AttributeValue, AttributeValueUpdate, QueryRequest}
-import pricemigrationengine.model.CohortTableFilter.{AmendmentComplete, EstimationComplete, ReadyForEstimation, SalesforcePriceRiceCreationComplete}
+import pricemigrationengine.model.CohortTableFilter.{
+  AmendmentComplete,
+  Cancelled,
+  EstimationComplete,
+  ReadyForEstimation,
+  SalesforcePriceRiceCreationComplete
+}
 import pricemigrationengine.model._
 import pricemigrationengine.services.CohortTable.Service
 import zio.stream.ZStream
@@ -20,16 +26,17 @@ object CohortTableLive {
         subscriptionNumber <- getStringFromResults(cohortItem, "subscriptionNumber")
         expectedStartDate <- getOptionalDateFromResults(cohortItem, "expectedStartDate")
         currency <- getOptionalStringFromResults(cohortItem, "currency")
-        oldPrice <-  getOptionalBigDecimalFromResults(cohortItem, "oldPrice")
+        oldPrice <- getOptionalBigDecimalFromResults(cohortItem, "oldPrice")
         estimatedNewPrice <- getOptionalBigDecimalFromResults(cohortItem, "estimatedNewPrice")
         billingPeriod <- getOptionalStringFromResults(cohortItem, "currency")
-      } yield CohortItem(
-        subscriptionNumber,
-        expectedStartDate,
-        currency,
-        oldPrice,
-        estimatedNewPrice,
-        billingPeriod
+      } yield
+        CohortItem(
+          subscriptionNumber,
+          expectedStartDate,
+          currency,
+          oldPrice,
+          estimatedNewPrice,
+          billingPeriod
       )
 
   private implicit val estimationResultSerialiser: DynamoDBUpdateSerialiser[EstimationResult] =
@@ -54,7 +61,8 @@ object CohortTableLive {
         stringFieldUpdate("whenAmendmentDone", Instant.now.toString)
       ).asJava
 
-  private implicit val salesforcePriceRiseCreationResultSerialiser: DynamoDBUpdateSerialiser[SalesforcePriceRiseCreationDetails] =
+  private implicit val salesforcePriceRiseCreationResultSerialiser
+    : DynamoDBUpdateSerialiser[SalesforcePriceRiseCreationDetails] =
     salesforcePriceRise =>
       Map(
         stringFieldUpdate("processingStage", SalesforcePriceRiceCreationComplete.value),
@@ -66,10 +74,11 @@ object CohortTableLive {
     key => Map(stringUpdate("subscriptionNumber", key.subscriptionNumber)).asJava
 
   private implicit val subscriptionSerialiser: DynamoDBSerialiser[CohortItem] =
-    cohortItem => Map(
-      stringUpdate("subscriptionNumber", cohortItem.subscriptionName),
-      stringUpdate("processingStage", ReadyForEstimation.value)
-    ).asJava
+    cohortItem =>
+      Map(
+        stringUpdate("subscriptionNumber", cohortItem.subscriptionName),
+        stringUpdate("processingStage", ReadyForEstimation.value)
+      ).asJava
 
   private def stringFieldUpdate(fieldName: String, stringValue: String) =
     fieldName -> new AttributeValueUpdate(new AttributeValue().withS(stringValue), AttributeAction.PUT)
@@ -101,121 +110,150 @@ object CohortTableLive {
     } yield string
   }
 
-  private def getOptionalStringFromResults(result: util.Map[String, AttributeValue], fieldName: String): IO[DynamoDBZIOError, Option[String]] = {
-    result
-      .asScala
+  private def getOptionalStringFromResults(
+      result: util.Map[String, AttributeValue],
+      fieldName: String
+  ): IO[DynamoDBZIOError, Option[String]] = {
+    result.asScala
       .get(fieldName)
-      .fold[IO[DynamoDBZIOError, Option[String]]](ZIO.succeed(None)) { attributeValue =>
+      .fold[IO[DynamoDBZIOError, Option[String]]](ZIO.none) { attributeValue =>
         ZIO
           .fromOption(Option(attributeValue.getS))
-          .orElseFail(DynamoDBZIOError(s"The '$fieldName' field was not a string in the record '$result'"))
-          .map(Some.apply)
+          .bimap(_ => DynamoDBZIOError(s"The '$fieldName' field was not a string in the record '$result'"), Some.apply)
       }
   }
 
-  private def getOptionalNumberStringFromResults(result: util.Map[String, AttributeValue], fieldName: String): IO[DynamoDBZIOError, Option[String]] = {
-    result
-      .asScala
+  private def getOptionalNumberStringFromResults(
+      result: util.Map[String, AttributeValue],
+      fieldName: String
+  ): IO[DynamoDBZIOError, Option[String]] = {
+    result.asScala
       .get(fieldName)
-      .fold[IO[DynamoDBZIOError, Option[String]]](ZIO.succeed(None)) { attributeValue =>
+      .fold[IO[DynamoDBZIOError, Option[String]]](ZIO.none) { attributeValue =>
         ZIO
           .fromOption(Option(attributeValue.getN))
-          .orElseFail(DynamoDBZIOError(s"The '$fieldName' field was not a number in the record '$result'"))
-          .map(Some.apply)
+          .bimap(_ => DynamoDBZIOError(s"The '$fieldName' field was not a number in the record '$result'"), Some.apply)
       }
   }
 
-  private def getOptionalDateFromResults(result: util.Map[String, AttributeValue], fieldName: String): IO[DynamoDBZIOError, Option[LocalDate]] =
+  private def getOptionalDateFromResults(
+      result: util.Map[String, AttributeValue],
+      fieldName: String
+  ): IO[DynamoDBZIOError, Option[LocalDate]] =
     for {
       optionalString <- getOptionalStringFromResults(result, fieldName)
-      optionalDate <-
-        optionalString.fold[IO[DynamoDBZIOError, Option[LocalDate]]](ZIO.succeed(None)) { string =>
-          ZIO
-            .effect(Some(LocalDate.parse(string)))
-            .mapError(ex => DynamoDBZIOError(s"The '$fieldName' has value '$string' which is not a valid date yyyy-MM-dd"))
-        }
+      optionalDate <- optionalString.fold[IO[DynamoDBZIOError, Option[LocalDate]]](ZIO.none) { string =>
+        ZIO
+          .effect(Some(LocalDate.parse(string)))
+          .mapError(
+            ex => DynamoDBZIOError(s"The '$fieldName' has value '$string' which is not a valid date yyyy-MM-dd")
+          )
+      }
     } yield optionalDate
 
-  private def getOptionalBigDecimalFromResults(result: util.Map[String, AttributeValue], fieldName: String): IO[DynamoDBZIOError, Option[BigDecimal]] =
+  private def getOptionalBigDecimalFromResults(
+      result: util.Map[String, AttributeValue],
+      fieldName: String
+  ): IO[DynamoDBZIOError, Option[BigDecimal]] =
     for {
       optionalNumberString <- getOptionalNumberStringFromResults(result, fieldName)
-      optionalDecimal <-
-        optionalNumberString.fold[IO[DynamoDBZIOError, Option[BigDecimal]]](ZIO.succeed(None)) { string =>
-          ZIO
-            .effect(Some(BigDecimal(string)))
-            .mapError(ex => DynamoDBZIOError(s"The '$fieldName' has value '$string' which is not a valid number"))
-        }
+      optionalDecimal <- optionalNumberString.fold[IO[DynamoDBZIOError, Option[BigDecimal]]](ZIO.none) { string =>
+        ZIO
+          .effect(Some(BigDecimal(string)))
+          .mapError(ex => DynamoDBZIOError(s"The '$fieldName' has value '$string' which is not a valid number"))
+      }
     } yield optionalDecimal
 
-  val impl: ZLayer[DynamoDBZIO with StageConfiguration with CohortTableConfiguration with Logging, Nothing, CohortTable] =
-    ZLayer.fromFunction { dependencies: DynamoDBZIO with StageConfiguration with CohortTableConfiguration with Logging =>
-      new Service {
-        override def fetch(
-            filter: CohortTableFilter
-        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
-          for {
-            cohortTableConfig <- CohortTableConfiguration.cohortTableConfig
-              .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
-            stageConfig <- StageConfiguration.stageConfig
-              .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
-            queryResults <- DynamoDBZIO
-              .query(
-                new QueryRequest()
-                  .withTableName(s"PriceMigrationEngine${stageConfig.stage}")
-                  .withIndexName("ProcessingStageIndexV2")
-                  .withKeyConditionExpression("processingStage = :processingStage")
-                  .withExpressionAttributeValues(
-                    Map(":processingStage" -> new AttributeValue(filter.value)).asJava
-                  )
-                  .withLimit(cohortTableConfig.batchSize)
+  val impl
+    : ZLayer[DynamoDBZIO with StageConfiguration with CohortTableConfiguration with Logging, Nothing, CohortTable] =
+    ZLayer.fromFunction {
+      dependencies: DynamoDBZIO with StageConfiguration with CohortTableConfiguration with Logging =>
+        new Service {
+          override def fetch(
+              filter: CohortTableFilter
+          ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
+            for {
+              cohortTableConfig <- CohortTableConfiguration.cohortTableConfig
+                .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
+              stageConfig <- StageConfiguration.stageConfig
+                .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
+              queryResults <- DynamoDBZIO
+                .query(
+                  new QueryRequest()
+                    .withTableName(s"PriceMigrationEngine${stageConfig.stage}")
+                    .withIndexName("ProcessingStageIndexV2")
+                    .withKeyConditionExpression("processingStage = :processingStage")
+                    .withExpressionAttributeValues(
+                      Map(":processingStage" -> new AttributeValue(filter.value)).asJava
+                    )
+                    .withLimit(cohortTableConfig.batchSize)
+                )
+                .map(_.mapError(error => CohortFetchFailure(error.toString)))
+            } yield queryResults
+          }.provide(dependencies)
+
+          override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
+            for {
+              config <- StageConfiguration.stageConfig
+                .mapError(error => CohortUpdateFailure(s"Failed to get configuration:${error.reason}"))
+              result <- DynamoDBZIO
+                .put(s"PriceMigrationEngine${config.stage}", cohortItem)
+                .mapError(error => CohortUpdateFailure(error.toString))
+            } yield result
+          }.provide(dependencies)
+
+          override def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit] = {
+            for {
+              config <- StageConfiguration.stageConfig
+                .mapError(error => CohortUpdateFailure(s"Failed to get configuration:${error.reason}"))
+              result <- DynamoDBZIO
+                .update(s"PriceMigrationEngine${config.stage}", CohortTableKey(result.subscriptionName), result)
+                .mapError(error => CohortUpdateFailure(error.toString))
+            } yield result
+          }.provide(dependencies)
+
+          override def update(
+              subscriptionName: String,
+              result: SalesforcePriceRiseCreationDetails
+          ): ZIO[Any, CohortUpdateFailure, Unit] = {
+            for {
+              config <- StageConfiguration.stageConfig
+                .mapError(error => CohortUpdateFailure(s"Failed to get configuration:${error.reason}"))
+              result <- DynamoDBZIO
+                .update(s"PriceMigrationEngine${config.stage}", CohortTableKey(subscriptionName), result)
+                .mapError(error => CohortUpdateFailure(error.toString))
+            } yield result
+          }.provide(dependencies)
+
+          override def update(result: AmendmentResult): ZIO[Any, CohortUpdateFailure, Unit] = {
+            (for {
+              config <- StageConfiguration.stageConfig
+                .mapError(error => CohortUpdateFailure(s"Failed to get configuration:${error.reason}"))
+              result <- DynamoDBZIO
+                .update(s"PriceMigrationEngine${config.stage}", CohortTableKey(result.subscriptionName), result)
+                .mapError(error => CohortUpdateFailure(error.toString))
+            } yield result)
+              .tapBoth(
+                e => Logging.error(s"Failed to update Cohort table: $e"),
+                _ => Logging.info(s"Wrote $result to Cohort table")
               )
-              .map(_.mapError(error => CohortFetchFailure(error.toString)))
-          } yield queryResults
-        }.provide(dependencies)
+          }.provide(dependencies)
 
-        override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
-          for {
-            config <- StageConfiguration.stageConfig
-              .mapError(error => CohortUpdateFailure(s"Failed to get configuration:${error.reason}"))
-            result <- DynamoDBZIO
-              .put(s"PriceMigrationEngine${config.stage}", cohortItem)
-              .mapError(error => CohortUpdateFailure(error.toString))
-          } yield result
-        }.provide(dependencies)
-
-        override def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit] = {
-          for {
-            config <- StageConfiguration.stageConfig
-              .mapError(error => CohortUpdateFailure(s"Failed to get configuration:${error.reason}"))
-            result <- DynamoDBZIO
-              .update(s"PriceMigrationEngine${config.stage}", CohortTableKey(result.subscriptionName), result)
-              .mapError(error => CohortUpdateFailure(error.toString))
-          } yield result
-        }.provide(dependencies)
-
-        override def update(subscriptionName: String, result: SalesforcePriceRiseCreationDetails): ZIO[Any, CohortUpdateFailure, Unit] = {
-          for {
-            config <- StageConfiguration.stageConfig
-              .mapError(error => CohortUpdateFailure(s"Failed to get configuration:${error.reason}"))
-            result <- DynamoDBZIO
-              .update(s"PriceMigrationEngine${config.stage}", CohortTableKey(subscriptionName), result)
-              .mapError(error => CohortUpdateFailure(error.toString))
-          } yield result
-        }.provide(dependencies)
-
-        override def update(result: AmendmentResult): ZIO[Any, CohortUpdateFailure, Unit] = {
-          (for {
-            config <- StageConfiguration.stageConfig
-              .mapError(error => CohortUpdateFailure(s"Failed to get configuration:${error.reason}"))
-            result <- DynamoDBZIO
-              .update(s"PriceMigrationEngine${config.stage}", CohortTableKey(result.subscriptionName), result)
-              .mapError(error => CohortUpdateFailure(error.toString))
-          } yield result)
-            .tapBoth(
-              e => Logging.error(s"Failed to update Cohort table: $e"),
-              _ => Logging.info(s"Wrote $result to Cohort table")
-            )
-        }.provide(dependencies)
-      }
+          override def updateToCancelled(item: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
+            implicit val serialiser: DynamoDBUpdateSerialiser[String] =
+              (processingStage: String) => Map(stringFieldUpdate("processingStage", processingStage)).asJava
+            (for {
+              config <- StageConfiguration.stageConfig
+                .mapError(error => CohortUpdateFailure(s"Failed to get configuration:${error.reason}"))
+              result <- DynamoDBZIO
+                .update(s"PriceMigrationEngine${config.stage}", CohortTableKey(item.subscriptionName), Cancelled.value)
+                .mapError(error => CohortUpdateFailure(error.toString))
+            } yield result)
+              .tapBoth(
+                e => Logging.error(s"Failed to update Cohort table: $e"),
+                _ => Logging.info(s"Wrote cancelled status of ${item.subscriptionName} to Cohort table")
+              )
+          }.provide(dependencies)
+        }
     }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
@@ -19,7 +19,7 @@ object Zuora {
     ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId]
   }
 
-  def fetchSubscription(subscriptionNumber: String): ZIO[Zuora, ZuoraFetchFailure, ZuoraSubscription] =
+  def fetchSubscription(subscriptionNumber: String): ZIO[Zuora, Failure, ZuoraSubscription] =
     ZIO.accessM(_.get.fetchSubscription(subscriptionNumber))
 
   def fetchInvoicePreview(accountId: String): ZIO[Zuora, ZuoraFetchFailure, ZuoraInvoiceList] =

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -24,24 +24,33 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
 
     val stubCohortTable = ZLayer.succeed(
       new CohortTable.Service {
-        override def fetch(filter: CohortTableFilter): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
+        override def fetch(
+            filter: CohortTableFilter
+        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
         override def update(result: EstimationResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
-        override def update(subscriptionName: String, result: SalesforcePriceRiseCreationDetails): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        override def update(
+            subscriptionName: String,
+            result: SalesforcePriceRiseCreationDetails
+        ): ZIO[Any, CohortUpdateFailure, Unit] = ???
         override def update(result: AmendmentResult): ZIO[Any, CohortUpdateFailure, Unit] = ???
         override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] =
           IO.effect {
-            subscriptionsWrittenToCohortTable.addOne(cohortItem)
-            ()
-          }.mapError(_ => CohortUpdateFailure(""))
+              subscriptionsWrittenToCohortTable.addOne(cohortItem)
+              ()
+            }
+            .orElseFail(CohortUpdateFailure(""))
+        override def updateToCancelled(item: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
       }
     )
 
     val stubS3: Layer[Nothing, Has[S3.Service]] = ZLayer.succeed(
       new S3.Service {
         def loadTestResource(path: String) = {
-          ZManaged.makeEffect(getClass.getResourceAsStream(path)) { stream =>
-            stream.close()
-          }.mapError(ex => S3Failure(s"Failed to load test resource: $ex"))
+          ZManaged
+            .makeEffect(getClass.getResourceAsStream(path)) { stream =>
+              stream.close()
+            }
+            .mapError(ex => S3Failure(s"Failed to load test resource: $ex"))
         }
 
         override def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream] = s3Location match {

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -43,12 +43,12 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZStream(item1, item2).mapM(item => IO.effect(item.asInstanceOf[A]).orElseFail(DynamoDBZIOError("")))
         }
 
-        override def update[A, B](table: String, key: A, value: B)
-                                 (implicit keySerializer: DynamoDBSerialiser[A],
-                                  valueSerializer: DynamoDBUpdateSerialiser[B]): IO[DynamoDBZIOError, Unit] = ???
+        override def update[A, B](table: String, key: A, value: B)(
+            implicit keySerializer: DynamoDBSerialiser[A],
+            valueSerializer: DynamoDBUpdateSerialiser[B]): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String, value: A)
-                           (implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
+        override def put[A](table: String,
+                            value: A)(implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
       }
     )
 
@@ -58,7 +58,7 @@ class CohortTableLiveTest extends munit.FunSuite {
           result <- CohortTable
             .fetch(ReadyForEstimation)
             .provideLayer(
-              stubCohortTableConfiguration ++ stubStageConfiguration++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
+              stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
                 CohortTableLive.impl
             )
           resultList <- result.run(Sink.collectAll[CohortItem])
@@ -110,8 +110,8 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def put[A](table: String, value: A)
-                           (implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
+        override def put[A](table: String,
+                            value: A)(implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
       }
     )
 
@@ -130,7 +130,7 @@ class CohortTableLiveTest extends munit.FunSuite {
           .update(estimationResult)
           .provideLayer(
             stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
-            CohortTableLive.impl
+              CohortTableLive.impl
           )
       ),
       Success(())
@@ -208,8 +208,8 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def put[A](table: String, value: A)
-                           (implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
+        override def put[A](table: String,
+                            value: A)(implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
       }
     )
 
@@ -279,23 +279,24 @@ class CohortTableLiveTest extends munit.FunSuite {
     val stubDynamoDBZIO = ZLayer.succeed(
       new DynamoDBZIO.Service {
         override def query[A](query: QueryRequest)(
-          implicit deserializer: DynamoDBDeserialiser[A]
+            implicit deserializer: DynamoDBDeserialiser[A]
         ): ZStream[Any, DynamoDBZIOError, A] = ???
 
         override def update[A, B](table: String, key: A, value: B)(
-          implicit keySerializer: DynamoDBSerialiser[A],
-          valueSerializer: DynamoDBUpdateSerialiser[B]
+            implicit keySerializer: DynamoDBSerialiser[A],
+            valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = {
           tableUpdated = Some(table)
           receivedKey = Some(key.asInstanceOf[CohortTableKey])
           receivedUpdate = Some(value.asInstanceOf[SalesforcePriceRiseCreationDetails])
           receivedKeySerialiser = Some(keySerializer.asInstanceOf[DynamoDBSerialiser[CohortTableKey]])
-          receivedValueSerialiser = Some(valueSerializer.asInstanceOf[DynamoDBUpdateSerialiser[SalesforcePriceRiseCreationDetails]])
+          receivedValueSerialiser =
+            Some(valueSerializer.asInstanceOf[DynamoDBUpdateSerialiser[SalesforcePriceRiseCreationDetails]])
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def put[A](table: String, value: A)
-                           (implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
+        override def put[A](table: String,
+                            value: A)(implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
       }
     )
 
@@ -312,7 +313,7 @@ class CohortTableLiveTest extends munit.FunSuite {
           .update("subscription-name", salesforcePriceRiseCreationResult)
           .provideLayer(
             stubStageConfiguration ++ stubCohortTableConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
-            CohortTableLive.impl
+              CohortTableLive.impl
           )
       ),
       Success(())
@@ -329,7 +330,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     val update = receivedValueSerialiser.get.serialise(receivedUpdate.get)
     assertEquals(
       update.get("processingStage"),
-      new AttributeValueUpdate(new AttributeValue().withS("SalesforcePriceRiceCreationComplete"), AttributeAction.PUT),
+      new AttributeValueUpdate(new AttributeValue().withS("SalesforcePriceRiseCreationComplete"), AttributeAction.PUT),
       "processingStage"
     )
     assertEquals(
@@ -352,16 +353,16 @@ class CohortTableLiveTest extends munit.FunSuite {
     val stubDynamoDBZIO = ZLayer.succeed(
       new DynamoDBZIO.Service {
         override def query[A](query: QueryRequest)(
-          implicit deserializer: DynamoDBDeserialiser[A]
+            implicit deserializer: DynamoDBDeserialiser[A]
         ): ZStream[Any, DynamoDBZIOError, A] = ???
 
         override def update[A, B](table: String, key: A, value: B)(
-          implicit keySerializer: DynamoDBSerialiser[A],
-          valueSerializer: DynamoDBUpdateSerialiser[B]
+            implicit keySerializer: DynamoDBSerialiser[A],
+            valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String, value: A)
-                           (implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = {
+        override def put[A](table: String,
+                            value: A)(implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = {
           tableUpdated = Some(table)
           receivedInsert = Some(value.asInstanceOf[CohortItem])
           receivedSerialiser = Some(valueSerializer.asInstanceOf[DynamoDBSerialiser[CohortItem]])


### PR DESCRIPTION
If a cancelled sub comes up during the amendment process, it is considered to be a success and marked as cancelled in the cohort table.

A cancelled sub is [identified and generates a failure](https://github.com/guardian/price-migration-engine/compare/kc-amend-cancelled?expand=1#diff-7e7faab75b94ac20b1e6efd5d0f2b264R66), which is then written as a [cancellation](https://github.com/guardian/price-migration-engine/compare/kc-amend-cancelled?expand=1#diff-7e7faab75b94ac20b1e6efd5d0f2b264R26) rather than an [amendment](https://github.com/guardian/price-migration-engine/compare/kc-amend-cancelled?expand=1#diff-7e7faab75b94ac20b1e6efd5d0f2b264R29).

[This](https://github.com/guardian/price-migration-engine/compare/kc-amend-cancelled?expand=1#diff-0a02d7fd1683c92d607be4bb7cc9d76bR242-R257) is the implementation of the cancellation update.
