### PR TITLE
Fixing cohort table update of notification dates

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -434,7 +434,7 @@ Resources:
     Properties:
       Description: Lambda used to update Price_Rise__c objects in salesforce with the notification sent date.
       FunctionName:
-        !Sub price-migration-engine-salesforce-notification-date-update-lambda-${Stage}
+        !Sub price-migration-engine-salesforce-notification-date-lambda-${Stage}
       Code:
         S3Bucket: membership-dist
         S3Key: !Sub membership/${Stage}/price-migration-engine-lambda/price-migration-engine-lambda.jar

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -199,6 +199,31 @@ Resources:
                   - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${QueueName}"
                   - { QueueName: !FindInMap [ StageMap, !Ref Stage, SQSQueueName ] }
 
+  PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: LambdaPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/price-migration-engine-salesforce-notification-date-update-lambda-${Stage}:log-stream:*"
+
   S3Bucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -402,6 +427,54 @@ Resources:
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineNotificationLambdaRole
+
+  PriceMigrationEngineSalesforceNotificationDateUpdateLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Lambda used to update Price_Rise__c objects in salesforce with the notification sent date.
+      FunctionName:
+        !Sub price-migration-engine-salesforce-notification-date-update-${Stage}
+      Code:
+        S3Bucket: membership-dist
+        S3Key: !Sub membership/${Stage}/price-migration-engine-lambda/price-migration-engine-lambda.jar
+      Handler: pricemigrationengine.handlers.SalesforceNotificationDateUpdateHandler::handleRequest
+      Environment:
+        Variables:
+          stage: !Ref Stage
+          batchSize: 100
+          salesforceAuthUrl:
+            !Sub
+            - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:salesforceAuthUrl::${SecretsVersion}}}'
+            - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+          salesforceClientId:
+            !Sub
+            - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:salesforceClientId::${SecretsVersion}}}'
+            - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+          salesforceClientSecret:
+            !Sub
+            - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:salesforceClientSecret::${SecretsVersion}}}'
+            - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+          salesforceUserName:
+            !Sub
+            - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:salesforceUserName::${SecretsVersion}}}'
+            - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+          salesforcePassword:
+            !Sub
+            - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:salesforcePassword::${SecretsVersion}}}'
+            - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+          salesforceToken:
+            !Sub
+            - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:salesforceToken::${SecretsVersion}}}'
+            - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+      Role:
+        Fn::GetAtt:
+          - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
+          - Arn
+      MemorySize: 1536
+      Runtime: java8
+      Timeout: 900
+    DependsOn:
+      - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
 
 Outputs:
   PriceMigrationEngineEstimationLambdaOutput:

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -51,7 +51,7 @@ Resources:
         - Ref: PriceMigrationEngineAmendmentLambdaRole
         - Ref: PriceMigrationEngineSubscriptionIdUploadLambdaRole
         - Ref: PriceMigrationEngineNotificationLambdaRole
-        - Ref: PriceMigrationEngineSalesforceNotificationDateUpdateLambda
+        - Ref: PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
 
   PriceMigrationEngineEstimationLambdaRole:
     Type: AWS::IAM::Role

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -434,7 +434,7 @@ Resources:
     Properties:
       Description: Lambda used to update Price_Rise__c objects in salesforce with the notification sent date.
       FunctionName:
-        !Sub price-migration-engine-salesforce-notification-date-update-${Stage}
+        !Sub price-migration-engine-salesforce-notification-date-update-lambda-${Stage}
       Code:
         S3Bucket: membership-dist
         S3Key: !Sub membership/${Stage}/price-migration-engine-lambda/price-migration-engine-lambda.jar

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -51,6 +51,7 @@ Resources:
         - Ref: PriceMigrationEngineAmendmentLambdaRole
         - Ref: PriceMigrationEngineSubscriptionIdUploadLambdaRole
         - Ref: PriceMigrationEngineNotificationLambdaRole
+        - Ref: PriceMigrationEngineSalesforceNotificationDateUpdateLambda
 
   PriceMigrationEngineEstimationLambdaRole:
     Type: AWS::IAM::Role

--- a/lambda/riff-raff.yaml
+++ b/lambda/riff-raff.yaml
@@ -22,5 +22,5 @@ deployments:
       - price-migration-engine-amendment-lambda-
       - price-migration-engine-subscription-id-upload-lambda-
       - price-migration-engine-notification-lambda-
