### PR TITLE
Fix post-amendment result

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -34,27 +34,29 @@ object AmendmentHandler extends App with RequestHandler[Unit, Unit] {
   ): ZIO[Logging with AmendmentConfiguration with Zuora, Failure, AmendmentResult] =
     for {
       config <- AmendmentConfiguration.amendmentConfig
-      subscription <- fetchSubscription(item)
-      invoicePreviewBeforeUpdate <- Zuora.fetchInvoicePreview(subscription.accountId)
+      subscriptionBeforeUpdate <- fetchSubscription(item)
+      invoicePreviewBeforeUpdate <- Zuora.fetchInvoicePreview(subscriptionBeforeUpdate.accountId)
       startDate <- ZIO.fromEither(
         AmendmentData.nextServiceStartDate(invoicePreviewBeforeUpdate, config.earliestStartDate)
       )
       update <- ZIO.fromEither(
-        ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(subscription, invoicePreviewBeforeUpdate, startDate)
+        ZuoraSubscriptionUpdate
+          .updateOfRatePlansToCurrent(subscriptionBeforeUpdate, invoicePreviewBeforeUpdate, startDate)
       )
-      newSubscriptionId <- Zuora.updateSubscription(subscription, update)
-      invoicePreviewAfterUpdate <- Zuora.fetchInvoicePreview(subscription.accountId)
+      newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
+      subscriptionAfterUpdate <- fetchSubscription(item)
+      invoicePreviewAfterUpdate <- Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId)
       totalChargeAmount <- ZIO
-        .fromEither(AmendmentData.totalChargeAmount(subscription, invoicePreviewAfterUpdate, startDate))
+        .fromEither(AmendmentData.totalChargeAmount(subscriptionAfterUpdate, invoicePreviewAfterUpdate, startDate))
         .mapError(
           e =>
             AmendmentDataFailure(
-              s"Failed to calculate amendment of subscription ${subscription.subscriptionNumber}: $e"
+              s"Failed to calculate amendment of subscription ${subscriptionBeforeUpdate.subscriptionNumber}: $e"
           )
         )
     } yield
       AmendmentResult(
-        subscription.subscriptionNumber,
+        subscriptionBeforeUpdate.subscriptionNumber,
         startDate,
         totalChargeAmount,
         newSubscriptionId


### PR DESCRIPTION
Need to fetch subscription before and after update, as well as the invoice preview, otherwise the new rate plan charges in the invoice preview won't match anything in the subscription.