### PR TITLE
Use earliestStartDate from Cohort Specification 

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -15,17 +15,14 @@ Mappings:
   StageMap:
     DEV:
       SecretsVersion: "6559354e-556f-4609-a89f-222824495d5d"
-      EarliestStartDate: 2020-05-15
       BucketName: price-migration-engine-dev
       SQSQueueName: contributions-thanks-dev
     CODE:
       SecretsVersion: "52529e0a-438b-4b63-8a08-35f158ed0bee"
-      EarliestStartDate: 2020-05-15
       BucketName: price-migration-engine-code
       SQSQueueName: contributions-thanks-dev
     PROD:
       SecretsVersion: "dd295c21-39df-47d0-b3b2-0d420ee3b055"
-      EarliestStartDate: 2020-08-02
       BucketName: price-migration-engine-prod
       SQSQueueName: contributions-thanks
 
@@ -281,7 +278,6 @@ Resources:
             !Sub
               - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientSecret::${SecretsVersion}}}'
               - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
-          earliestStartDate: !FindInMap [StageMap, !Ref Stage, EarliestStartDate]
           batchSize: 100
       Role:
         Fn::GetAtt:
@@ -366,7 +362,6 @@ Resources:
             !Sub
             - '{{resolve:secretsmanager:price-migration-engine-lambda-${Stage}:SecretString:zuoraClientSecret::${SecretsVersion}}}'
             - SecretsVersion: !FindInMap [StageMap, !Ref Stage, SecretsVersion]
-          earliestStartDate: !FindInMap [StageMap, !Ref Stage, EarliestStartDate]
           batchSize: 100
       Role:
         Fn::GetAtt:
@@ -560,3 +555,7 @@ Outputs:
     Value: !GetAtt PriceMigrationEngineSalesforcePriceCreationLambda.Arn
     Export:
       Name: !Sub "${AWS::StackName}-CreatingSalesforceRecordsLambda"
+  PriceMigrationEngineNotificationLambdaOutput:
+    Value: !GetAtt PriceMigrationEngineNotificationLambda.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-NotifyingSubscribersLambda"

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -1,28 +1,31 @@
 package pricemigrationengine.handlers
 
+import java.io.InputStream
 import java.time.{Instant, LocalDate}
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.services._
+import upickle.default.read
 import zio.console.Console
 import zio.random.Random
-import zio.{ExitCode, Runtime, ZEnv, ZIO, ZLayer, random}
+import zio.{ExitCode, IO, Runtime, ZEnv, ZIO, ZLayer, random}
 
