### PR TITLE
Repeat estimation step when it isn't complete

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -1,32 +1,35 @@
 package pricemigrationengine.handlers
 
-import java.io.InputStream
+import java.io.{InputStream, OutputStream}
 import java.time.{Instant, LocalDate}
 
-import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.services._
-import upickle.default.read
+import ujson.Readable
+import upickle.default.{read, stream}
 import zio.console.Console
 import zio.random.Random
-import zio.{ExitCode, IO, Runtime, ZEnv, ZIO, ZLayer, random}
-
-import scala.io.Source
+import zio.{ExitCode, Runtime, ZEnv, ZIO, ZLayer, random}
 
 /**
   * Calculates start date and new price for a set of CohortItems.
   *
   * Expected input is a CohortSpec in json format.
+  *
+  * Output is a HandlerOutput in json format.
   */
-object EstimationHandler extends zio.App with RequestHandler[InputStream, Unit] {
+object EstimationHandler extends zio.App with RequestStreamHandler {
 
-  def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora with Random, Failure, Unit] =
+  def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora with Random, Failure, HandlerOutput] =
     for {
       newProductPricing <- Zuora.fetchProductCatalogue.map(ZuoraProductCatalogue.productPricingMap)
       cohortItems <- CohortTable.fetch(ReadyForEstimation, None)
       _ <- cohortItems.foreach(estimate(newProductPricing, cohortSpec.earliestPriceMigrationStartDate))
-    } yield ()
+      itemsToGo <- CohortTable.fetch(ReadyForEstimation, None)
+      numItemsToGo <- itemsToGo.take(1).runCount
+    } yield HandlerOutput(cohortSpec, isComplete = numItemsToGo == 0)
 
   private def estimate(newProductPricing: ZuoraPricingData, earliestStartDate: LocalDate)(
       item: CohortItem
@@ -117,32 +120,39 @@ object EstimationHandler extends zio.App with RequestHandler[InputStream, Unit] 
       .tapError(e => loggingService.error(s"Failed to create service environment: $e"))
   }
 
-  private def go(loggingService: Logging.Service, input: IO[Failure, String]) =
+  private def go(loggingService: Logging.Service, input: Readable): ZIO[ZEnv, Failure, HandlerOutput] =
     (for {
-      inputStr <- input
       cohortSpec <-
         ZIO
-          .effect(Option(read[CohortSpec](inputStr)))
+          .effect(Option(read[CohortSpec](input)))
           .mapError(e => InputFailure(s"Failed to parse json: $e"))
           .filterOrElse(_.exists(CohortSpec.isValid))(spec => ZIO.fail(InputFailure(s"Invalid cohort spec: $spec")))
           .tap(spec => loggingService.info(s"Input: $spec"))
-      validSpec <- ZIO.fromOption(cohortSpec)
-      _ <- main(validSpec).provideCustomLayer(env(loggingService))
-    } yield ()).tapError(e => loggingService.error(s"Failed to read input: $e"))
+      validSpec <- ZIO.fromOption(cohortSpec).orElseFail(InputFailure("No input"))
+      output <- main(validSpec).provideCustomLayer(env(loggingService))
+    } yield output).tapBoth(
+      e => loggingService.error(e.toString),
+      output => loggingService.info(s"Output: $output")
+    )
 
   def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
-    go(
-      loggingService = ConsoleLogging.service(Console.Service.live),
-      input = ZIO.fromOption(args.headOption).orElseFail(InputFailure("No input"))
-    ).exitCode
-
-  def handleRequest(input: InputStream, context: Context): Unit =
-    Runtime.default.unsafeRun(
-      go(
-        loggingService = LambdaLogging.service(context),
-        input = ZIO
-          .effect(Source.fromInputStream(input).mkString)
-          .mapError(e => InputFailure(s"Cannot read from input stream: $e"))
+    (for {
+      input <- ZIO.fromOption(args.headOption).orElseFail(InputFailure("No input"))
+      _ <- go(
+        loggingService = ConsoleLogging.service(Console.Service.live),
+        input = input
       )
-    )
+    } yield ()).exitCode
+
+  def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
+    val program = for {
+      handlerOutput <- go(
+        loggingService = LambdaLogging.service(context),
+        input
+      )
+      writable <- ZIO.effect(stream(handlerOutput))
+      _ <- ZIO.effect(writable.writeBytesTo(output))
+    } yield ()
+    Runtime.default.unsafeRun(program)
+  }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/HandlerOutput.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/HandlerOutput.scala
@@ -1,0 +1,23 @@
+package pricemigrationengine.model
+
+import upickle.default.{ReadWriter, macroRW}
+
+/**
+  * Output of a handler.
+  *
+  * This is useful in the context of a state machine because it enables us to change the behaviour of the machine.
+  */
+case class HandlerOutput(
+    /**
+      * Specification that was the input to the handler.
+      */
+    cohortSpec: CohortSpec,
+    /**
+      * True iff the process completed in the time available to the handler.
+      */
+    isComplete: Boolean
+)
+
+object HandlerOutput {
+  implicit val rwSubscription: ReadWriter[HandlerOutput] = macroRW
+}

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -88,14 +88,6 @@ Resources:
                 "Retry": [
                   {
                     "ErrorEquals": [
-                      "Lambda.Unknown"
-                    ],
-                    "IntervalSeconds": 10,
-                    "MaxAttempts": 25000,
-                    "BackoffRate": 1.0
-                  },
-                  {
-                    "ErrorEquals": [
                       "States.ALL"
                     ],
                     "IntervalSeconds": 30,

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -103,7 +103,19 @@ Resources:
                     "BackoffRate": 2.0
                   }
                 ],
-                "Next": "CreatingSalesforceRecords"
+                "Next": "IsEstimatingComplete"
+              },
+              "IsEstimatingComplete": {
+                "Type": "Choice",
+                "Comment": "Is the estimating step complete?",
+                "Choices": [
+                {
+                  "Variable": "$.isComplete",
+                  "BooleanEquals": false,
+                  "Next": "Estimating"
+                }
+                ],
+                "Default": "CreatingSalesforceRecords"
               },
               "CreatingSalesforceRecords": {
                 "Type": "Task",


### PR DESCRIPTION
Previously we were relying on [the estimation lambda failing with a timeout and then being retried](https://github.com/guardian/price-migration-engine/blob/620a83db33ab32bc0400febb34fb7bc79535f50b/stateMachine/cfn/cfn.yaml#L89-L96), which is a bit of hack.  The hack ~~is still there but can be removed in future~~ has now been removed.

With this change, we output the state of the estimation process when the lambda has estimated the current batch so that it can be used to decide what to do next.  The output is a generic [HandlerOutput](https://github.com/guardian/price-migration-engine/compare/kc-estimating-complete?expand=1#diff-12422a3d1a5586f1e202adc6a04f295fR10-R19), which can be reused as the output of all the lambdas.

This allows us to add [a decision](https://github.com/guardian/price-migration-engine/compare/kc-estimating-complete?expand=1#diff-175c5386eb6f680be3ea41be703fe3e7R108-R119) to the state machine, whether to repeat the previous step or go to the next one.  So the state machine now looks like this:

![stepfunctions_graph](https://user-images.githubusercontent.com/1722550/87132935-7e664e80-c28e-11ea-9f63-6f18877241b3.png)
