### PR TITLE
Avoid logging writing twice

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -32,12 +32,7 @@ object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, 
         salesforcePriceRiseId = optionalNewPriceRiseId,
         whenSfShowEstimate = Some(now)
       )
-      _ <- CohortTable
-        .update(salesforcePriceRiseCreationDetails)
-        .tapBoth(
-          e => Logging.error(s"Failed to update Cohort table: $e"),
-          _ => Logging.info(s"Wrote $salesforcePriceRiseCreationDetails to Cohort table")
-        )
+      _ <- CohortTable.update(salesforcePriceRiseCreationDetails)
     } yield ()
 
   private def updateSalesforce(


### PR DESCRIPTION
The writing back to cohort table is already being done [here](https://github.com/guardian/price-migration-engine/blob/master/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala#L167-L170).