### PR TITLE
limiting the number of price rise notifications sent per run to 100

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -38,7 +38,7 @@ object NotificationHandler {
         SalesforcePriceRiceCreationComplete,
         Some(today.plusDays(NotificationLeadTimeDays))
       )
-      count <- subscriptions.mapM(sendNotification).runCount
+      count <- subscriptions.take(100).mapM(sendNotification).runCount
       _ <- Logging.info(s"Successfully sent $count prices rise notifications")
     } yield ()
   }


### PR DESCRIPTION
Initially sending batches of the price rise notification mails of 100 to enable some sanity checking of the data sent.