-      - price-migration-engine-salesforce-notification-update-lambda-
+      - price-migration-engine-salesforce-notification-date-lambda-
     dependencies: [cfn]

--- a/lambda/riff-raff.yaml
+++ b/lambda/riff-raff.yaml
@@ -22,4 +22,5 @@ deployments:
       - price-migration-engine-amendment-lambda-
       - price-migration-engine-subscription-id-upload-lambda-
       - price-migration-engine-notification-lambda-
+      - price-migration-engine-salesforce-notification-date-update-lambda-
     dependencies: [cfn]

--- a/lambda/riff-raff.yaml
+++ b/lambda/riff-raff.yaml
@@ -22,5 +22,5 @@ deployments:
       - price-migration-engine-amendment-lambda-
       - price-migration-engine-subscription-id-upload-lambda-
       - price-migration-engine-notification-lambda-
-      - price-migration-engine-salesforce-notification-date-update-lambda-
+      - price-migration-engine-salesforce-notification-update-lambda-
     dependencies: [cfn]

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -34,6 +34,9 @@ object CohortTableLive {
       newPrice <- getOptionalBigDecimalFromResults(cohortItem, "newPrice")
       newSubscriptionId <- getOptionalStringFromResults(cohortItem, "newSubscriptionId")
       whenAmendmentDone <- getOptionalInstantFromResults(cohortItem, "whenAmendmentDone")
+      whenNotificationSent <- getOptionalInstantFromResults(cohortItem, "whenNotificationSent")
+      whenNotificationSentWrittenToSalesforce <-
+        getOptionalInstantFromResults(cohortItem, "whenNotificationSentWrittenToSalesforce")
     } yield
       CohortItem(
         subscriptionName = subscriptionNumber,
@@ -48,7 +51,9 @@ object CohortTableLive {
         whenSfShowEstimate = whenSfShowEstimate,
         newPrice = newPrice,
         newSubscriptionId = newSubscriptionId,
-        whenAmendmentDone = whenAmendmentDone
+        whenAmendmentDone = whenAmendmentDone,
+        whenNotificationSent = whenNotificationSent,
+        whenNotificationSentWrittenToSalesforce = whenNotificationSentWrittenToSalesforce
       )
   }
 
