### PR TITLE
Write new subscription ID to Salesforce

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -1,0 +1,80 @@
+package pricemigrationengine.handlers
+
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import pricemigrationengine.model.CohortTableFilter.{AmendmentComplete, AmendmentWrittenToSalesforce}
+import pricemigrationengine.model.{CohortItem, Failure, SalesforcePriceRise, SalesforcePriceRiseWriteFailure}
+import pricemigrationengine.services._
+import zio.clock.Clock
+import zio.console.Console
+import zio.{ExitCode, IO, Runtime, ZEnv, ZIO, ZLayer}
+
+/**
+  * Updates Salesforce with evidence of the price-rise amendment that was applied in Zuora.
+  */
+object SalesforceAmendmentUpdateHandler extends zio.App with RequestHandler[Unit, Unit] {
+
+  private val main: ZIO[CohortTable with SalesforceClient with Clock with Logging, Failure, Unit] =
+    for {
+      cohortItems <- CohortTable.fetch(AmendmentComplete, None)
+      _ <- cohortItems.foreach(updateSfWithNewSubscriptionId)
+    } yield ()
+
+  private def updateSfWithNewSubscriptionId(
+      item: CohortItem
+  ): ZIO[CohortTable with SalesforceClient with Clock with Logging, Failure, Unit] =
+    for {
+      priceRise <- ZIO.fromEither(buildPriceRise(item))
+      salesforcePriceRiseId <- IO
+        .fromOption(item.salesforcePriceRiseId)
+        .orElseFail(
+          SalesforcePriceRiseWriteFailure(
+            s"${item.subscriptionName}: salesforcePriceRiseId is required to update Salesforce"
+          ))
+      _ <- SalesforceClient
+        .updatePriceRise(salesforcePriceRiseId, priceRise)
+        .tapBoth(
+          e => Logging.error(s"${item.subscriptionName}: failed to update Salesforce: $e"),
+          _ => Logging.info(s"Amendment of ${item.subscriptionName} recorded in Salesforce")
+        )
+      now <- Time.thisInstant
+      _ <- CohortTable
+        .update(
+          CohortItem(
+            subscriptionName = item.subscriptionName,
+            processingStage = AmendmentWrittenToSalesforce,
+            whenAmendmentWrittenToSalesforce = Some(now)
+          ))
+    } yield ()
+
+  private def buildPriceRise(
+      cohortItem: CohortItem
+  ): Either[SalesforcePriceRiseWriteFailure, SalesforcePriceRise] =
+    cohortItem.newSubscriptionId
+      .map(newSubscriptionId => SalesforcePriceRise(Amended_Zuora_Subscription_Id__c = Some(newSubscriptionId)))
+      .toRight(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have a newSubscriptionId field"))
+
+  private def env(
+      loggingService: Logging.Service
+  ): ZLayer[Any, Any, Logging with CohortTable with SalesforceClient with Clock] = {
+    val loggingLayer = ZLayer.succeed(loggingService)
+    loggingLayer ++ EnvConfiguration.dynamoDbImpl >>>
+      DynamoDBClient.dynamoDB ++ loggingLayer >>>
+      DynamoDBZIOLive.impl ++ loggingLayer ++ EnvConfiguration.cohortTableImp ++ EnvConfiguration.stageImp ++ EnvConfiguration.salesforceImp >>>
+      (loggingLayer ++ CohortTableLive.impl ++ SalesforceClientLive.impl ++ Clock.live)
+        .tapError(e => loggingService.error(s"Failed to create service environment: $e"))
+  }
+
+  def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
+    main
+      .provideSomeLayer(
+        env(ConsoleLogging.service(Console.Service.live))
+      )
+      .exitCode
+
+  def handleRequest(unused: Unit, context: Context): Unit =
+    Runtime.default.unsafeRun(
+      main.provideSomeLayer(
+        env(LambdaLogging.service(context))
+      )
+    )
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -17,5 +17,6 @@ case class CohortItem(
     newSubscriptionId: Option[ZuoraSubscriptionId] = None,
     whenAmendmentDone: Option[Instant] = None,
     whenNotificationSent: Option[Instant] = None,
-    whenNotificationSentWrittenToSalesforce: Option[Instant] = None
+    whenNotificationSentWrittenToSalesforce: Option[Instant] = None,
+    whenAmendmentWrittenToSalesforce: Option[Instant] = None
 )

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
@@ -3,11 +3,12 @@ package pricemigrationengine.model
 import java.time.LocalDate
 
 case class SalesforcePriceRise(
-  Name: Option[String] = None,
-  Buyer__c: Option[String] = None,
-  Current_Price_Today__c: Option[BigDecimal] = None,
-  Guardian_Weekly_New_Price__c: Option[BigDecimal] = None,
-  Price_Rise_Date__c: Option[LocalDate] = None,
-  SF_Subscription__c: Option[String] = None,
-  Date_Letter_Sent__c: Option[LocalDate] = None
+    Name: Option[String] = None,
+    Buyer__c: Option[String] = None,
+    Current_Price_Today__c: Option[BigDecimal] = None,
+    Guardian_Weekly_New_Price__c: Option[BigDecimal] = None,
+    Price_Rise_Date__c: Option[LocalDate] = None,
+    SF_Subscription__c: Option[String] = None,
+    Date_Letter_Sent__c: Option[LocalDate] = None,
+    Amended_Zuora_Subscription_Id__c: Option[ZuoraSubscriptionId] = None
 )

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -35,8 +35,9 @@ object CohortTableLive {
       newSubscriptionId <- getOptionalStringFromResults(cohortItem, "newSubscriptionId")
       whenAmendmentDone <- getOptionalInstantFromResults(cohortItem, "whenAmendmentDone")
       whenNotificationSent <- getOptionalInstantFromResults(cohortItem, "whenNotificationSent")
-      whenNotificationSentWrittenToSalesforce <-
-        getOptionalInstantFromResults(cohortItem, "whenNotificationSentWrittenToSalesforce")
+      whenNotificationSentWrittenToSalesforce <- getOptionalInstantFromResults(
+        cohortItem,
+        "whenNotificationSentWrittenToSalesforce")
     } yield
       CohortItem(
         subscriptionName = subscriptionNumber,
@@ -87,13 +88,15 @@ object CohortTableLive {
         cohortItem.whenNotificationSent
           .map(whenNotificationSent => instantFieldUpdate("whenNotificationSent", whenNotificationSent)),
         cohortItem.whenNotificationSentWrittenToSalesforce
-          .map(whenNotificationSentWrittenToSalesforce =>
-            instantFieldUpdate(
-              "whenNotificationSentWrittenToSalesforce",
-              whenNotificationSentWrittenToSalesforce
-            )
-          )
-  ).flatten.toMap.asJava
+          .map(
+            whenNotificationSentWrittenToSalesforce =>
+              instantFieldUpdate(
+                "whenNotificationSentWrittenToSalesforce",
+                whenNotificationSentWrittenToSalesforce
+            )),
+        cohortItem.whenAmendmentWrittenToSalesforce.map(instant =>
+          instantFieldUpdate("whenAmendmentWrittenToSalesforce", instant))
+      ).flatten.toMap.asJava
 
   private implicit val cohortTableKeySerialiser: DynamoDBSerialiser[CohortTableKey] =
     key => Map(stringUpdate("subscriptionNumber", key.subscriptionNumber)).asJava


### PR DESCRIPTION
After the amendment has been made in Zuora, we update the corresponding Salesforce price rise record with evidence of the amendment.  The evidence is the ID of the subscription in Zuora that was generated by the price rise amendment.  This should be enough to tie everything together.