### PR TITLE
Avoid duplicated logging

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
@@ -35,10 +35,6 @@ object SalesforceNotificationDateUpdateHandler extends App with RequestHandler[U
       )
       _ <- CohortTable
         .update(salesforcePriceRiseDetails)
-        .tapBoth(
-          e => Logging.error(s"Failed to update Cohort table: $e"),
-          _ => Logging.info(s"Wrote $salesforcePriceRiseDetails to Cohort table")
-        )
     } yield ()
 
   private def updateSalesforce(


### PR DESCRIPTION
Similar to #94.
The writing back to cohort table is already being done [here](https://github.com/guardian/price-migration-engine/blob/master/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala#L167-L170).