### PR TITLE
Add steps to state machine

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -259,7 +259,7 @@ Resources:
   PriceMigrationEngineEstimationLambda:
     Type: AWS::Lambda::Function
     Properties:
-      Description: Lambda used to create estimated price, start date and other details of a price rise
+      Description: Lambda used to create estimated price, start date and other details of a price rise.
       FunctionName:
         !Sub price-migration-engine-estimation-lambda-${Stage}
       Code:
@@ -271,16 +271,16 @@ Resources:
           stage: !Ref Stage
           zuoraApiHost:
             !Sub
-              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraApiHost::${SecretsVersion}}}'
-              - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+            - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraApiHost::${SecretsVersion}}}'
+            - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           zuoraClientId:
             !Sub
-              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientId::${SecretsVersion}}}'
-              - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+            - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientId::${SecretsVersion}}}'
+            - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           zuoraClientSecret:
             !Sub
-              - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientSecret::${SecretsVersion}}}'
-              - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
+            - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientSecret::${SecretsVersion}}}'
+            - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
           earliestStartDate: !FindInMap [StageMap, !Ref Stage, EarliestStartDate]
           batchSize: 100
       Role:
@@ -560,3 +560,15 @@ Outputs:
     Value: !GetAtt PriceMigrationEngineSalesforcePriceCreationLambda.Arn
     Export:
       Name: !Sub "${AWS::StackName}-CreatingSalesforceRecordsLambda"
+  PriceMigrationEngineNotificationLambdaOutput:
+    Value: !GetAtt PriceMigrationEngineNotificationLambda.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-NotifyingSubscribersLambda"
+  PriceMigrationEngineAmendmentLambdaOutput:
+    Value: !GetAtt PriceMigrationEngineAmendmentLambda.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-AmendingLambda"
+  PriceMigrationEngineSalesforceAmendmentUpdateLambdaOutput:
+    Value: !GetAtt PriceMigrationEngineSalesforceAmendmentUpdateLambda.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-UpdatingSalesforceWithAmendsLambda"

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -43,6 +43,9 @@ Resources:
                 Resource:
                   - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-EstimatingLambda
                   - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-CreatingSalesforceRecordsLambda
+                  - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-NotifyingSubscribersLambda
+                  - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-AmendingLambda
+                  - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-UpdatingSalesforceWithAmendsLambda
         - PolicyName: LoggingPolicy
           PolicyDocument:
             Statement:
@@ -54,7 +57,7 @@ Resources:
                   - logs:UpdateLogDelivery
                   - logs:DescribeLogGroups
                 Resource:
-                  - !GetAtt CohortStateMachineLogGroup.Arn
+                  - "*"
 
   CohortStateMachine:
     Type: AWS::StepFunctions::StateMachine
