### PR TITLE
Fixing logging permissions for notification lambda

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -188,7 +188,7 @@ Resources:
                   - logs:PutLogEvents
                   - lambda:InvokeFunction
                 Resource:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/price-migration-engine-notification-email-lambda-${Stage}:log-stream:*"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/price-migration-engine-notification-lambda-${Stage}:log-stream:*"
         - PolicyName: SendNotificationRequestSQSMessage
           PolicyDocument:
             Statement:


### PR DESCRIPTION
the notification handler logging permissions were out of sync with the lambda name

