### PR TITLE
Give lambda access to its logs

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -223,7 +223,7 @@ Resources:
                   - logs:PutLogEvents
                   - lambda:InvokeFunction
                 Resource:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/price-migration-engine-salesforce-notification-date-update-lambda-${Stage}:log-stream:*"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/price-migration-engine-salesforce-notification-date-lambda-${Stage}:log-stream:*"
 
   S3Bucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
The `PriceMigrationEngineSalesforceNotificationDateUpdateLambda` lambda has a different [name](https://github.com/guardian/price-migration-engine/blob/be7b4c743c1a5831d8733ff7c171424c4fbe0d7b/lambda/cfn.yaml#L226) to its logs.

So when you run it and try to look at logs, you get the error `Log group does not exist`.