@@ -76,69 +79,103 @@ Resources:
         - |
           {
             "Comment": "Price-migration orchestration engine.",
-            "StartAt": "WritingEstimatesToSalesforce",
+            "StartAt": "Estimating",
             "States": {
-              "WritingEstimatesToSalesforce": {
-                "Type": "Parallel",
-                "End": true,
-                "Branches": [
+              "Estimating": {
+                "Type": "Task",
+                "Comment": "Calculating start date and new price for each sub in this cohort.",
+                "Resource": "${EstimatingLambdaArn}",
+                "Retry": [
                   {
-                    "StartAt": "Estimating",
-                    "States": {
-                      "Estimating": {
-                        "Type": "Task",
-                        "Resource": "${EstimatingLambdaArn}",
-                        "Retry": [
-                          {
-                            "ErrorEquals": [
-                              "Lambda.Unknown"
-                            ],
-                            "IntervalSeconds": 10,
-                            "MaxAttempts": 25000,
-                            "BackoffRate": 1.0
-                          },
-                          {
-                            "ErrorEquals": [
-                              "States.ALL"
-                            ],
-                            "IntervalSeconds": 30,
-                            "MaxAttempts": 25000,
-                            "BackoffRate": 2.0
-                          }
-                        ],
-                        "End": true
-                      }
-                    }
+                    "ErrorEquals": [
+                      "Lambda.Unknown"
+                    ],
+                    "IntervalSeconds": 10,
+                    "MaxAttempts": 25000,
+                    "BackoffRate": 1.0
                   },
                   {
-                    "StartAt": "CreatingSalesforceRecords",
-                    "States": {
-                      "CreatingSalesforceRecords": {
-                        "Type": "Task",
-                        "Resource": "${CreatingSalesforceRecordsLambdaArn}",
-                        "Retry": [
-                          {
-                            "ErrorEquals": [
-                              "Lambda.Unknown"
-                            ],
-                            "IntervalSeconds": 10,
-                            "MaxAttempts": 25000,
-                            "BackoffRate": 1.0
-                          },
-                          {
-                            "ErrorEquals": [
-                              "States.ALL"
-                            ],
-                            "IntervalSeconds": 30,
-                            "MaxAttempts": 25000,
-                            "BackoffRate": 2.0
-                          }
-                        ],
-                        "End": true
-                      }
-                    }
+                    "ErrorEquals": [
+                      "States.ALL"
+                    ],
+                    "IntervalSeconds": 30,
+                    "MaxAttempts": 25000,
+                    "BackoffRate": 2.0
                   }
-                ]
+                ],
+                "Next": "CreatingSalesforceRecords"
+              },
+              "CreatingSalesforceRecords": {
+                "Type": "Task",
+                "Comment": "Inserting a price-rise record for each sub in this cohort into Salesforce.",
+                "Resource": "${CreatingSalesforceRecordsLambdaArn}",
+                "Retry": [
+                  {
+                    "ErrorEquals": [
+                      "Lambda.Unknown"
+                    ],
+                    "IntervalSeconds": 10,
+                    "MaxAttempts": 25000,
+                    "BackoffRate": 1.0
+                  },
+                  {
+                    "ErrorEquals": [
+                      "States.ALL"
+                    ],
+                    "IntervalSeconds": 30,
+                    "MaxAttempts": 25000,
+                    "BackoffRate": 2.0
+                  }
+                ],
+                "Next": "Amending"
+              },
+              "Amending": {
+                "Type": "Task",
+                "Comment": "Applying price-rise amendment in Zuora on each sub in this cohort.",
+                "Resource": "${AmendingLambdaArn}",
+                "Retry": [
+                  {
+                    "ErrorEquals": [
+                      "Lambda.Unknown"
+                    ],
+                    "IntervalSeconds": 10,
+                    "MaxAttempts": 25000,
+                    "BackoffRate": 1.0
+                  },
+                  {
+                    "ErrorEquals": [
+                      "States.ALL"
+                    ],
+                    "IntervalSeconds": 30,
+                    "MaxAttempts": 25000,
+                    "BackoffRate": 2.0
+                  }
+                ],
+                "Next": "UpdatingSalesforceWithAmendments"
+              },
+              "UpdatingSalesforceWithAmendments": {
+                "Type": "Task",
+                "Comment": "Updating price-rise record for each sub in this cohort with amendment evidence.",
+                "Resource": "${UpdatingSalesforceWithAmendsLambdaArn}",
+                "Retry": [
+                  {
+                    "ErrorEquals": [
+                      "Lambda.Unknown"
+                    ],
+                    "IntervalSeconds": 10,
+                    "MaxAttempts": 25000,
+                    "BackoffRate": 1.0
+                  },
+                  {
+                    "ErrorEquals": [
+                      "States.ALL"
+                    ],
+                    "IntervalSeconds": 30,
+                    "MaxAttempts": 25000,
+                    "BackoffRate": 2.0
+                  }
+                ],
+                "End": true
               }
             }
           }
@@ -146,3 +183,9 @@ Resources:
             Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-EstimatingLambda
           CreatingSalesforceRecordsLambdaArn:
             Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-CreatingSalesforceRecordsLambda
+          NotifyingSubscribersLambdaArn:
+            Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-NotifyingSubscribersLambda
+          AmendingLambdaArn:
+            Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-AmendingLambda
+          UpdatingSalesforceWithAmendsLambdaArn:
+            Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-UpdatingSalesforceWithAmendsLambda


### PR DESCRIPTION
This adds the [amending](https://github.com/guardian/price-migration-engine/compare/kc-amend-state?expand=1#diff-175c5386eb6f680be3ea41be703fe3e7R132-R155) and [UpdatingSalesforceWithAmendments](https://github.com/guardian/price-migration-engine/compare/kc-amend-state?expand=1#diff-175c5386eb6f680be3ea41be703fe3e7R132-R155) steps to the state machine.

These should be safe to run repeatedly now.

I've left out the notification step for now.

![stepfunctions_graph](https://user-images.githubusercontent.com/1722550/86900036-b6408b00-c102-11ea-9d65-a79cf27cfd5c.png)
