### PR TITLE
Update status on estimation failure

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.handlers
 import java.time.{Instant, LocalDate}
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
-import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, ReadyForEstimation}
+import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, EstimationFailed, ReadyForEstimation}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
 import zio.console.Console
@@ -16,12 +16,24 @@ object EstimationHandler extends zio.App with RequestHandler[Unit, Unit] {
     for {
       newProductPricing <- Zuora.fetchProductCatalogue.map(ZuoraProductCatalogue.productPricingMap)
       cohortItems <- CohortTable.fetch(ReadyForEstimation, None)
-      _ <- cohortItems.foreach(writeEstimation(newProductPricing))
+      _ <- cohortItems.foreach(estimate(newProductPricing))
     } yield ()
 
-  private def writeEstimation(
+  private def estimate(
       newProductPricing: ZuoraPricingData
   )(item: CohortItem): ZIO[Logging with AmendmentConfiguration with CohortTable with Zuora with Random, Failure, Unit] =
+    doEstimation(newProductPricing, item).foldM(
+      failure = {
+        case _: AmendmentDataFailure => CohortTable.update(CohortItem(item.subscriptionName, EstimationFailed))
+        case e                       => ZIO.fail(e)
+      },
+      success = CohortTable.update
+    )
+
+  private def doEstimation(
+      newProductPricing: ZuoraPricingData,
+      item: CohortItem
+  ): ZIO[Logging with AmendmentConfiguration with CohortTable with Zuora with Random, Failure, CohortItem] =
     for {
       subscription <- Zuora.fetchSubscription(item.subscriptionName)
       invoicePreview <- Zuora.fetchInvoicePreview(subscription.accountId)
@@ -33,20 +45,16 @@ object EstimationHandler extends zio.App with RequestHandler[Unit, Unit] {
             Logging.error(s"Failed to estimate amendment data for subscription ${subscription.subscriptionNumber}: $e"),
           result => Logging.info(s"Estimated result: $result")
         )
-      _ <- CohortTable
-        .update(
-          CohortItem(
-            result.subscriptionName,
-            processingStage = EstimationComplete,
-            oldPrice = Some(result.oldPrice),
-            estimatedNewPrice = Some(result.estimatedNewPrice),
-            currency = Some(result.currency),
-            startDate = Some(result.startDate),
-            billingPeriod = Some(result.billingPeriod),
-            whenEstimationDone = Some(Instant.now())
-          )
-        )
-    } yield ()
+    } yield CohortItem(
+      result.subscriptionName,
+      processingStage = EstimationComplete,
+      oldPrice = Some(result.oldPrice),
+      estimatedNewPrice = Some(result.estimatedNewPrice),
+      currency = Some(result.currency),
+      startDate = Some(result.startDate),
+      billingPeriod = Some(result.billingPeriod),
+      whenEstimationDone = Some(Instant.now())
+    )
 
   /*
    * Earliest start date spread out over 3 months.

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -4,7 +4,10 @@ sealed trait CohortTableFilter { val value: String }
 
 object CohortTableFilter {
   case object ReadyForEstimation extends CohortTableFilter { override val value: String = "ReadyForEstimation" }
+
+  case object EstimationFailed extends CohortTableFilter { override val value: String = "EstimationFailed" }
   case object EstimationComplete extends CohortTableFilter { override val value: String = "EstimationComplete" }
+
   case object SalesforcePriceRiceCreationComplete extends CohortTableFilter {
     override val value: String = "SalesforcePriceRiseCreationComplete"
   }
@@ -17,6 +20,10 @@ object CohortTableFilter {
   case object Cancelled extends CohortTableFilter { override val value: String = "Cancelled" }
 
   val all = Set(
-    ReadyForEstimation, EstimationComplete, SalesforcePriceRiceCreationComplete, AmendmentComplete, Cancelled
+    ReadyForEstimation,
+    EstimationComplete,
+    SalesforcePriceRiceCreationComplete,
+    AmendmentComplete,
+    Cancelled
   )
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -21,6 +21,7 @@ object CohortTableFilter {
 
   val all = Set(
     ReadyForEstimation,
+    EstimationFailed,
     EstimationComplete,
     SalesforcePriceRiceCreationComplete,
     AmendmentComplete,


### PR DESCRIPTION
Instead of stopping.

This will allow the lambda to continue on its own overnight once it's part of a state machine.
There don't seem to be many failures at the moment so this shouldn't get out of control.

Any Zuora failures will still stop the process.