@@ -78,8 +83,17 @@ object CohortTableLive {
         cohortItem.newSubscriptionId
           .map(newSubscriptionId => stringFieldUpdate("newSubscriptionId", newSubscriptionId)),
         cohortItem.whenAmendmentDone
-          .map(whenAmendmentDone => instantFieldUpdate("whenAmendmentDone", whenAmendmentDone))
-      ).flatten.toMap.asJava
+          .map(whenAmendmentDone => instantFieldUpdate("whenAmendmentDone", whenAmendmentDone)),
+        cohortItem.whenNotificationSent
+          .map(whenNotificationSent => instantFieldUpdate("whenNotificationSent", whenNotificationSent)),
+        cohortItem.whenNotificationSentWrittenToSalesforce
+          .map(whenNotificationSentWrittenToSalesforce =>
+            instantFieldUpdate(
+              "whenNotificationSentWrittenToSalesforce",
+              whenNotificationSentWrittenToSalesforce
+            )
+          )
+  ).flatten.toMap.asJava
 
   private implicit val cohortTableKeySerialiser: DynamoDBSerialiser[CohortTableKey] =
     key => Map(stringUpdate("subscriptionNumber", key.subscriptionNumber)).asJava

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -39,8 +39,8 @@ class CohortTableLiveTest extends munit.FunSuite {
   val expectedWhenEstimationDone =  Instant.ofEpochMilli(Random.nextLong())
   val expectedPriceRiseId = "price-rise-id"
   val expectedSfShowEstimate =  Instant.ofEpochMilli(Random.nextLong())
-  val expectedNewSuscriptionId = "new-sub-id"
-  val expectedWhenAmmendmentDone = Instant.ofEpochMilli(Random.nextLong())
+  val expectedNewSubscriptionId = "new-sub-id"
+  val expectedWhenAmendmentDone = Instant.ofEpochMilli(Random.nextLong())
   val expectedWhenNotificationSent = Instant.ofEpochMilli(Random.nextLong())
   val expectedWhenNotificationSentWrittenToSalesforce = Instant.ofEpochMilli(Random.nextLong())
   val item1 = CohortItem("subscription-1", ReadyForEstimation)
@@ -111,8 +111,8 @@ class CohortTableLiveTest extends munit.FunSuite {
             "whenSfShowEstimate" -> new AttributeValue().withS(formatTimestamp(expectedSfShowEstimate)),
             "startDate" -> new AttributeValue().withS(expectedStartDate.toString),
             "newPrice" -> new AttributeValue().withN(expectedNewPrice.toString),
-            "newSubscriptionId" -> new AttributeValue().withS(expectedNewSuscriptionId),
-            "whenAmendmentDone" -> new AttributeValue().withS(formatTimestamp(expectedWhenAmmendmentDone)),
+            "newSubscriptionId" -> new AttributeValue().withS(expectedNewSubscriptionId),
+            "whenAmendmentDone" -> new AttributeValue().withS(formatTimestamp(expectedWhenAmendmentDone)),
             "whenNotificationSent" -> new AttributeValue().withS(formatTimestamp(expectedWhenNotificationSent)),
             "whenNotificationSentWrittenToSalesforce" ->
               new AttributeValue().withS(formatTimestamp(expectedWhenNotificationSentWrittenToSalesforce)),
@@ -131,7 +131,7 @@ class CohortTableLiveTest extends munit.FunSuite {
           salesforcePriceRiseId = Some(expectedPriceRiseId),
           whenSfShowEstimate = Some(expectedSfShowEstimate),
           newPrice = Some(expectedNewPrice),
-          newSubscriptionId = Some(expectedNewSuscriptionId),
+          newSubscriptionId = Some(expectedNewSubscriptionId),
           whenAmendmentDone = Some(expectedWhenAmendmentDone),
           whenNotificationSent = Some(expectedWhenNotificationSent),
           whenNotificationSentWrittenToSalesforce = Some(expectedWhenNotificationSentWrittenToSalesforce),
@@ -236,8 +236,8 @@ class CohortTableLiveTest extends munit.FunSuite {
       salesforcePriceRiseId = Some(expectedPriceRiseId),
       whenSfShowEstimate = Some(expectedSfShowEstimate),
       startDate = Some(expectedStartDate),
-      newSubscriptionId = Some(expectedNewSuscriptionId),
-      whenAmendmentDone = Some(expectedWhenAmmendmentDone),
+      newSubscriptionId = Some(expectedNewSubscriptionId),
+      whenAmendmentDone = Some(expectedWhenAmendmentDone),
       whenNotificationSent = Some(expectedWhenNotificationSent),
       whenNotificationSentWrittenToSalesforce = Some(expectedWhenNotificationSentWrittenToSalesforce)
     )
@@ -314,14 +314,14 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
     assertEquals(
       update.get("newSubscriptionId"),
-      new AttributeValueUpdate(new AttributeValue().withS(expectedNewSuscriptionId), AttributeAction.PUT),
+      new AttributeValueUpdate(new AttributeValue().withS(expectedNewSubscriptionId), AttributeAction.PUT),
       "newSubscriptionId"
     )
     assertEquals(
       update.get("whenAmendmentDone"),
       new AttributeValueUpdate(
         new AttributeValue()
-          .withS(formatTimestamp(expectedWhenAmmendmentDone)),
+          .withS(formatTimestamp(expectedWhenAmendmentDone)),
         AttributeAction.PUT
       ),
       "whenAmendmentDone"

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -40,7 +40,9 @@ class CohortTableLiveTest extends munit.FunSuite {
   val expectedPriceRiseId = "price-rise-id"
   val expectedSfShowEstimate =  Instant.ofEpochMilli(Random.nextLong())
   val expectedNewSuscriptionId = "new-sub-id"
-  val expectedWhenAmmendmentDone =  Instant.ofEpochMilli(Random.nextLong())
+  val expectedWhenAmmendmentDone = Instant.ofEpochMilli(Random.nextLong())
+  val expectedWhenNotificationSent = Instant.ofEpochMilli(Random.nextLong())
+  val expectedWhenNotificationSentWrittenToSalesforce = Instant.ofEpochMilli(Random.nextLong())
   val item1 = CohortItem("subscription-1", ReadyForEstimation)
   val item2 = CohortItem("subscription-2", ReadyForEstimation)
 
@@ -110,7 +112,10 @@ class CohortTableLiveTest extends munit.FunSuite {
             "startDate" -> new AttributeValue().withS(expectedStartDate.toString),
             "newPrice" -> new AttributeValue().withN(expectedNewPrice.toString),
             "newSubscriptionId" -> new AttributeValue().withS(expectedNewSuscriptionId),
-            "whenAmendmentDone" -> new AttributeValue().withS(formatTimestamp(expectedWhenAmmendmentDone))
+            "whenAmendmentDone" -> new AttributeValue().withS(formatTimestamp(expectedWhenAmmendmentDone)),
+            "whenNotificationSent" -> new AttributeValue().withS(formatTimestamp(expectedWhenNotificationSent)),
+            "whenNotificationSentWrittenToSalesforce" ->
+              new AttributeValue().withS(formatTimestamp(expectedWhenNotificationSentWrittenToSalesforce)),
           ).asJava
         )
       ),
@@ -127,7 +132,9 @@ class CohortTableLiveTest extends munit.FunSuite {
           whenSfShowEstimate = Some(expectedSfShowEstimate),
           newPrice = Some(expectedNewPrice),
           newSubscriptionId = Some(expectedNewSuscriptionId),
-          whenAmendmentDone = Some(expectedWhenAmmendmentDone)
+          whenAmendmentDone = Some(expectedWhenAmmendmentDone),
+          whenNotificationSent = Some(expectedWhenNotificationSent),
+          whenNotificationSentWrittenToSalesforce = Some(expectedWhenNotificationSentWrittenToSalesforce),
         )
       )
     )
@@ -230,7 +237,9 @@ class CohortTableLiveTest extends munit.FunSuite {
       whenSfShowEstimate = Some(expectedSfShowEstimate),
       startDate = Some(expectedStartDate),
       newSubscriptionId = Some(expectedNewSuscriptionId),
-      whenAmendmentDone = Some(expectedWhenAmmendmentDone)
+      whenAmendmentDone = Some(expectedWhenAmmendmentDone),
+      whenNotificationSent = Some(expectedWhenNotificationSent),
+      whenNotificationSentWrittenToSalesforce = Some(expectedWhenNotificationSentWrittenToSalesforce)
     )
 
     assertEquals(
@@ -316,6 +325,24 @@ class CohortTableLiveTest extends munit.FunSuite {
         AttributeAction.PUT
       ),
       "whenAmendmentDone"
+    )
+    assertEquals(
+      update.get("whenNotificationSentWrittenToSalesforce"),
+      new AttributeValueUpdate(
+        new AttributeValue()
+          .withS(formatTimestamp(expectedWhenNotificationSentWrittenToSalesforce)),
+        AttributeAction.PUT
+      ),
+      "whenNotificationSentWrittenToSalesforce"
+    )
+    assertEquals(
+      update.get("whenNotificationSent"),
+      new AttributeValueUpdate(
+        new AttributeValue()
+          .withS(formatTimestamp(expectedWhenNotificationSent)),
+        AttributeAction.PUT
+      ),
+      "whenNotificationSent"
     )
   }
 

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -132,7 +132,7 @@ class CohortTableLiveTest extends munit.FunSuite {
           whenSfShowEstimate = Some(expectedSfShowEstimate),
           newPrice = Some(expectedNewPrice),
           newSubscriptionId = Some(expectedNewSuscriptionId),
-          whenAmendmentDone = Some(expectedWhenAmmendmentDone),
+          whenAmendmentDone = Some(expectedWhenAmendmentDone),
           whenNotificationSent = Some(expectedWhenNotificationSent),
           whenNotificationSentWrittenToSalesforce = Some(expectedWhenNotificationSentWrittenToSalesforce),
         )


### PR DESCRIPTION
This PR adds the cloudformation and riff-raff config for the SalesforceNotificationDateUpdateLambda.

Additionally there is a fix for the CohortTable that was not writing the whenNotificationSent and whenNotificationSentWrittenToSalesforce fields to dynamoDb