### PR TITLE
Extend invoice preview target date

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
@@ -10,8 +10,7 @@ case class AmendmentConfig(
 case class ZuoraConfig(
     apiHost: String,
     clientId: String,
-    clientSecret: String,
-    yearInFuture: LocalDate = LocalDate.now.plusYears(1)
+    clientSecret: String
 )
 
 case class DynamoDBConfig(endpoint: Option[DynamoDBEndpointConfig])

--- a/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
@@ -1,5 +1,7 @@
 package pricemigrationengine.services
 
+import java.time.LocalDate
+
 import pricemigrationengine.model._
 import zio.ZIO
 
@@ -9,7 +11,7 @@ object Zuora {
 
     def fetchSubscription(subscriptionNumber: String): ZIO[Any, ZuoraFetchFailure, ZuoraSubscription]
 
-    def fetchInvoicePreview(accountId: String): ZIO[Any, ZuoraFetchFailure, ZuoraInvoiceList]
+    def fetchInvoicePreview(accountId: String, targetDate: LocalDate): ZIO[Any, ZuoraFetchFailure, ZuoraInvoiceList]
 
     val fetchProductCatalogue: ZIO[Any, ZuoraFetchFailure, ZuoraProductCatalogue]
 
@@ -22,8 +24,8 @@ object Zuora {
   def fetchSubscription(subscriptionNumber: String): ZIO[Zuora, Failure, ZuoraSubscription] =
     ZIO.accessM(_.get.fetchSubscription(subscriptionNumber))
 
-  def fetchInvoicePreview(accountId: String): ZIO[Zuora, ZuoraFetchFailure, ZuoraInvoiceList] =
-    ZIO.accessM(_.get.fetchInvoicePreview(accountId))
+  def fetchInvoicePreview(accountId: String, targetDate: LocalDate): ZIO[Zuora, ZuoraFetchFailure, ZuoraInvoiceList] =
+    ZIO.accessM(_.get.fetchInvoicePreview(accountId, targetDate))
 
   val fetchProductCatalogue: ZIO[Zuora, ZuoraFetchFailure, ZuoraProductCatalogue] =
     ZIO.accessM(_.get.fetchProductCatalogue)

--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -124,13 +124,16 @@ object ZuoraLive {
               )
 
           // See https://www.zuora.com/developer/api-reference/#operation/POST_BillingPreviewRun
-          def fetchInvoicePreview(accountId: String): ZIO[Any, ZuoraFetchFailure, ZuoraInvoiceList] =
+          def fetchInvoicePreview(
+              accountId: String,
+              targetDate: LocalDate
+          ): ZIO[Any, ZuoraFetchFailure, ZuoraInvoiceList] =
             post[ZuoraInvoiceList](
               path = "operations/billing-preview",
               body = write(
                 InvoicePreviewRequest(
                   accountId,
-                  targetDate = config.yearInFuture,
+                  targetDate,
                   assumeRenewal = "Autorenew",
                   chargeTypeToExclude = "OneTime"
                 )


### PR DESCRIPTION
So that next invoice of an annual sub is guaranteed to be included in preview.

