### PR TITLE
Bump dependencies

### DIFF
--- a/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
@@ -9,7 +9,7 @@ import pricemigrationengine.services._
 import zio.Exit.Success
 import zio.Runtime.default
 import zio.stream.Sink
-import zio.{ZIO, ZLayer, console}
+import zio.{Chunk, ZIO, ZLayer}
 
 import scala.jdk.CollectionConverters._
 
@@ -46,7 +46,7 @@ class DynamoDBZIOLiveTest extends munit.FunSuite {
       case Success(results) =>
         assertEquals(
           default.unsafeRunSync(results.run(Sink.collectAll[String])),
-          Success(List("id-1", "id-2", "id-3"))
+          Success(Chunk("id-1", "id-2", "id-3"))
         )
       case failure =>
         fail(s"Query returned failure $failure")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  private val zioVersion = "1.0.0-RC20"
-  private val awsSdkVersion = "1.11.816"
+  private val zioVersion = "1.0.0-RC21-2"
+  private val awsSdkVersion = "1.11.820"
 
   lazy val awsDynamoDb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
   lazy val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.3.13


### PR DESCRIPTION
It looks like the updated version of scalafmt (#115) has slightly different formatting conventions, hence more changes than expected.
