### PR TITLE
Mark cancelled sub and don't process it

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -74,7 +74,7 @@ object AmendmentHandler extends App with RequestHandler[Unit, Unit] {
   private def fetchSubscription(item: CohortItem): ZIO[Zuora, Failure, ZuoraSubscription] =
     Zuora
       .fetchSubscription(item.subscriptionName)
-      .filterOrFail(_.status == "Active")(CancelledSubscriptionFailure(item.subscriptionName))
+      .filterOrFail(_.status != "Cancelled")(CancelledSubscriptionFailure(item.subscriptionName))
 
   private def env(
       loggingLayer: ZLayer[Any, Nothing, Logging]


### PR DESCRIPTION
If a sub is identified as 'cancelled' during the estimation step, there's no point in processing it any further.  Instead the sub is marked as cancelled in the cohort table and ignored by future steps.

