### PR TITLE
Adding cancellation check before price rise notification send

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -51,9 +51,9 @@ object NotificationHandler {
     } yield count
 
   def sendNotification(
-                        cohortItem: CohortItem,
-                        sfSubscription: SalesforceSubscription
-                      ): ZIO[EmailSender with SalesforceClient with CohortTable with Clock with Logging, Failure, Int] = {
+    cohortItem: CohortItem,
+    sfSubscription: SalesforceSubscription
+  ): ZIO[EmailSender with SalesforceClient with CohortTable with Clock with Logging, Failure, Int] = {
     val result = for {
       _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
       contact <- SalesforceClient.getContact(sfSubscription.Buyer__c)

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforceSubscription.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforceSubscription.scala
@@ -1,3 +1,3 @@
 package pricemigrationengine.model
 
-case class SalesforceSubscription(Id: String, Name: String, Buyer__c: String)
+case class SalesforceSubscription(Id: String, Name: String, Buyer__c: String, Status__c: String)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -64,7 +64,8 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
             SalesforceSubscription(
               s"SubscritionId-$subscriptionName",
               subscriptionName,
-              s"Buyer-$subscriptionName"
+              s"Buyer-$subscriptionName",
+              "Active"
             )
           )
           .orElseFail(SalesforceClientFailure(""))


### PR DESCRIPTION
This change prevents customers who have cancelled their subscriptions from receiving price rise notification letters.

The SF_Subscription status field is checked prior to the notification being send. 

Subscriptions in a Cancelled status have their associated CohortItem put into a cancelled status to prevent any further processing, and the notification sqs message is not sent.

The number of items processed by the notification handler on each execution has also been bumped to 150.
