### PR TITLE
Use start date set by EstimationHandler for amendment

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -40,7 +40,7 @@ object EstimationHandler extends App with RequestHandler[Unit, Unit] {
             oldPrice = Some(result.oldPrice),
             estimatedNewPrice = Some(result.estimatedNewPrice),
             currency = Some(result.currency),
-            expectedStartDate = Some(result.expectedStartDate),
+            startDate = Some(result.startDate),
             billingPeriod = Some(result.billingPeriod),
             whenEstimationDone = Some(Instant.now())
           )

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -5,7 +5,7 @@ import java.time.{Instant, LocalDate}
 case class CohortItem(
     subscriptionName: String,
     processingStage: CohortTableFilter,
-    expectedStartDate: Option[LocalDate] = None,
+    startDate: Option[LocalDate] = None,
     currency: Option[Currency] = None,
     oldPrice: Option[BigDecimal] = None,
     estimatedNewPrice: Option[BigDecimal] = None,
@@ -13,7 +13,6 @@ case class CohortItem(
     whenEstimationDone: Option[Instant] = None,
     salesforcePriceRiseId: Option[String] = None,
     whenSfShowEstimate: Option[Instant] = None,
-    startDate: Option[LocalDate] = None,
     newPrice: Option[BigDecimal] = None,
     newSubscriptionId: Option[ZuoraSubscriptionId] = None,
     whenAmendmentDone: Option[Instant] = None

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 case class EstimationResult(
     subscriptionName: String,
-    expectedStartDate: LocalDate,
+    startDate: LocalDate,
     currency: Currency,
     oldPrice: BigDecimal,
     estimatedNewPrice: BigDecimal,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -37,7 +37,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     val stubLogging = console.Console.live >>> ConsoleLogging.impl
 
     val expectedSubscriptionName = "Sub-0001"
-    val expectedStartDate = LocalDate.of(2020, 1, 1)
+    val startDate = LocalDate.of(2020, 1, 1)
     val expectedCurrency = "GBP"
     val expectedOldPrice = BigDecimal(11.11)
     val expectedEstimatedNewPrice = BigDecimal(22.22)
@@ -55,11 +55,11 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
               CohortItem(
                 subscriptionName = expectedSubscriptionName,
                 processingStage = filter,
-                expectedStartDate = Some(expectedStartDate),
+                startDate = Some(startDate),
                 currency = Some(expectedCurrency),
                 oldPrice = Some(expectedOldPrice),
                 estimatedNewPrice = Some(expectedEstimatedNewPrice)
-              ),
+              )
             )
           )
         }
@@ -109,7 +109,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     assertEquals(createdPriceRises(0).Buyer__c, s"Buyer-$expectedSubscriptionName")
     assertEquals(createdPriceRises(0).Current_Price_Today__c, expectedOldPrice)
     assertEquals(createdPriceRises(0).Guardian_Weekly_New_Price__c, expectedEstimatedNewPrice)
-    assertEquals(createdPriceRises(0).Price_Rise_Date__c, expectedStartDate)
+    assertEquals(createdPriceRises(0).Price_Rise_Date__c, startDate)
 
     assertEquals(updatedResultsWrittenToCohortTable.size, 1)
     assertEquals(

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -47,10 +47,12 @@ class CohortTableLiveTest extends munit.FunSuite {
 
         override def update[A, B](table: String, key: A, value: B)(
             implicit keySerializer: DynamoDBSerialiser[A],
-            valueSerializer: DynamoDBUpdateSerialiser[B]): IO[DynamoDBZIOError, Unit] = ???
+            valueSerializer: DynamoDBUpdateSerialiser[B]
+        ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String,
-                            value: A)(implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
+        override def put[A](table: String, value: A)(
+            implicit valueSerializer: DynamoDBSerialiser[A]
+        ): IO[DynamoDBZIOError, Unit] = ???
       }
     )
 
