### PR TITLE
Increasing NotificationHandler batch size

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -30,7 +30,7 @@ object NotificationHandler {
         Some(today.plusDays(NotificationLeadTimeDays))
       )
       count <- subscriptions
-        .take(250)
+        .take(1000)
         .mapM(sendNotification)
         .fold(0) { (sum, count) => sum + count }
       _ <- Logging.info(s"Successfully sent $count prices rise notifications")


### PR DESCRIPTION
Increasing NotificationHandler batch size to 1000 in most cases this should be all of the Notifications for a particular day