### PR TITLE
Handling missing billing address and annual subscriptions

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -45,9 +45,10 @@ object NotificationHandler {
       emailAddress <- requiredField(contact.Email, "Contact.Email")
       firstName <- requiredField(contact.FirstName, "Contact.FirstName")
       lastName <- requiredField(contact.LastName, "Contact.LastName")
-      street <- requiredField(contact.OtherAddress.street, "Contact.OtherAddress.street")
-      postalCode <- requiredField(contact.OtherAddress.postalCode, "Contact.OtherAddress.postalCode")
-      country <- requiredField(contact.OtherAddress.country, "Contact.OtherAddress.country")
+      otherAddress <- requiredField(contact.OtherAddress, "Contact.OtherAddress" )
+      street <- requiredField(otherAddress.street, "Contact.OtherAddress.street")
+      postalCode <- requiredField(otherAddress.postalCode, "Contact.OtherAddress.postalCode")
+      country <- requiredField(otherAddress.country, "Contact.OtherAddress.country")
       estimatedNewPrice <- requiredField(cohortItem.estimatedNewPrice.map(_.toString()), "CohortItem.estimatedNewPrice")
       startDate <- requiredField(cohortItem.startDate.map(_.toString()), "CohortItem.startDate")
       billingPeriod <- requiredField(cohortItem.billingPeriod, "CohortItem.billingPeriod")
@@ -66,9 +67,9 @@ object NotificationHandler {
                 last_name = lastName,
                 billing_address_1 = street,
                 billing_address_2 = None, //See 'Billing Address Format' section in the readme
-                billing_city = contact.OtherAddress.city,
+                billing_city = otherAddress.city,
                 billing_postal_code = postalCode,
-                billing_state = contact.OtherAddress.state,
+                billing_state = otherAddress.state,
                 billing_country = country,
                 payment_amount = estimatedNewPrice,
                 next_payment_date = startDate,
@@ -93,7 +94,7 @@ object NotificationHandler {
     }
   }
 
-  def requiredField(field: Option[String], fieldName: String): ZIO[Any, NotificationHandlerFailure, String] = {
+  def requiredField[A](field: Option[A], fieldName: String): ZIO[Any, NotificationHandlerFailure, A] = {
     ZIO.fromOption(field).orElseFail(NotificationHandlerFailure(s"$fieldName is a required field"))
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -101,7 +101,8 @@ object NotificationHandler {
   val paymentFrequencyMapping = Map(
     "Month" -> "Monthly",
     "Quarter" -> "Quarterly",
-    "Semi_Annual" -> "Semiannually"
+    "Semi_Annual" -> "Semiannually",
+    "Annual" -> "Annually"
   )
 
   def paymentFrequency(billingPeriod: String) =

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforceContact.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforceContact.scala
@@ -7,5 +7,5 @@ case class SalesforceContact(
   Salutation: Option[String],
   FirstName: Option[String],
   LastName: Option[String],
-  OtherAddress: SalesforceAddress
+  OtherAddress: Option[SalesforceAddress]
 )

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -133,12 +133,14 @@ class NotificationHandlerTest extends munit.FunSuite {
       FirstName = Some(expectedFirstName),
       LastName = Some(expectedLastName),
       OtherAddress =
-        SalesforceAddress(
-          street = Some(expectedStreet),
-          city = Some(expectedCity),
-          state = Some(expectedState),
-          postalCode = Some(expectedPostalCode),
-          country = Some(expectedCountry),
+        Some(
+          SalesforceAddress(
+            street = Some(expectedStreet),
+            city = Some(expectedCity),
+            state = Some(expectedState),
+            postalCode = Some(expectedPostalCode),
+            country = Some(expectedCountry),
+          )
         )
     )
 


### PR DESCRIPTION
Some subs do not seem to have a billing address, this was causing the NotificationHandler to NPE and fail.

This change handles that case and logs an error.

This also adds a mapping for Annual billing periods