### PR TITLE
Create subscription update with charge overrides

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -244,7 +244,7 @@ object AmendmentData {
     * In these cases, the price has to be multiplied
     * by the number of months in the subscription billing period.
     */
-  private def adjustedForBillingPeriod(
+  private[model] def adjustedForBillingPeriod(
       price: BigDecimal,
       subscriptionBillingPeriod: Option[String],
       productBillingPeriod: Option[String]

--- a/lambda/src/main/scala/pricemigrationengine/model/Either.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Either.scala
@@ -1,0 +1,15 @@
+package pricemigrationengine.model
+
+object Either {
+
+  /**
+    * Converts a Seq of Eithers to either a Left
+    * containing the first Left value of the Seq if any of the Seq has a Left value,
+    * or else to a Right that contains the Seq of all the Right values in the original Seq.
+    */
+  def fromSeq[E, A](eithers: Seq[Either[E, A]]): Either[E, Seq[A]] =
+    eithers
+      .collectFirst { case Left(e) => e }
+      .map(Left(_))
+      .getOrElse(Right(eithers.collect { case Right(a) => a }))
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/Either.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Either.scala
@@ -7,9 +7,12 @@ object Either {
     * containing the first Left value of the Seq if any of the Seq has a Left value,
     * or else to a Right that contains the Seq of all the Right values in the original Seq.
     */
-  def fromSeq[E, A](eithers: Seq[Either[E, A]]): Either[E, Seq[A]] =
-    eithers
-      .collectFirst { case Left(e) => e }
-      .map(Left(_))
-      .getOrElse(Right(eithers.collect { case Right(a) => a }))
+  // to keep the lambda package small we are not importing cats
+  implicit final class TraverseOps[E, A](eithers: Seq[Either[E, A]]) {
+    def sequence: Either[E, Seq[A]] =
+      eithers
+        .collectFirst { case Left(e) => e }
+        .map(Left(_))
+        .getOrElse(Right(eithers.collect { case Right(a) => a }))
+  }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
@@ -39,13 +39,16 @@ object ZuoraSubscriptionUpdate {
 
     if (ratePlans.isEmpty)
       Left(AmendmentDataFailure("No rate plans to update"))
-    else
-      ratePlans.map(AddZuoraRatePlan.fromRatePlan(pricingData, date)).sequence.map { adds =>
+    else if (ratePlans.size > 1)
+      Left(AmendmentDataFailure(s"Multiple rate plans to update: ${ratePlans.map(_.id)}"))
+    else {
+      ratePlans.map(AddZuoraRatePlan.fromRatePlan(pricingData, date)).sequence.map { add =>
         ZuoraSubscriptionUpdate(
-          add = adds,
+          add,
           remove = ratePlans.map(ratePlan => RemoveZuoraRatePlan(ratePlan.id, date))
         )
       }
+    }
   }
 }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
@@ -40,13 +40,12 @@ object ZuoraSubscriptionUpdate {
     if (ratePlans.isEmpty)
       Left(AmendmentDataFailure("No rate plans to update"))
     else
-      for {
-        adds <- ratePlans.map(AddZuoraRatePlan.fromRatePlan(pricingData, date)).sequence
-      } yield
+      ratePlans.map(AddZuoraRatePlan.fromRatePlan(pricingData, date)).sequence.map { adds =>
         ZuoraSubscriptionUpdate(
           add = adds,
           remove = ratePlans.map(ratePlan => RemoveZuoraRatePlan(ratePlan.id, date))
         )
+      }
   }
 }
 

--- a/lambda/src/test/resources/AnnualVoucher/Subscription.json
+++ b/lambda/src/test/resources/AnnualVoucher/Subscription.json
@@ -59,7 +59,7 @@
   "CancellationReason__c": null,
   "ratePlans": [
     {
-      "id": "id",
+      "id": "rp571",
       "productId": "2c92a0fc55a0dc530155dfa5b8dd56c0",
       "productName": "Newspaper Voucher",
       "productSku": "ABC-00000014",

--- a/lambda/src/test/resources/QuarterlyGW/Subscription.json
+++ b/lambda/src/test/resources/QuarterlyGW/Subscription.json
@@ -129,7 +129,7 @@
       "subscriptionProductFeatures": []
     },
     {
-      "id": "id",
+      "id": "rp123",
       "lastChangeType": "Add",
       "productId": "2c92a0ff6619bf8901661aa3247c4b1d",
       "productName": "Guardian Weekly - Domestic",

--- a/lambda/src/test/resources/QuarterlyVoucher/Subscription.json
+++ b/lambda/src/test/resources/QuarterlyVoucher/Subscription.json
@@ -59,7 +59,7 @@
   "CancellationReason__c": null,
   "ratePlans": [
     {
-      "id": "id",
+      "id": "rp456",
       "productId": "2c92a0fc55a0dc530155dfa5b8dd56c0",
       "productName": "Newspaper Voucher",
       "productSku": "ABC-00000014",

--- a/lambda/src/test/resources/SemiAnnualVoucher/Subscription.json
+++ b/lambda/src/test/resources/SemiAnnualVoucher/Subscription.json
@@ -59,7 +59,7 @@
   "CancellationReason__c": null,
   "ratePlans": [
     {
-      "id": "id",
+      "id": "rp42",
       "productId": "2c92a0fc55a0dc530155dfa5b8dd56c0",
       "productName": "Newspaper Voucher",
       "productSku": "ABC-00000014",

--- a/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
@@ -3,6 +3,8 @@ package pricemigrationengine.model
 import java.time.LocalDate
 
 import pricemigrationengine.Fixtures
+import pricemigrationengine.Fixtures.productCatalogueFromJson
+import pricemigrationengine.model.ZuoraProductCatalogue.productPricingMap
 
 class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
 
@@ -10,6 +12,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
     val fixtureSet = "Monthly"
     val date = LocalDate.of(2020, 5, 28)
     val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+      pricingData = productPricingMap(productCatalogueFromJson(s"$fixtureSet/Catalogue.json")),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date
@@ -33,6 +36,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
     val fixtureSet = "MonthlyDiscounted"
     val date = LocalDate.of(2020, 6, 15)
     val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+      pricingData = productPricingMap(productCatalogueFromJson(s"$fixtureSet/Catalogue.json")),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date
@@ -46,6 +50,167 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
           ),
           remove = List(
             RemoveZuoraRatePlan(ratePlanId = "rp2", contractEffectiveDate = date)
+          )
+        )
+      )
+    )
+  }
+
+  test("updateOfRatePlansToCurrent: updates correct rate plans on a quarterly voucher sub") {
+    val fixtureSet = "QuarterlyVoucher"
+    val date = LocalDate.of(2020, 7, 5)
+    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+      pricingData = productPricingMap(productCatalogueFromJson(s"$fixtureSet/Catalogue.json")),
+      subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
+      invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
+      date
+    )
+    assertEquals(
+      update,
+      Right(
+        ZuoraSubscriptionUpdate(
+          add = List(
+            AddZuoraRatePlan(
+              productRatePlanId = "2c92a0ff56fe33f00157040f9a537f4b",
+              contractEffectiveDate = date,
+              chargeOverrides = Seq(
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0ff56fe33f00157041713362b51",
+                  billingPeriod = "Quarter",
+                  price = 32.97
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fc56fe26ba01570417df6d1b54",
+                  billingPeriod = "Quarter",
+                  price = 33.00
+                )
+              )
+            )
+          ),
+          remove = List(
+            RemoveZuoraRatePlan(ratePlanId = "rp456", contractEffectiveDate = date)
+          )
+        )
+      )
+    )
+  }
+
+  test("updateOfRatePlansToCurrent: updates correct rate plans on a quarterly GW sub") {
+    val fixtureSet = "QuarterlyGW"
+    val date = LocalDate.of(2020, 7, 28)
+    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+      pricingData = productPricingMap(productCatalogueFromJson(s"$fixtureSet/Catalogue.json")),
+      subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
+      invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
+      date
+    )
+    assertEquals(
+      update,
+      Right(
+        ZuoraSubscriptionUpdate(
+          add = List(
+            AddZuoraRatePlan(productRatePlanId = "2c92a0fe6619b4b301661aa494392ee2", contractEffectiveDate = date)
+          ),
+          remove = List(
+            RemoveZuoraRatePlan(ratePlanId = "rp123", contractEffectiveDate = date)
+          )
+        )
+      )
+    )
+  }
+
+  test("updateOfRatePlansToCurrent: updates correct rate plans on a semi-annual voucher sub") {
+    val fixtureSet = "SemiAnnualVoucher"
+    val date = LocalDate.of(2020, 7, 13)
+    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+      pricingData = productPricingMap(productCatalogueFromJson(s"$fixtureSet/Catalogue.json")),
+      subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
+      invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
+      date
+    )
+    assertEquals(
+      update,
+      Right(
+        ZuoraSubscriptionUpdate(
+          add = List(
+            AddZuoraRatePlan(
+              productRatePlanId = "2c92a0fd56fe270b0157040e42e536ef",
+              contractEffectiveDate = date,
+              chargeOverrides = Seq(
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fd56fe26b601570431210a310e",
+                  billingPeriod = "Semi_Annual",
+                  price = 42.00
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fd56fe270b015709be701e78b6",
+                  billingPeriod = "Semi_Annual",
+                  price = 42.00
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0ff56fe33f5015709bf7fdd6a4d",
+                  billingPeriod = "Semi_Annual",
+                  price = 59.94
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fd56fe270b015709bd2d3d75d7",
+                  billingPeriod = "Semi_Annual",
+                  price = 42.00
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fc56fe26ba015709bee15d653a",
+                  billingPeriod = "Semi_Annual",
+                  price = 42.00
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fe56fe33ff015709bdb6153cd4",
+                  billingPeriod = "Semi_Annual",
+                  price = 42.00
+                )
+              )
+            )
+          ),
+          remove = List(
+            RemoveZuoraRatePlan(ratePlanId = "rp42", contractEffectiveDate = date)
+          )
+        )
+      )
+    )
+  }
+
+  test("updateOfRatePlansToCurrent: updates correct rate plans on an annual voucher sub") {
+    val fixtureSet = "AnnualVoucher"
+    val date = LocalDate.of(2020, 12, 7)
+    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+      pricingData = productPricingMap(productCatalogueFromJson(s"$fixtureSet/Catalogue.json")),
+      subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
+      invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
+      date
+    )
+    assertEquals(
+      update,
+      Right(
+        ZuoraSubscriptionUpdate(
+          add = List(
+            AddZuoraRatePlan(
+              productRatePlanId = "2c92a0ff56fe33f00157040f9a537f4b",
+              contractEffectiveDate = date,
+              chargeOverrides = Seq(
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0ff56fe33f00157041713362b51",
+                  billingPeriod = "Annual",
+                  price = 131.88
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fc56fe26ba01570417df6d1b54",
+                  billingPeriod = "Annual",
+                  price = 132.00
+                )
+              )
+            )
+          ),
+          remove = List(
+            RemoveZuoraRatePlan(ratePlanId = "rp571", contractEffectiveDate = date)
           )
         )
       )


### PR DESCRIPTION
When the billing period of a rate plan charge is different to the billing period of its corresponding product rate plan charge, we have add a charge override to the subscription update to reflect the different price over a different period.
In most cases this won't be relevant, but with some products there's a base monthly price and for longer periods the price is just a multiple of the base price.

So, for matching billing periods, update looks like:
```
{
  "add": [
    {
      "productRatePlanId": "prp1",
      "contractEffectiveDate": "2020-06-01"
    }
  ],
  "remove": [
    {
      "ratePlanId": "rp1",
      "contractEffectiveDate": "2020-06-01"
    }
  ]
}
```

And for different billing periods:
```
{
  "add": [
    {
      "productRatePlanId": "prp1",
      "contractEffectiveDate": "2020-06-01",
      "chargeOverrides": [
        {
          "productRatePlanChargeId": "prpc1",
          "billingPeriod": "Quarter",
          "price": 1.23
        },
        {
          "productRatePlanChargeId": "prpc2",
          "billingPeriod": "Quarter",
          "price": 2.34
        }
      ]
    }
  ],
  "remove": [
    {
      "ratePlanId": "rp1",
      "contractEffectiveDate": "2020-06-01"
    }
  ]
}
```
