### PR TITLE
Log price rise notification error and continue

### DIFF
--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -221,7 +221,7 @@ class NotificationHandlerTest extends munit.FunSuite {
             TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ failingStubEmailSender
           )
       ),
-      Failure(Cause.fail(EmailSenderFailure("Bang!!")))
+      Success()
     )
 
     assertEquals(updatedResultsWrittenToCohortTable.size, 1)


### PR DESCRIPTION
Logging and recovering from an error in the notification email processing, so one failing sub does not stop the processing of others.