@@ -100,12 +102,12 @@ class CohortTableLiveTest extends munit.FunSuite {
     val stubDynamoDBZIO = ZLayer.succeed(
       new DynamoDBZIO.Service {
         override def query[A](query: QueryRequest)(
-          implicit deserializer: DynamoDBDeserialiser[A]
+            implicit deserializer: DynamoDBDeserialiser[A]
         ): ZStream[Any, DynamoDBZIOError, A] = ???
 
         override def update[A, B](table: String, key: A, value: B)(
-          implicit keySerializer: DynamoDBSerialiser[A],
-          valueSerializer: DynamoDBUpdateSerialiser[B]
+            implicit keySerializer: DynamoDBSerialiser[A],
+            valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = {
           tableUpdated = Some(table)
           receivedKey = Some(key.asInstanceOf[CohortTableKey])
@@ -115,24 +117,25 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def put[A](table: String,
-                            value: A)(implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
+        override def put[A](table: String, value: A)(
+            implicit valueSerializer: DynamoDBSerialiser[A]
+        ): IO[DynamoDBZIOError, Unit] = ???
       }
     )
 
     val expectedSubscriptionId = "subscription-id"
     val expectedProcessingStage = ReadyForEstimation
-    val expectedStartDate = LocalDate.now.plusDays(Random.nextInt(365))
+    val startDate = LocalDate.now.plusDays(Random.nextInt(365))
     val expectedCurrency = "GBP"
     val expectedOldPrice = Random.nextDouble()
     val expectedNewPrice = Random.nextDouble()
     val expectedEstimatedNewPrice = Random.nextDouble()
     val expectedBillingPeriod = "Monthly"
-    val expectedWhenEstimationDone =  Instant.ofEpochMilli(Random.nextLong())
+    val expectedWhenEstimationDone = Instant.ofEpochMilli(Random.nextLong())
     val expectedPriceRiseId = "price-rise-id"
-    val expectedSfShowEstimate =  Instant.ofEpochMilli(Random.nextLong())
+    val expectedSfShowEstimate = Instant.ofEpochMilli(Random.nextLong())
     val expectedNewSuscriptionId = "new-sub-id"
-    val expectedWhenAmmendmentDone =  Instant.ofEpochMilli(Random.nextLong())
+    val expectedWhenAmmendmentDone = Instant.ofEpochMilli(Random.nextLong())
 
     val cohortItem = CohortItem(
       subscriptionName = expectedSubscriptionId,
@@ -145,7 +148,7 @@ class CohortTableLiveTest extends munit.FunSuite {
       whenEstimationDone = Some(expectedWhenEstimationDone),
       salesforcePriceRiseId = Some(expectedPriceRiseId),
       whenSfShowEstimate = Some(expectedSfShowEstimate),
-      startDate = Some(expectedStartDate),
+      startDate = Some(startDate),
       newSubscriptionId = Some(expectedNewSuscriptionId),
       whenAmendmentDone = Some(expectedWhenAmmendmentDone)
     )
@@ -208,12 +211,16 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
     assertEquals(
       update.get("whenSfShowEstimate"),
-      new AttributeValueUpdate(new AttributeValue().withS(DateTimeFormatter.ISO_DATE_TIME.format(expectedSfShowEstimate.atZone(ZoneOffset.UTC))), AttributeAction.PUT),
+      new AttributeValueUpdate(
+        new AttributeValue()
+          .withS(DateTimeFormatter.ISO_DATE_TIME.format(expectedSfShowEstimate.atZone(ZoneOffset.UTC))),
+        AttributeAction.PUT
+      ),
       "whenSfShowEstimate"
     )
     assertEquals(
       update.get("startDate"),
-      new AttributeValueUpdate(new AttributeValue().withS(expectedStartDate.toString), AttributeAction.PUT),
+      new AttributeValueUpdate(new AttributeValue().withS(startDate.toString), AttributeAction.PUT),
       "startDate"
     )
     assertEquals(
@@ -223,7 +230,11 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
     assertEquals(
       update.get("whenAmendmentDone"),
-      new AttributeValueUpdate(new AttributeValue().withS(DateTimeFormatter.ISO_DATE_TIME.format(expectedWhenAmmendmentDone.atZone(ZoneOffset.UTC))), AttributeAction.PUT),
+      new AttributeValueUpdate(
+        new AttributeValue()
+          .withS(DateTimeFormatter.ISO_DATE_TIME.format(expectedWhenAmmendmentDone.atZone(ZoneOffset.UTC))),
+        AttributeAction.PUT
+      ),
       "whenAmendmentDone"
     )
   }
@@ -247,8 +258,9 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def put[A](table: String,
-                            value: A)(implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = ???
+        override def put[A](table: String, value: A)(
+            implicit valueSerializer: DynamoDBSerialiser[A]
+        ): IO[DynamoDBZIOError, Unit] = ???
       }
     )
 
@@ -257,7 +269,7 @@ class CohortTableLiveTest extends munit.FunSuite {
 
     val cohortItem = CohortItem(
       subscriptionName = expectedSubscriptionId,
-      processingStage = expectedProcessingStage,
+      processingStage = expectedProcessingStage
     )
 
     assertEquals(
@@ -280,7 +292,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
     assertEquals(update.get("currency"), None, "currency")
     assertEquals(update.get("oldPrice"), None, "oldPrice")
-    assertEquals(update.get("newPrice"),None, "newPrice")
+    assertEquals(update.get("newPrice"), None, "newPrice")
     assertEquals(update.get("estimatedNewPrice"), None, "estimatedNewPrice")
     assertEquals(update.get("billingPeriod"), None, "billingPeriod")
     assertEquals(update.get("salesforcePriceRiseId"), None, "salesforcePriceRiseId")
@@ -306,8 +318,9 @@ class CohortTableLiveTest extends munit.FunSuite {
             valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String,
-                            value: A)(implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] = {
+        override def put[A](table: String, value: A)(
+            implicit valueSerializer: DynamoDBSerialiser[A]
+        ): IO[DynamoDBZIOError, Unit] = {
           tableUpdated = Some(table)
           receivedInsert = Some(value.asInstanceOf[CohortItem])
           receivedSerialiser = Some(valueSerializer.asInstanceOf[DynamoDBSerialiser[CohortItem]])

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,6 @@ object Dependencies {
   lazy val upickle = "com.lihaoyi" %% "upickle" % "1.1.0"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"
-  lazy val munit = "org.scalameta" %% "munit" % "0.7.7"
+  lazy val munit = "org.scalameta" %% "munit" % "0.7.8"
   lazy val commonsCsv = "org.apache.commons" % "commons-csv" % "1.8"
 }


### PR DESCRIPTION
In #46 a random factor was introduced into the calculation of the earliest start date, which means that we can no longer recalculate the start date for the price migration during the Amendment process.  Instead, the start date is read from the value stored in the CohortItem.
There is no longer an expected start date; there's just a start date.

This means that if the billing period of the sub is adjusted somehow between estimation and amendment, the price migration amendment would fail.  But that seems very unlikely to happen.  It's questionable whether we actually need an estimation process at all.