-object EstimationHandler extends zio.App with RequestHandler[Unit, Unit] {
+import scala.io.Source
 
-  val main: ZIO[Logging with AmendmentConfiguration with CohortTable with Zuora with Random, Failure, Unit] =
+object EstimationHandler extends zio.App with RequestHandler[InputStream, Unit] {
+
+  def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora with Random, Failure, Unit] =
     for {
       newProductPricing <- Zuora.fetchProductCatalogue.map(ZuoraProductCatalogue.productPricingMap)
       cohortItems <- CohortTable.fetch(ReadyForEstimation, None)
-      _ <- cohortItems.foreach(estimate(newProductPricing))
+      _ <- cohortItems.foreach(estimate(newProductPricing, cohortSpec.earliestPriceMigrationStartDate))
     } yield ()
 
-  private def estimate(
-      newProductPricing: ZuoraPricingData
-  )(item: CohortItem): ZIO[Logging with AmendmentConfiguration with CohortTable with Zuora with Random, Failure, Unit] =
-    doEstimation(newProductPricing, item).foldM(
+  private def estimate(newProductPricing: ZuoraPricingData, earliestStartDate: LocalDate)(
+      item: CohortItem): ZIO[Logging with CohortTable with Zuora with Random, Failure, Unit] =
+    doEstimation(newProductPricing, item, earliestStartDate).foldM(
       failure = {
         case _: AmendmentDataFailure         => CohortTable.update(CohortItem(item.subscriptionName, EstimationFailed))
         case _: CancelledSubscriptionFailure => CohortTable.update(CohortItem(item.subscriptionName, Cancelled))
@@ -33,16 +36,15 @@ object EstimationHandler extends zio.App with RequestHandler[Unit, Unit] {
 
   private def doEstimation(
       newProductPricing: ZuoraPricingData,
-      item: CohortItem
-  ): ZIO[Logging with AmendmentConfiguration with CohortTable with Zuora with Random, Failure, CohortItem] =
+      item: CohortItem,
+      earliestStartDate: LocalDate): ZIO[Logging with CohortTable with Zuora with Random, Failure, CohortItem] =
     for {
-      config <- AmendmentConfiguration.amendmentConfig
       subscription <- Zuora
         .fetchSubscription(item.subscriptionName)
         .filterOrFail(_.status != "Cancelled")(CancelledSubscriptionFailure(item.subscriptionName))
-      invoicePreviewTargetDate = config.earliestStartDate.plusMonths(13)
+      invoicePreviewTargetDate = earliestStartDate.plusMonths(13)
       invoicePreview <- Zuora.fetchInvoicePreview(subscription.accountId, invoicePreviewTargetDate)
-      earliestStartDate <- spreadEarliestStartDate(subscription, invoicePreview)
+      earliestStartDate <- spreadEarliestStartDate(subscription, invoicePreview, earliestStartDate)
       result <- ZIO
         .fromEither(EstimationResult(newProductPricing, subscription, invoicePreview, earliestStartDate))
         .tapBoth(
@@ -67,14 +69,14 @@ object EstimationHandler extends zio.App with RequestHandler[Unit, Unit] {
    */
   private[handlers] def spreadEarliestStartDate(
       subscription: ZuoraSubscription,
-      invoicePreview: ZuoraInvoiceList
-  ): ZIO[AmendmentConfiguration with Random, ConfigurationFailure, LocalDate] = {
+      invoicePreview: ZuoraInvoiceList,
+      earliestStartDate: LocalDate): ZIO[Random, ConfigurationFailure, LocalDate] = {
 
-    def earliestStartDateForAMonthlySub(config: AmendmentConfig) =
+    lazy val earliestStartDateForAMonthlySub =
       for {
         randomFactor <- random.nextIntBetween(0, 3)
-        earliestStartDate = config.earliestStartDate.plusMonths(randomFactor)
-      } yield earliestStartDate
+        actualEarliestStartDate = earliestStartDate.plusMonths(randomFactor)
+      } yield actualEarliestStartDate
 
     val isMonthlySubscription =
       invoicePreview.invoiceItems
@@ -83,43 +85,49 @@ object EstimationHandler extends zio.App with RequestHandler[Unit, Unit] {
         .headOption
         .contains("Month")
 
-    AmendmentConfiguration.amendmentConfig flatMap { config =>
-      if (isMonthlySubscription)
-        earliestStartDateForAMonthlySub(config)
-      else
-        ZIO.succeed(config.earliestStartDate)
-    }
+    if (isMonthlySubscription)
+      earliestStartDateForAMonthlySub
+    else
+      ZIO.succeed(earliestStartDate)
   }
 
-  private def env(
-      loggingService: Logging.Service
-  ): ZLayer[Any, ConfigurationFailure, Logging with AmendmentConfiguration with CohortTable with Zuora with Random] = {
+  private def env(loggingService: Logging.Service)
+    : ZLayer[Any, ConfigurationFailure, Logging with CohortTable with Zuora with Random] = {
     val loggingLayer = ZLayer.succeed(loggingService)
     val cohortTableLayer =
-      loggingLayer ++ EnvConfiguration.dynamoDbImpl >>>
-        DynamoDBClient.dynamoDB ++ loggingLayer ++ EnvConfiguration.amendmentImpl >>>
-        DynamoDBZIOLive.impl ++ loggingLayer ++ EnvConfiguration.cohortTableImp ++ EnvConfiguration.stageImp >>>
+      loggingLayer ++ EnvConfiguration.dynamoDbImpl andTo
+        DynamoDBClient.dynamoDB andTo
+        DynamoDBZIOLive.impl ++ loggingLayer ++ EnvConfiguration.cohortTableImp ++ EnvConfiguration.stageImp andTo
         CohortTableLive.impl
     val zuoraLayer =
       EnvConfiguration.zuoraImpl ++ loggingLayer >>>
         ZuoraLive.impl
-    (loggingLayer ++ EnvConfiguration.amendmentImpl ++ cohortTableLayer ++ zuoraLayer ++ Random.live)
+    (loggingLayer ++ cohortTableLayer ++ zuoraLayer ++ Random.live)
       .tapError(e => loggingService.error(s"Failed to create service environment: $e"))
   }
 
-  private val runtime = Runtime.default
+  private def go(loggingService: Logging.Service, input: IO[Failure, String]) =
+    for {
+      cohortSpec <- input
+        .flatMap(inputStr => ZIO.effect(read[CohortSpec](inputStr)))
+        .filterOrElse(CohortSpec.isValid)(spec => ZIO.fail(ConfigurationFailure(s"Invalid spec: $spec")))
+        .tapBoth(e => loggingService.error(s"Failed to read valid spec: $e"),
+                 spec => loggingService.info(s"Input: $spec"))
+      _ <- main(cohortSpec).provideCustomLayer(env(loggingService))
+    } yield ()
 
   def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
-    main
-      .provideSomeLayer(
-        env(ConsoleLogging.service(Console.Service.live))
-      )
-      .exitCode
+    go(
+      loggingService = ConsoleLogging.service(Console.Service.live),
+      input = ZIO.fromOption(args.headOption).orElseFail(ConfigurationFailure("No input"))
+    ).exitCode
 
-  def handleRequest(unused: Unit, context: Context): Unit =
-    runtime.unsafeRun(
-      main.provideSomeLayer(
-        env(LambdaLogging.service(context))
-      )
-    )
+  def handleRequest(input: InputStream, context: Context): Unit =
+    Runtime.default.unsafeRun(
+      go(
+        loggingService = LambdaLogging.service(context),
+        input = ZIO
+          .effect(Source.fromInputStream(input).mkString)
+          .mapError(e => ConfigurationFailure(s"Cannot read from input stream: $e"))
+      ))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -14,6 +14,11 @@ import zio.{ExitCode, IO, Runtime, ZEnv, ZIO, ZLayer, random}
 
 import scala.io.Source
 
+/**
+  * Calculates start date and new price for a set of CohortItems.
+  *
+  * Expected input is a CohortSpec in json format.
+  */
 object EstimationHandler extends zio.App with RequestHandler[InputStream, Unit] {
 
   def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora with Random, Failure, Unit] =

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
@@ -1,12 +1,5 @@
 package pricemigrationengine.model
 
-import java.time.LocalDate
-
-case class AmendmentConfig(
-    // earliest date that price migration can take place
-    earliestStartDate: LocalDate
-)
-
 case class ZuoraConfig(
     apiHost: String,
     clientId: String,

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -26,4 +26,6 @@ object CohortSpec {
 
   def isActive(spec: CohortSpec)(date: LocalDate): Boolean =
     !spec.importStartDate.isAfter(date) && spec.migrationCompleteDate.forall(_.isAfter(date))
+
+  def isValid(spec: CohortSpec): Boolean = spec.earliestPriceMigrationStartDate.isAfter(spec.importStartDate)
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
@@ -3,15 +3,6 @@ package pricemigrationengine.services
 import pricemigrationengine.model._
 import zio.{IO, ZIO}
 
-object AmendmentConfiguration {
-  trait Service {
-    val config: IO[ConfigurationFailure, AmendmentConfig]
-  }
-
-  val amendmentConfig: ZIO[AmendmentConfiguration, ConfigurationFailure, AmendmentConfig] =
-    ZIO.accessM(_.get.config)
-}
-
 object ZuoraConfiguration {
   trait Service {
     val config: IO[ConfigurationFailure, ZuoraConfig]

--- a/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
@@ -1,7 +1,6 @@
 package pricemigrationengine.services
 
 import java.lang.System.getenv
-import java.time.LocalDate
 
 import pricemigrationengine.model._
 import zio.{IO, ZIO, ZLayer}
@@ -17,14 +16,6 @@ object EnvConfiguration {
     ZIO
       .effect(Option(getenv(name)))
       .mapError(e => ConfigurationFailure(e.getMessage))
-
-  val amendmentImpl: ZLayer[Any, Nothing, AmendmentConfiguration] = ZLayer.succeed {
-    new AmendmentConfiguration.Service {
-      val config: IO[ConfigurationFailure, AmendmentConfig] = for {
-        earliestStartDate <- env("earliestStartDate").map(LocalDate.parse)
-      } yield AmendmentConfig(earliestStartDate)
-    }
-  }
 
   val zuoraImpl: ZLayer[Any, Nothing, ZuoraConfiguration] = ZLayer.succeed {
     new ZuoraConfiguration.Service {

--- a/lambda/src/main/scala/pricemigrationengine/services/package.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/package.scala
@@ -5,7 +5,6 @@ import zio.Has
 
 package object services {
 
-  type AmendmentConfiguration = Has[AmendmentConfiguration.Service]
   type ZuoraConfiguration = Has[ZuoraConfiguration.Service]
   type DynamoDBConfiguration = Has[DynamoDBConfiguration.Service]
   type CohortTableConfiguration = Has[CohortTableConfiguration.Service]

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
@@ -3,22 +3,12 @@ package pricemigrationengine.handlers
 import java.time.LocalDate
 
 import pricemigrationengine.Fixtures
-import pricemigrationengine.model.AmendmentConfig
-import pricemigrationengine.services.AmendmentConfiguration
 import zio.random.Random
-import zio.{Chunk, IO, Runtime, UIO, ULayer, ZLayer}
+import zio.{Chunk, Runtime, UIO, ULayer, ZLayer}
 
 class EstimationHandlerTest extends munit.FunSuite {
 
-  private val config: ULayer[AmendmentConfiguration] = ZLayer.succeed(
-    new AmendmentConfiguration.Service {
-      val config: UIO[AmendmentConfig] = IO.succeed(
-        AmendmentConfig(
-          earliestStartDate = LocalDate.of(2020, 6, 2)
-        )
-      )
-    }
-  )
+  private val absoluteEarliestStartDate = LocalDate.of(2020, 6, 2)
 
   private val random: ULayer[Random] = ZLayer.succeed(
     new Random.Service {
@@ -43,14 +33,15 @@ class EstimationHandlerTest extends munit.FunSuite {
     }
   )
 
-  private val env = config ++ random
+  private val env = random
 
   private val runtime = Runtime.default
 
   test("spreadEarliestStartDate: gives default value for a quarterly subscription") {
     val earliestStartDateCalc = EstimationHandler.spreadEarliestStartDate(
       subscription = Fixtures.subscriptionFromJson("QuarterlyVoucher/Subscription.json"),
-      invoicePreview = Fixtures.invoiceListFromJson("QuarterlyVoucher/InvoicePreview.json")
+      invoicePreview = Fixtures.invoiceListFromJson("QuarterlyVoucher/InvoicePreview.json"),
+      absoluteEarliestStartDate
     )
     val earliestStartDate = runtime.unsafeRun(earliestStartDateCalc.provideLayer(env))
     assertEquals(earliestStartDate, LocalDate.of(2020, 6, 2))
@@ -59,7 +50,8 @@ class EstimationHandlerTest extends munit.FunSuite {
   test("spreadEarliestStartDate: gives randomised value for a monthly subscription") {
     val earliestStartDateCalc = EstimationHandler.spreadEarliestStartDate(
       subscription = Fixtures.subscriptionFromJson("Monthly/Subscription.json"),
-      invoicePreview = Fixtures.invoiceListFromJson("Monthly/InvoicePreview.json")
+      invoicePreview = Fixtures.invoiceListFromJson("Monthly/InvoicePreview.json"),
+      absoluteEarliestStartDate
     )
     val earliestStartDate = runtime.unsafeRun(earliestStartDateCalc.provideLayer(env))
     assertEquals(earliestStartDate, LocalDate.of(2020, 7, 2))


### PR DESCRIPTION
This change gets the earliestStartDate from a [CohortSpec](https://github.com/guardian/price-migration-engine/blob/master/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala) instead of from [a parameter in the cloudformation template](https://github.com/guardian/price-migration-engine/compare/kc-earliest-date?expand=1#diff-367b63a358fded148863253f23ab34b0L284).
This is the first step in supporting multiple cohorts with different specifications.

The way it works is that the lambda takes a CohortSpec as input.  When the lambda is running in a state machine, the input to the state machine will be an item in the CohortSpecTable.
