### PR TITLE
Add ad-hoc status query

### DIFF
--- a/dynamoDb/scripts/cohortItemsStatusUpdate.bash
+++ b/dynamoDb/scripts/cohortItemsStatusUpdate.bash
@@ -16,7 +16,7 @@ function update() {
     --key "{\"subscriptionNumber\": {\"S\": \"$3\"}}" \
     --update-expression "SET #P = :p" \
     --expression-attribute-names "{\"#P\": \"processingStage\"}" \
-    --expression-attribute-values "{\":p\": {\"S\": \"$2\"}}" #\
+    --expression-attribute-values "{\":p\": {\"S\": \"$2\"}}" \
     --return-values UPDATED_OLD
 }
 

--- a/dynamoDb/scripts/cohortStateQuery.bash
+++ b/dynamoDb/scripts/cohortStateQuery.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# =====================================================================
+# Gives a line-separated list of subscription numbers
+# that are in a given processing stage
+# and have a start date up to and including a given threshold.
+#
+# Arg 1: Deployment stage: DEV, CODE or PROD
+# Arg 2: processingStage, eg. EstimationComplete
+# Arg 3: Inclusive maximum date
+# =====================================================================
+
+# Arg 1: Deployment stage: DEV, CODE or PROD
+# Arg 2: processingStage
+# Arg 3: Inclusive maximum date
+function query() {
+  aws dynamodb query --region eu-west-1 --profile membership \
+    --table-name "PriceMigrationEngine$1" \
+    --index-name "ProcessingStageIndexV3" \
+    --projection-expression "subscriptionNumber" \
+    --key-condition-expression "processingStage = :s AND startDate <= :d " \
+    --expression-attribute-values "{\":s\": {\"S\": \"$2\"}, \":d\": {\"S\": \"$3\"}}" \
+    --page-size "100000"
+}
+
+query "$1" "$2" "$3" | jq --raw-output '.Items[] | .subscriptionNumber | .S'

--- a/dynamoDb/scripts/cohortStateQuery.bash
+++ b/dynamoDb/scripts/cohortStateQuery.bash
@@ -20,7 +20,7 @@ function query() {
     --projection-expression "subscriptionNumber" \
     --key-condition-expression "processingStage = :s AND startDate <= :d " \
     --expression-attribute-values "{\":s\": {\"S\": \"$2\"}, \":d\": {\"S\": \"$3\"}}" \
-    --page-size "100000"
+    --max-items "100000"
 }
 
 query "$1" "$2" "$3" | jq --raw-output '.Items[] | .subscriptionNumber | .S'


### PR DESCRIPTION
Query is designed so that its output can be fed into one of the ad-hoc update or delete scripts already written.