### PR TITLE
explicitly setting PriceRise__c.name field to subscription id

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -79,6 +79,7 @@ object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, 
         .orElseFail(SalesforcePriceRiseCreationFailure(s"$cohortItem does not have a startDate"))
     } yield
       SalesforcePriceRise(
+        subscription.Name,
         subscription.Buyer__c,
         currentPrice,
         newPrice,

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
@@ -3,6 +3,7 @@ package pricemigrationengine.model
 import java.time.LocalDate
 
 case class SalesforcePriceRise(
+  Name: String,
   Buyer__c: String,
   Current_Price_Today__c: BigDecimal,
   Guardian_Weekly_New_Price__c: BigDecimal,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -121,6 +121,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     )
 
     assertEquals(createdPriceRises.size, 1)
+    assertEquals(createdPriceRises(0).Name, expectedSubscriptionName)
     assertEquals(createdPriceRises(0).SF_Subscription__c, s"SubscritionId-$expectedSubscriptionName")
     assertEquals(createdPriceRises(0).Buyer__c, s"Buyer-$expectedSubscriptionName")
     assertEquals(createdPriceRises(0).Current_Price_Today__c, expectedOldPrice)


### PR DESCRIPTION
This PR adds populates the PriceRise__c.Name field with the subscription number.

This makes the name consistent with the name field label as it was being populated automatically with the PriceRise__c.Id field