### PR TITLE
Cloudform initial state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,7 @@
 This repo consists of a set of lambdas and DynamoDB table templates that are designed to interact together in a state 
 machine.  
 
-Documentation for the lambda code is in the [lambda readme doc](lambda/README.md).
+See readme for:  
+* [State machine](stateMachine/README.md)
+* [Lambdas](lambda/README.md)
+* [Data stores](dynamoDb/README.md)

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -385,3 +385,13 @@ Resources:
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineNotificationEmailLambdaRole
+
+Outputs:
+  PriceMigrationEngineEstimationLambdaOutput:
+    Value: !GetAtt PriceMigrationEngineEstimationLambda.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-EstimatingLambda"
+  PriceMigrationEngineSalesforcePriceCreationLambdaOutput:
+    Value: !GetAtt PriceMigrationEngineSalesforcePriceCreationLambda.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-CreatingSalesforceRecordsLambda"

--- a/stateMachine/README.md
+++ b/stateMachine/README.md
@@ -1,0 +1,7 @@
+# State machine
+
+This sub-project combines all the [lambdas](../lambda/README.md) into an orchestration engine.
+
+See:
+* https://docs.aws.amazon.com/step-functions/latest/dg/concepts-error-handling.html#error-handling-examples
+* https://docs.aws.amazon.com/step-functions/latest/dg/limits.html

--- a/stateMachine/cfn.yaml
+++ b/stateMachine/cfn.yaml
@@ -1,0 +1,148 @@
+Description: Price-migration orchestration engine.
+
+Parameters:
+
+  Stage:
+    Type: String
+    AllowedValues:
+      - PROD
+      - CODE
+      - DEV
+    Default: DEV
+
+  ResourceNamePrefix:
+    Type: String
+    Default: price-migration-engine
+
+Resources:
+
+  CohortStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/states/${ResourceNamePrefix}-cohort-steps-${Stage}
+      RetentionInDays: 180
+
+  CohortStateMachineExecutionRole:
+    Type: AWS::IAM::Role
+    DependsOn:
+      - CohortStateMachineLogGroup
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: !Sub states.${AWS::Region}.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaInvokePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-EstimatingLambda
+                  - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-CreatingSalesforceRecordsLambda
+        - PolicyName: LoggingPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:ListLogDeliveries
+                  - logs:GetLogDelivery
+                  - logs:CreateLogDelivery
+                  - logs:UpdateLogDelivery
+                  - logs:DescribeLogGroups
+                Resource:
+                  - !GetAtt CohortStateMachineLogGroup.Arn
+
+  CohortStateMachine:
+    Type: AWS::StepFunctions::StateMachine
+    DependsOn:
+      - CohortStateMachineLogGroup
+      - CohortStateMachineExecutionRole
+    Properties:
+      StateMachineName:
+        !Sub ${ResourceNamePrefix}-cohort-steps-${Stage}
+      RoleArn: !GetAtt CohortStateMachineExecutionRole.Arn
+      LoggingConfiguration:
+        Level: ALL
+        IncludeExecutionData: TRUE
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt CohortStateMachineLogGroup.Arn
+      DefinitionString:
+        !Sub
+        - |
+          {
+            "Comment": "Price-migration orchestration engine.",
+            "StartAt": "WritingEstimatesToSalesforce",
+            "States": {
+              "WritingEstimatesToSalesforce": {
+                "Type": "Parallel",
+                "End": true,
+                "Branches": [
+                  {
+                    "StartAt": "Estimating",
+                    "States": {
+                      "Estimating": {
+                        "Type": "Task",
+                        "Resource": "${EstimatingLambdaArn}",
+                        "Retry": [
+                          {
+                            "ErrorEquals": [
+                              "Lambda.Unknown"
+                            ],
+                            "IntervalSeconds": 10,
+                            "MaxAttempts": 25000,
+                            "BackoffRate": 1.0
+                          },
+                          {
+                            "ErrorEquals": [
+                              "States.ALL"
+                            ],
+                            "IntervalSeconds": 30,
+                            "MaxAttempts": 25000,
+                            "BackoffRate": 2.0
+                          }
+                        ],
+                        "End": true
+                      }
+                    }
+                  },
+                  {
+                    "StartAt": "CreatingSalesforceRecords",
+                    "States": {
+                      "CreatingSalesforceRecords": {
+                        "Type": "Task",
+                        "Resource": "${CreatingSalesforceRecordsLambdaArn}",
+                        "Retry": [
+                          {
+                            "ErrorEquals": [
+                              "Lambda.Unknown"
+                            ],
+                            "IntervalSeconds": 10,
+                            "MaxAttempts": 25000,
+                            "BackoffRate": 1.0
+                          },
+                          {
+                            "ErrorEquals": [
+                              "States.ALL"
+                            ],
+                            "IntervalSeconds": 30,
+                            "MaxAttempts": 25000,
+                            "BackoffRate": 2.0
+                          }
+                        ],
+                        "End": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        - EstimatingLambdaArn:
+            Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-EstimatingLambda
+          CreatingSalesforceRecordsLambdaArn:
+            Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-CreatingSalesforceRecordsLambda


### PR DESCRIPTION
This change includes the [cloudformation template](https://github.com/guardian/price-migration-engine/blob/51d5feefc2780520450ad16401de9510aaa2708d/stateMachine/cfn.yaml) for a state machine that's already been used in production:

![stepfunctions_graph](https://user-images.githubusercontent.com/1722550/84646939-af0ad080-aefa-11ea-8749-41dc2c063051.png)

Eventually this will hold all the steps involved in a price migration.

When a lambda times out, it returns a [Lambda.Unknown](https://github.com/guardian/price-migration-engine/compare/kc-state-machine?expand=1#diff-bd341ba6709387aedaa0b70e5607e942R94) error.  So we take this error as a signal that there is more work to do and re-run the lambda.  Once it completes within the time available to the lambda, the step is considered to be successful.
