### PR TITLE
Write mail sent timestamp to sf

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -27,7 +27,7 @@ object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, 
         )
       time <- clock.currentDateTime
         .mapError { error =>
-          SalesforcePriceRiseCreationFailure(s"Failed to get currentTime: $error")
+          SalesforcePriceRiseWriteFailure(s"Failed to get currentTime: $error")
         }
       salesforcePriceRiseCreationDetails = CohortItem(
         subscriptionName = item.subscriptionName,
@@ -65,17 +65,17 @@ object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, 
   def buildPriceRise(
       cohortItem: CohortItem,
       subscription: SalesforceSubscription
-  ): IO[SalesforcePriceRiseCreationFailure, SalesforcePriceRise] = {
+  ): IO[SalesforcePriceRiseWriteFailure, SalesforcePriceRise] = {
     for {
       currentPrice <- ZIO
         .fromOption(cohortItem.oldPrice)
-        .orElseFail(SalesforcePriceRiseCreationFailure(s"$cohortItem does not have an oldPrice"))
+        .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have an oldPrice"))
       newPrice <- ZIO
         .fromOption(cohortItem.estimatedNewPrice)
-        .orElseFail(SalesforcePriceRiseCreationFailure(s"$cohortItem does not have an estimatedNewPrice"))
+        .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have an estimatedNewPrice"))
       priceRiseDate <- ZIO
         .fromOption(cohortItem.startDate)
-        .orElseFail(SalesforcePriceRiseCreationFailure(s"$cohortItem does not have a startDate"))
+        .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have a startDate"))
     } yield
       SalesforcePriceRise(
         Some(subscription.Name),

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -16,5 +16,6 @@ case class CohortItem(
     newPrice: Option[BigDecimal] = None,
     newSubscriptionId: Option[ZuoraSubscriptionId] = None,
     whenAmendmentDone: Option[Instant] = None,
-    whenEmailSent: Option[Instant] = None
+    whenEmailSent: Option[Instant] = None,
+    whenEmailSentWrittenToSalesforce: Option[Instant] = None
 )

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -20,6 +20,7 @@ object CohortTableFilter {
   case object Cancelled extends CohortTableFilter { override val value: String = "Cancelled" }
   case object EmailSendProcessingOrError extends CohortTableFilter { override val value: String = "EmailSendProcessingOrError" }
   case object EmailSendComplete extends CohortTableFilter { override val value: String = "EmailSendComplete" }
+  case object EmailSendDateWrittenToSalesforce extends CohortTableFilter { override val value: String = "EmailSendDateWrittenToSalesforce" }
 
   val all = Set(
     ReadyForEstimation,

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -23,7 +23,7 @@ case class AmendmentDataFailure(reason: String) extends Failure
 case class CancelledSubscriptionFailure(reason: String) extends Failure
 
 case class SalesforceFailure(reason: String) extends Failure
-case class SalesforcePriceRiseCreationFailure(reason: String) extends Failure
+case class SalesforcePriceRiseWriteFailure(reason: String) extends Failure
 case class SalesforceClientFailure(reason: String) extends Failure
 
 case class S3Failure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
@@ -3,10 +3,11 @@ package pricemigrationengine.model
 import java.time.LocalDate
 
 case class SalesforcePriceRise(
-  Name: String,
-  Buyer__c: String,
-  Current_Price_Today__c: BigDecimal,
-  Guardian_Weekly_New_Price__c: BigDecimal,
-  Price_Rise_Date__c: LocalDate,
-  SF_Subscription__c: String
+  Name: Option[String] = None,
+  Buyer__c: Option[String] = None,
+  Current_Price_Today__c: Option[BigDecimal] = None,
+  Guardian_Weekly_New_Price__c: Option[BigDecimal] = None,
+  Price_Rise_Date__c: Option[LocalDate] = None,
+  SF_Subscription__c: Option[String] = None,
+  Date_Letter_Sent__c: Option[LocalDate] = None
 )

--- a/lambda/src/test/scala/pricemigrationengine/TestLogging.scala
+++ b/lambda/src/test/scala/pricemigrationengine/TestLogging.scala
@@ -1,0 +1,9 @@
+package pricemigrationengine
+
+import pricemigrationengine.services.ConsoleLogging
+import zio.console
+
+object TestLogging {
+  val logging = console.Console.live >>> ConsoleLogging.impl
+
+}

--- a/lambda/src/test/scala/pricemigrationengine/TestLogging.scala
+++ b/lambda/src/test/scala/pricemigrationengine/TestLogging.scala
@@ -5,5 +5,4 @@ import zio.console
 
 object TestLogging {
   val logging = console.Console.live >>> ConsoleLogging.impl
-
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationEmailHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationEmailHandlerTest.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.handlers
 import java.time._
 import java.time.temporal.ChronoUnit
 
-import pricemigrationengine.StubClock
+import pricemigrationengine.{StubClock, TestLogging}
 import pricemigrationengine.model.CohortTableFilter.{AmendmentComplete, EmailSendComplete, EmailSendProcessingOrError, EstimationComplete, SalesforcePriceRiceCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.model.membershipworkflow.EmailMessage
@@ -16,7 +16,6 @@ import zio.stream.ZStream
 import scala.collection.mutable.ArrayBuffer
 
 class NotificationEmailHandlerTest extends munit.FunSuite {
-  val stubLogging = console.Console.live >>> ConsoleLogging.impl
   val expectedSubscriptionName = "Sub-0001"
   val expectedStartDate = LocalDate.of(2020, 1, 1)
   val expectedCurrency = "GBP"
@@ -165,7 +164,7 @@ class NotificationEmailHandlerTest extends munit.FunSuite {
       default.unsafeRunSync(
         NotificationEmailHandler.main
           .provideLayer(
-            stubLogging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
+            TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
           )
       ),
       Success(())
@@ -219,7 +218,7 @@ class NotificationEmailHandlerTest extends munit.FunSuite {
       default.unsafeRunSync(
         NotificationEmailHandler.main
           .provideLayer(
-            stubLogging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ failingStubEmailSender
+            TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ failingStubEmailSender
           )
       ),
       Failure(Cause.fail(EmailSenderFailure("Bang!!")))

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -1,0 +1,116 @@
+package pricemigrationengine.handlers
+
+import java.time.{LocalDate, ZoneOffset}
+
+import pricemigrationengine.model.CohortTableFilter.{EmailSendComplete, EmailSendDateWrittenToSalesforce}
+import pricemigrationengine.model._
+import pricemigrationengine.services._
+import pricemigrationengine.{StubClock, TestLogging}
+import zio.Exit.Success
+import zio.Runtime.default
+import zio.stream.ZStream
+import zio.{IO, ZIO, ZLayer}
+
+import scala.collection.mutable.ArrayBuffer
+
+class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
+  val expectedSubscriptionName = "Sub-0001"
+  val expectedWhenEmailSentDate = LocalDate.of(2020,3,23)
+  val expectedPriceRiseId = "price-rise-id"
+
+  def createStubCohortTable(updatedResultsWrittenToCohortTable:ArrayBuffer[CohortItem], cohortItem: CohortItem) = {
+    ZLayer.succeed(
+      new CohortTable.Service {
+        override def fetch(
+          filter: CohortTableFilter,
+          beforeDateInclusive: Option[LocalDate]
+        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
+          assertEquals(filter, EmailSendComplete)
+          IO.succeed(ZStream(cohortItem))
+        }
+
+        override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+
+        override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
+          updatedResultsWrittenToCohortTable.addOne(result)
+          IO.succeed(())
+        }
+      }
+    )
+  }
+
+  private def stubSFClient(
+    updatedPriceRises: ArrayBuffer[SalesforcePriceRise]
+  ) = {
+    ZLayer.succeed(
+      new SalesforceClient.Service {
+        override def getSubscriptionByName(
+            subscriptionName: String
+        ): IO[SalesforceClientFailure, SalesforceSubscription] = ???
+
+        override def createPriceRise(
+            priceRise: SalesforcePriceRise
+        ): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResponse] = ???
+
+        override def updatePriceRise(
+            priceRiseId: String, priceRise: SalesforcePriceRise
+        ): IO[SalesforceClientFailure, Unit] = {
+          updatedPriceRises.addOne(priceRise)
+          ZIO.unit
+        }
+
+        override def getContact(
+            contactId: String
+        ): IO[SalesforceClientFailure, SalesforceContact] = ???
+      }
+    )
+  }
+
+  test("SalesforceNotificationDateUpdateHandler should write whenEmailSentWrittenToSalesforce to salesforce") {
+    val updatedPriceRises = ArrayBuffer[SalesforcePriceRise]()
+    val stubSalesforceClient = stubSFClient(updatedPriceRises)
+    val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
+
+    val cohortItem = CohortItem(
+      subscriptionName = expectedSubscriptionName,
+      processingStage = EmailSendComplete,
+      salesforcePriceRiseId = Some(expectedPriceRiseId),
+      whenEmailSent = Some(expectedWhenEmailSentDate.atStartOfDay().toInstant(ZoneOffset.UTC))
+    )
+
+    val stubCohortTable = createStubCohortTable(updatedResultsWrittenToCohortTable, cohortItem)
+
+    assertEquals(
+      default.unsafeRunSync(
+        SalesforceNotificationDateUpdateHandler.main
+          .provideLayer(
+            TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ StubClock.clock
+          )
+      ),
+      Success(())
+    )
+
+    assertEquals(updatedPriceRises.size, 1)
+    assertEquals(updatedPriceRises(0).Name, None)
+    assertEquals(updatedPriceRises(0).SF_Subscription__c, None)
+    assertEquals(updatedPriceRises(0).Buyer__c, None)
+    assertEquals(updatedPriceRises(0).Current_Price_Today__c, None)
+    assertEquals(updatedPriceRises(0).Guardian_Weekly_New_Price__c, None)
+    assertEquals(updatedPriceRises(0).Price_Rise_Date__c, None)
+    assertEquals(updatedPriceRises(0).Date_Letter_Sent__c, Some(expectedWhenEmailSentDate))
+
+    assertEquals(updatedResultsWrittenToCohortTable.size, 1)
+    assertEquals(
+      updatedResultsWrittenToCohortTable(0).subscriptionName,
+      s"Sub-0001"
+    )
+    assertEquals(
+      updatedResultsWrittenToCohortTable(0).processingStage,
+      EmailSendDateWrittenToSalesforce
+    )
+    assertEquals(
+      updatedResultsWrittenToCohortTable(0).whenEmailSentWrittenToSalesforce,
+      Some(StubClock.expectedCurrentTime)
+    )
+  }
+}

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -3,6 +3,7 @@ package pricemigrationengine.handlers
 import java.io.InputStream
 import java.time.LocalDate
 
+import pricemigrationengine.TestLogging
 import pricemigrationengine.model._
 import pricemigrationengine.services._
 import zio.Exit.Success
@@ -58,13 +59,11 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
       }
     )
 
-    val stubLogging = console.Console.live >>> ConsoleLogging.impl
-
     assertEquals(
       default.unsafeRunSync(
         SubscriptionIdUploadHandler.main
           .provideLayer(
-            stubLogging ++ stubConfiguration ++ stubCohortTable ++ stubS3
+            TestLogging.logging ++ stubConfiguration ++ stubCohortTable ++ stubS3
           )
       ),
       Success(())

--- a/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
@@ -4,6 +4,7 @@ import java.util
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model._
+import pricemigrationengine.TestLogging
 import pricemigrationengine.services._
 import zio.Exit.Success
 import zio.Runtime.default
@@ -13,8 +14,6 @@ import zio.{ZIO, ZLayer, console}
 import scala.jdk.CollectionConverters._
 
 class DynamoDBZIOLiveTest extends munit.FunSuite {
-  val stubLogging = console.Console.live >>> ConsoleLogging.impl
-
   test("DynamoDBZIOLive should get all batches of query results and convert the batches to a stream") {
     def item(id: String) = Map("id" -> new AttributeValue(id)).asJava
 
@@ -42,7 +41,7 @@ class DynamoDBZIOLiveTest extends munit.FunSuite {
     default.unsafeRunSync(
       DynamoDBZIO
         .query(queryRequest)
-        .provideLayer((stubDynamoDBClient ++ stubLogging) >>> DynamoDBZIOLive.impl)
+        .provideLayer((stubDynamoDBClient ++ TestLogging.logging) >>> DynamoDBZIOLive.impl)
     ) match {
       case Success(results) =>
         assertEquals(
@@ -80,7 +79,7 @@ class DynamoDBZIOLiveTest extends munit.FunSuite {
       default.unsafeRunSync(
         DynamoDBZIO
           .update("a-table", "key", "value")
-          .provideLayer((stubDynamoDBClient ++ stubLogging) >>> DynamoDBZIOLive.impl)
+          .provideLayer((stubDynamoDBClient ++ TestLogging.logging) >>> DynamoDBZIOLive.impl)
       ),
       Success(())
     )

--- a/lambda/src/test/scala/pricemigrationengine/service/SalesforceClientLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/SalesforceClientLiveTest.scala
@@ -1,0 +1,45 @@
+package pricemigrationengine.service
+
+import java.time.LocalDate
+
+import pricemigrationengine.model.SalesforcePriceRise
+import pricemigrationengine.services.SalesforceClientLive
+
+class SalesforceClientLiveTest extends munit.FunSuite {
+  test("SalesforceClientLive should serialise SalesforcePriceRise with all fields") {
+    assertEquals(
+      SalesforceClientLive.serialisePriceRise(
+        SalesforcePriceRise(
+          Name = Some("name"),
+          Buyer__c = Some("buyer"),
+          Current_Price_Today__c = Some(1.23),
+          Guardian_Weekly_New_Price__c = Some(1.99),
+          Price_Rise_Date__c = Some(LocalDate.of(2020, 1, 1)),
+          SF_Subscription__c = Some("subscriptionId"),
+          Date_Letter_Sent__c = Some(LocalDate.of(2020, 1, 2))
+        )
+      ),
+      """{
+        |  "Name": "name",
+        |  "Buyer__c": "buyer",
+        |  "Current_Price_Today__c": "1.23",
+        |  "Guardian_Weekly_New_Price__c": "1.99",
+        |  "Price_Rise_Date__c": "2020-01-01",
+        |  "SF_Subscription__c": "subscriptionId",
+        |  "Date_Letter_Sent__c": "2020-01-02"
+        |}""".stripMargin
+    )
+  }
+  test("SalesforceClientLive should serialise SalesforcePriceRise with fields missing") {
+    assertEquals(
+      SalesforceClientLive.serialisePriceRise(
+        SalesforcePriceRise(
+          Date_Letter_Sent__c = Some(LocalDate.of(2020, 1, 2))
+        )
+      ),
+      """{
+        |  "Date_Letter_Sent__c": "2020-01-02"
+        |}""".stripMargin
+    )
+  }
+}


### PR DESCRIPTION
This PR creates a handler that writes the date on which the prices rise notification mail was sent for a particular subscription into salesforce, allowing the CSRs to inform customers when they were notified about a price rise.

The handler follows the process:
- Read CohortItems with a status of 'EmailSendComplete'
- Convert the CohortItem.whenEmailSend into a Date
- Write the date to the salesforce Price_Rise__c object using a PATCH/update request
- Update the CohortItem setting the processingStage to 'EmailSendDateWrittenToSalesforce' and the 'whenEmailSentWrittenToSalesforce' field to the current time.

Other changes:
- Extracted test logging duplicated code into shared class
- Added test for salesforce request body serialisation to ensure correct behaviour when updating SF