### PR TITLE
Service definitions and handler for cohort specifications

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
@@ -1,0 +1,30 @@
+package pricemigrationengine.handlers
+
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import pricemigrationengine.model.CohortSpec
+import pricemigrationengine.services.{CohortSpecTable, CohortStateMachine}
+import zio.{ExitCode, Runtime, ULayer, ZEnv, ZIO}
+
+/**
+  * Executes price migration for active cohorts.
+  */
+class MigrationHandler extends zio.App with RequestHandler[Unit, Unit] {
+
+  private val migrateActiveCohorts =
+    for {
+      cohortSpecStream <- CohortSpecTable.fetchAll
+      _ <- cohortSpecStream
+        .filterM(cohort => Time.today.map(CohortSpec.isActive(cohort)))
+        .foreach(cohort => CohortStateMachine.startExecution(cohort))
+    } yield ()
+
+  private val runtime = Runtime.default
+
+  private val env: ULayer[CohortSpecTable with CohortStateMachine] = ???
+
+  def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
+    migrateActiveCohorts.provideCustomLayer(env).exitCode
+
+  def handleRequest(unused: Unit, context: Context): Unit =
+    runtime.unsafeRun(migrateActiveCohorts.provideCustomLayer(env))
+}

--- a/lambda/src/main/scala/pricemigrationengine/handlers/Time.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/Time.scala
@@ -1,0 +1,17 @@
+package pricemigrationengine.handlers
+
+import java.time.LocalDate
+
+import pricemigrationengine.model.TimeFailure
+import zio.clock.Clock
+import zio.{ZIO, clock}
+
+object Time {
+
+  val today: ZIO[Clock, TimeFailure, LocalDate] =
+    clock.currentDateTime
+      .bimap(
+        e => TimeFailure(s"Extremely unlikely failure of time: $e"),
+        _.toLocalDate
+      )
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -21,5 +21,5 @@ case class CohortSpec(
 object CohortSpec {
 
   def isActive(spec: CohortSpec)(date: LocalDate): Boolean =
-    !(spec.importStartDate.isAfter(date) || spec.migrationCompleteDate.exists(_.isBefore(date)))
+    !spec.importStartDate.isAfter(date) && spec.migrationCompleteDate.forall(_.isAfter(date))
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -1,0 +1,25 @@
+package pricemigrationengine.model
+
+import java.time.LocalDate
+
+/**
+  * Specification of a cohort.
+  *
+  * @param cohortName Name that uniquely identifies a cohort, eg. "Vouchers 2020"
+  * @param earliestPriceMigrationStartDate Earliest date on which any sub in the cohort can have price migrated.
+  *                                        The actual date for any sub will depend on its billing dates.
+  * @param importStartDate Date on which to start importing data from the source S3 bucket.
+  * @param migrationCompleteDate Date on which the final step in the price migration was complete for every sub in the cohort.
+  */
+case class CohortSpec(
+    cohortName: String,
+    earliestPriceMigrationStartDate: LocalDate,
+    importStartDate: LocalDate,
+    migrationCompleteDate: Option[LocalDate]
+)
+
+object CohortSpec {
+
+  def isActive(spec: CohortSpec)(date: LocalDate): Boolean =
+    !(spec.importStartDate.isAfter(date) || spec.migrationCompleteDate.exists(_.isBefore(date)))
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -6,6 +6,13 @@ sealed trait Failure {
 
 case class ConfigurationFailure(reason: String) extends Failure
 
+case class TimeFailure(reason: String) extends Failure
+
+case class CohortStateMachineFailure(reason: String) extends Failure
+
+case class CohortSpecFetchFailure(reason: String) extends Failure
+case class CohortSpecUpdateFailure(reason: String) extends Failure
+
 case class CohortFetchFailure(reason: String) extends Failure
 case class CohortUpdateFailure(reason: String) extends Failure
 

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortSpecTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortSpecTable.scala
@@ -1,0 +1,22 @@
+package pricemigrationengine.services
+
+import pricemigrationengine.model.{CohortSpec, CohortSpecFetchFailure, CohortSpecUpdateFailure}
+import zio.stream.ZStream
+import zio.{IO, ZIO}
+
+/**
+  * For accessing the specifications of each cohort.
+  */
+object CohortSpecTable {
+
+  trait Service {
+    val fetchAll: IO[CohortSpecFetchFailure, ZStream[Any, CohortSpecFetchFailure, CohortSpec]]
+    def update(spec: CohortSpec): ZIO[Any, CohortSpecUpdateFailure, Unit]
+  }
+
+  val fetchAll: ZIO[CohortSpecTable, CohortSpecFetchFailure, ZStream[Any, CohortSpecFetchFailure, CohortSpec]] =
+    ZIO.accessM(_.get.fetchAll)
+
+  def update(spec: CohortSpec): ZIO[CohortSpecTable, CohortSpecUpdateFailure, Unit] =
+    ZIO.accessM(_.get.update(spec))
+}

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachine.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachine.scala
@@ -1,0 +1,17 @@
+package pricemigrationengine.services
+
+import pricemigrationengine.model.{CohortSpec, CohortStateMachineFailure}
+import zio.ZIO
+
+/**
+  * Kicks off the migration process for a particular cohort.
+  */
+object CohortStateMachine {
+
+  trait Service {
+    def startExecution(spec: CohortSpec): ZIO[Any, CohortStateMachineFailure, Unit]
+  }
+
+  def startExecution(spec: CohortSpec): ZIO[CohortStateMachine, CohortStateMachineFailure, Unit] =
+    ZIO.accessM(_.get.startExecution(spec))
+}

--- a/lambda/src/main/scala/pricemigrationengine/services/package.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/package.scala
@@ -10,6 +10,8 @@ package object services {
   type CohortTableConfiguration = Has[CohortTableConfiguration.Service]
   type SalesforceConfiguration = Has[SalesforceConfiguration.Service]
   type StageConfiguration = Has[StageConfiguration.Service]
+  type CohortStateMachine = Has[CohortStateMachine.Service]
+  type CohortSpecTable = Has[CohortSpecTable.Service]
   type CohortTable = Has[CohortTable.Service]
   type Zuora = Has[Zuora.Service]
   type Logging = Has[Logging.Service]

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -1,0 +1,42 @@
+package pricemigrationengine.model
+
+import java.time.LocalDate
+
+class CohortSpecTest extends munit.FunSuite {
+
+  private val importStartDate = LocalDate.of(2020, 5, 1)
+  private val migrationCompleteDate = LocalDate.of(2020, 6, 18)
+
+  private def isActive(onDay: LocalDate, migrationComplete: Option[LocalDate] = Some(migrationCompleteDate)) =
+    CohortSpec.isActive(
+      CohortSpec(
+        "name",
+        LocalDate.of(2021, 1, 1),
+        importStartDate,
+        migrationComplete
+      ))(onDay)
+
+  test("isActive: should be false when given date is before import start date") {
+    assertEquals(isActive(importStartDate.minusDays(3)), false)
+  }
+
+  test("isActive: should be true when given date is import start date") {
+    assertEquals(isActive(importStartDate), true)
+  }
+
+  test("isActive: should be true when given date is between import start date and migration complete date") {
+    assertEquals(isActive(importStartDate.plusDays(3)), true)
+  }
+
+  test("isActive: should be false when given date is on migration complete date") {
+    assertEquals(isActive(migrationCompleteDate), false)
+  }
+
+  test("isActive: should be false when given date is after migration complete date") {
+    assertEquals(isActive(migrationCompleteDate.plusDays(3)), false)
+  }
+
+  test("isActive: should be true when given date is after import start date and migration isn't complete") {
+    assertEquals(isActive(importStartDate.plusDays(3), migrationComplete = None), true)
+  }
+}


### PR DESCRIPTION
This change defines two new services:
* [CohortStateMachine](https://github.com/guardian/price-migration-engine/blob/0777d438e8ecee2627df66414baffa97959baa02/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachine.scala) for kicking off the migration process for a particular cohort
* [CohortSpecTable](https://github.com/guardian/price-migration-engine/blob/0777d438e8ecee2627df66414baffa97959baa02/lambda/src/main/scala/pricemigrationengine/services/CohortSpecTable.scala) for accessing the specifications of each cohort
These need implementing in another PR.

There's also the [handler](https://github.com/guardian/price-migration-engine/blob/0777d438e8ecee2627df66414baffa97959baa02/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala) that makes use of them to find active cohorts and process them.
I envisage this handler being run on a daily schedule. 
The handler will tip the cohort spec into the top of the state machine so that each step can use it to constrain their behaviour.
