### PR TITLE
reverting CohortTableLive to use the v2 index

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -205,7 +205,7 @@ object CohortTableLive {
                 .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
               queryRequest = new QueryRequest()
                 .withTableName(s"PriceMigrationEngine${stageConfig.stage}")
-                .withIndexName("ProcessingStageIndexV3")
+                .withIndexName("ProcessingStageIndexV2")
                 .withKeyConditionExpression(
                   "processingStage = :processingStage" + latestStartDateInclusive.fold("") { _ =>
                     " AND startDate <= :latestStartDateInclusive"

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -87,7 +87,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
 
     assertEquals(receivedRequest.get.getTableName, "PriceMigrationEngineDEV")
-    assertEquals(receivedRequest.get.getIndexName, "ProcessingStageIndexV3")
+    assertEquals(receivedRequest.get.getIndexName, "ProcessingStageIndexV2")
     assertEquals(receivedRequest.get.getKeyConditionExpression, "processingStage = :processingStage")
     assertEquals(
       receivedRequest.get.getExpressionAttributeValues,


### PR DESCRIPTION
Reverting the version of the ProcessingStageIndex used by the cohort table as the V3 version does not contain items without a startDate