### PR TITLE
extending notification letter lead time to 37 days

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationEmailHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationEmailHandler.scala
@@ -14,7 +14,7 @@ object NotificationEmailHandler {
   //https://github.com/guardian/membership-workflow/blob/master/conf/PROD.public.conf#L39
   val BrazeCampaignName = "SV_VO_Pricerise_Q22020"
 
-  private val NotificationEmailLeadTimeDays = 30
+  private val NotificationEmailLeadTimeDays = 37
 
   val main: ZIO[Logging with CohortTable with SalesforceClient with Clock with EmailSender, Failure, Unit] = {
     for {

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationEmailHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationEmailHandlerTest.scala
@@ -50,7 +50,7 @@ class NotificationEmailHandlerTest extends munit.FunSuite {
             beforeDateInclusive,
             Some(
               LocalDate
-                .from(StubClock.expectedCurrentTime.plus(30, ChronoUnit.DAYS).atOffset(ZoneOffset.UTC))
+                .from(StubClock.expectedCurrentTime.plus(37, ChronoUnit.DAYS).atOffset(ZoneOffset.UTC))
             )
           )
           IO.succeed(ZStream(cohortItem))


### PR DESCRIPTION
Extending notification letter lead time to 37 days. 

This includes the statutory 30 days to notify customers of the price rise + 7 days for postage and packing.