### PR TITLE
Implement CohortStateMachine service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ lazy val lambda = (project in file("lambda"))
       awsLambda,
       awsS3,
       awsSQS,
+      awsStateMachine,
       http,
       commonsCsv,
       munit % Test

--- a/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
@@ -2,8 +2,9 @@ package pricemigrationengine.handlers
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import pricemigrationengine.model.CohortSpec
-import pricemigrationengine.services.{CohortSpecTable, CohortStateMachine}
-import zio.{ExitCode, Runtime, ULayer, ZEnv, ZIO}
+import pricemigrationengine.services._
+import zio.console.Console
+import zio.{ExitCode, Runtime, ZEnv, ZIO, ZLayer}
 
 /**
   * Executes price migration for active cohorts.
@@ -11,19 +12,31 @@ import zio.{ExitCode, Runtime, ULayer, ZEnv, ZIO}
 object MigrationHandler extends zio.App with RequestHandler[Unit, Unit] {
 
   private val migrateActiveCohorts =
-    for {
+    (for {
+      today <- Time.today
       cohortSpecs <- CohortSpecTable.fetchAll
-      activeSpecs <- ZIO.filter(cohortSpecs)(cohort => Time.today.map(CohortSpec.isActive(cohort)))
-      _ <- ZIO.foreach(activeSpecs)(CohortStateMachine.startExecution)
-    } yield ()
+      activeSpecs <- ZIO
+        .filter(cohortSpecs)(cohort => ZIO.succeed(CohortSpec.isActive(cohort)(today)))
+        .tap(specs => Logging.info(s"Currently ${specs.size} active cohorts"))
+      _ <- ZIO.foreach(activeSpecs)(CohortStateMachine.startExecution(today))
+    } yield ()).tapError(e => Logging.error(s"Migration run failed: $e"))
 
-  private val runtime = Runtime.default
-
-  private val env: ULayer[CohortSpecTable with CohortStateMachine] = ???
+  private def env(loggingService: Logging.Service) =
+    ZLayer.succeed(loggingService) and EnvConfiguration.dynamoDbImpl andTo
+      DynamoDBClient.dynamoDB andTo
+      EnvConfiguration.stageImp andTo
+      EnvConfiguration.cohortStateMachineImpl andTo
+      (CohortSpecTableLive.impl and CohortStateMachineLive.impl)
+        .tapError(e => loggingService.error(s"Failed to create service environment: $e"))
 
   def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
-    migrateActiveCohorts.provideCustomLayer(env).exitCode
+    migrateActiveCohorts
+      .provideCustomLayer(env(ConsoleLogging.service(Console.Service.live)))
+      .exitCode
 
   def handleRequest(unused: Unit, context: Context): Unit =
-    runtime.unsafeRun(migrateActiveCohorts.provideCustomLayer(env))
+    Runtime.default.unsafeRun(
+      migrateActiveCohorts
+        .provideCustomLayer(env(LambdaLogging.service(context)))
+    )
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
@@ -31,3 +31,5 @@ case class SalesforceConfig(
 )
 
 case class EmailSenderConfig(sqsEmailQueueName: String)
+
+case class CohortStateMachineConfig(stateMachineArn: String)

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -2,6 +2,8 @@ package pricemigrationengine.model
 
 import java.time.LocalDate
 
+import upickle.default.{ReadWriter, macroRW}
+
 /**
   * Specification of a cohort.
   *
@@ -19,6 +21,8 @@ case class CohortSpec(
 )
 
 object CohortSpec {
+
+  implicit val rw: ReadWriter[CohortSpec] = macroRW
 
   def isActive(spec: CohortSpec)(date: LocalDate): Boolean =
     !spec.importStartDate.isAfter(date) && spec.migrationCompleteDate.forall(_.isAfter(date))

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachine.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachine.scala
@@ -1,17 +1,23 @@
 package pricemigrationengine.services
 
+import java.time.LocalDate
+
+import com.amazonaws.services.stepfunctions.model.StartExecutionResult
 import pricemigrationengine.model.{CohortSpec, CohortStateMachineFailure}
 import zio.ZIO
 
 /**
   * Kicks off the migration process for a particular cohort.
+  *
+  * The specification of the cohort is used as the input to the state machine.
   */
 object CohortStateMachine {
 
   trait Service {
-    def startExecution(spec: CohortSpec): ZIO[Any, CohortStateMachineFailure, Unit]
+    def startExecution(date: LocalDate)(spec: CohortSpec): ZIO[Any, CohortStateMachineFailure, StartExecutionResult]
   }
 
-  def startExecution(spec: CohortSpec): ZIO[CohortStateMachine, CohortStateMachineFailure, Unit] =
-    ZIO.accessM(_.get.startExecution(spec))
+  def startExecution(date: LocalDate)(
+      spec: CohortSpec): ZIO[CohortStateMachine, CohortStateMachineFailure, StartExecutionResult] =
+    ZIO.accessM(_.get.startExecution(date)(spec))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
@@ -1,0 +1,39 @@
+package pricemigrationengine.services
+
+import java.time.LocalDate
+
+import com.amazonaws.regions.Regions.EU_WEST_1
+import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder
+import com.amazonaws.services.stepfunctions.model.{StartExecutionRequest, StartExecutionResult}
+import pricemigrationengine.model._
+import upickle.default.write
+import zio.{IO, ZIO, ZLayer}
+
+object CohortStateMachineLive {
+
+  val impl: ZLayer[CohortStateMachineConfiguration with Logging, ConfigurationFailure, CohortStateMachine] = {
+
+    val stateMachine = AWSStepFunctionsClientBuilder.standard.withRegion(EU_WEST_1).build
+
+    ZLayer.fromServicesM[CohortStateMachineConfiguration.Service,
+                         Logging.Service,
+                         Any,
+                         ConfigurationFailure,
+                         CohortStateMachine.Service] { (configuration, logging) =>
+      configuration.config map { config =>
+        new CohortStateMachine.Service {
+          def startExecution(date: LocalDate)(spec: CohortSpec): IO[CohortStateMachineFailure, StartExecutionResult] =
+            ZIO
+              .effect(
+                stateMachine.startExecution(
+                  new StartExecutionRequest()
+                    .withStateMachineArn(config.stateMachineArn)
+                    .withName(s"${spec.cohortName}-$date")
+                    .withInput(write(spec))))
+              .mapError(e => CohortStateMachineFailure(s"Failed to start execution: $e"))
+              .tap(result => logging.info(s"Started execution: $result"))
+        }
+      }
+    }
+  }
+}

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
@@ -7,24 +7,27 @@ import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder
 import com.amazonaws.services.stepfunctions.model.{StartExecutionRequest, StartExecutionResult}
 import pricemigrationengine.model._
 import upickle.default.write
-import zio.{IO, ZIO, ZLayer}
+import zio.blocking.Blocking
+import zio.{IO, ZLayer}
 
 object CohortStateMachineLive {
 
-  val impl: ZLayer[CohortStateMachineConfiguration with Logging, ConfigurationFailure, CohortStateMachine] = {
+  val impl
+    : ZLayer[CohortStateMachineConfiguration with Logging with Blocking, ConfigurationFailure, CohortStateMachine] = {
 
     val stateMachine = AWSStepFunctionsClientBuilder.standard.withRegion(EU_WEST_1).build
 
     ZLayer.fromServicesM[CohortStateMachineConfiguration.Service,
                          Logging.Service,
+                         Blocking.Service,
                          Any,
                          ConfigurationFailure,
-                         CohortStateMachine.Service] { (configuration, logging) =>
+                         CohortStateMachine.Service] { (configuration, logging, blocking) =>
       configuration.config map { config =>
         new CohortStateMachine.Service {
           def startExecution(date: LocalDate)(spec: CohortSpec): IO[CohortStateMachineFailure, StartExecutionResult] =
-            ZIO
-              .effect(
+            blocking
+              .effectBlocking(
                 stateMachine.startExecution(
                   new StartExecutionRequest()
                     .withStateMachineArn(config.stateMachineArn)

--- a/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
@@ -65,3 +65,11 @@ object EmailSenderConfiguration {
   val emailSenderConfig: ZIO[EmailSenderConfiguration, ConfigurationFailure, EmailSenderConfig] =
     ZIO.accessM(_.get.config)
 }
+
+object CohortStateMachineConfiguration {
+  trait Service {
+    val config: IO[ConfigurationFailure, CohortStateMachineConfig]
+  }
+  val cohortStateMachineConfig: ZIO[CohortStateMachineConfiguration, ConfigurationFailure, CohortStateMachineConfig] =
+    ZIO.accessM(_.get.config)
+}

--- a/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
@@ -103,9 +103,19 @@ object EnvConfiguration {
       val config: IO[ConfigurationFailure, EmailSenderConfig] =
         for {
           emailSqsQueueName <- env("sqsEmailQueueName")
-        } yield EmailSenderConfig(
-          sqsEmailQueueName = emailSqsQueueName
-        )
+        } yield
+          EmailSenderConfig(
+            sqsEmailQueueName = emailSqsQueueName
+          )
+    }
+  }
+
+  val cohortStateMachineImpl: ZLayer[Any, ConfigurationFailure, CohortStateMachineConfiguration] = ZLayer.fromEffect {
+    env("cohortStateMachineArn") map { arn =>
+      new CohortStateMachineConfiguration.Service {
+        val config: IO[ConfigurationFailure, CohortStateMachineConfig] =
+          ZIO.succeed(CohortStateMachineConfig(stateMachineArn = arn))
+      }
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/package.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/package.scala
@@ -4,12 +4,16 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import zio.Has
 
 package object services {
+
   type AmendmentConfiguration = Has[AmendmentConfiguration.Service]
   type ZuoraConfiguration = Has[ZuoraConfiguration.Service]
   type DynamoDBConfiguration = Has[DynamoDBConfiguration.Service]
   type CohortTableConfiguration = Has[CohortTableConfiguration.Service]
   type SalesforceConfiguration = Has[SalesforceConfiguration.Service]
   type StageConfiguration = Has[StageConfiguration.Service]
+  type EmailSenderConfiguration = Has[EmailSenderConfiguration.Service]
+  type CohortStateMachineConfiguration = Has[CohortStateMachineConfiguration.Service]
+
   type CohortStateMachine = Has[CohortStateMachine.Service]
   type CohortSpecTable = Has[CohortSpecTable.Service]
   type CohortTable = Has[CohortTable.Service]
@@ -20,5 +24,4 @@ package object services {
   type SalesforceClient = Has[SalesforceClient.Service]
   type S3 = Has[S3.Service]
   type EmailSender = Has[EmailSender.Service]
-  type EmailSenderConfiguration = Has[EmailSenderConfiguration.Service]
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,11 +2,12 @@ import sbt._
 
 object Dependencies {
   private val zioVersion = "1.0.0-RC20"
-  private val awsSdkVersion = "1.11.811"
+  private val awsSdkVersion = "1.11.816"
 
   lazy val awsDynamoDb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
   lazy val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion
   lazy val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion
+  lazy val awsStateMachine = "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsSdkVersion
   lazy val zio = "dev.zio" %% "zio" % zioVersion
   lazy val zioStreams = "dev.zio" %% "zio-streams" % zioVersion
   lazy val upickle = "com.lihaoyi" %% "upickle" % "1.1.0"


### PR DESCRIPTION
This wires together the [MigrationHandler](https://github.com/guardian/price-migration-engine/blob/kc-machine-kick/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala) with the [CohortStateMachineLive](https://github.com/guardian/price-migration-engine/blob/kc-machine-kick/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala) implementation.

The [CohortStateMachineConfig](https://github.com/guardian/price-migration-engine/compare/kc-machine-kick?expand=1#diff-48fde3af0d999d859f698d02ce587fb0R35) gives the ARN of the state machine.  Which cohort the state machine actually operates on depends on the content of the [CohortSpec](https://github.com/guardian/price-migration-engine/blob/kc-machine-kick/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala).
