### PR TITLE
Repeat each step in state machine until complete

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -24,7 +24,7 @@ object AmendmentHandler extends CohortHandler {
           .foreach(item => amend(newProductPricing, item).tapBoth(Logging.logFailure(item), Logging.logSuccess(item)))
       itemsToGo <- fetchFromCohortTable
       numItemsToGo <- itemsToGo.take(1).runCount
-    } yield HandlerOutput(cohortSpec, isComplete = numItemsToGo == 0)
+    } yield HandlerOutput(isComplete = numItemsToGo == 0)
 
   private def fetchFromCohortTable = CohortTable.fetch(NotificationSendDateWrittenToSalesforce, None)
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -1,33 +1,37 @@
 package pricemigrationengine.handlers
 
-import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import pricemigrationengine.model.CohortTableFilter.NotificationSendDateWrittenToSalesforce
 import pricemigrationengine.model._
 import pricemigrationengine.services._
 import zio.clock.Clock
-import zio.console.Console
-import zio.{App, ExitCode, Runtime, ZEnv, ZIO, ZLayer}
+import zio.{ZEnv, ZIO, ZLayer}
 
 /**
   * Carries out price-rise amendments in Zuora.
   */
-object AmendmentHandler extends App with RequestHandler[Unit, Unit] {
+object AmendmentHandler extends CohortHandler {
 
-  val main: ZIO[Logging with CohortTable with Zuora with Clock, Failure, Unit] =
+  // TODO: move to config
+  private val batchSize = 100
+
+  def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora with Clock, Failure, HandlerOutput] =
     for {
       newProductPricing <- Zuora.fetchProductCatalogue.map(ZuoraProductCatalogue.productPricingMap)
-      cohortItems <- CohortTable
-        .fetch(NotificationSendDateWrittenToSalesforce, None)
-      _ <- cohortItems.foreach(
-        item =>
-          amend(newProductPricing, item).tapBoth(
-            Logging.logFailure(item),
-            Logging.logSuccess(item)
-        ))
-    } yield ()
+      cohortItems <- fetchFromCohortTable
+      _ <-
+        cohortItems
+          .take(batchSize)
+          .foreach(item => amend(newProductPricing, item).tapBoth(Logging.logFailure(item), Logging.logSuccess(item)))
+      itemsToGo <- fetchFromCohortTable
+      numItemsToGo <- itemsToGo.take(1).runCount
+    } yield HandlerOutput(cohortSpec, isComplete = numItemsToGo == 0)
 
-  private def amend(newProductPricing: ZuoraPricingData,
-                    item: CohortItem): ZIO[CohortTable with Zuora with Clock, Failure, AmendmentResult] =
+  private def fetchFromCohortTable = CohortTable.fetch(NotificationSendDateWrittenToSalesforce, None)
+
+  private def amend(
+      newProductPricing: ZuoraPricingData,
+      item: CohortItem
+  ): ZIO[CohortTable with Zuora with Clock, Failure, AmendmentResult] =
     for {
       result <- doAmendment(newProductPricing, item).foldM(
         failure = {
@@ -44,37 +48,46 @@ object AmendmentHandler extends App with RequestHandler[Unit, Unit] {
       )
     } yield result
 
-  private def doAmendment(newProductPricing: ZuoraPricingData,
-                          item: CohortItem): ZIO[Zuora with Clock, Failure, SuccessfulAmendmentResult] =
+  private def doAmendment(
+      newProductPricing: ZuoraPricingData,
+      item: CohortItem
+  ): ZIO[Zuora with Clock, Failure, SuccessfulAmendmentResult] =
     for {
       startDate <- ZIO.fromOption(item.startDate).orElseFail(AmendmentDataFailure(s"No start date in $item"))
       oldPrice <- ZIO.fromOption(item.oldPrice).orElseFail(AmendmentDataFailure(s"No old price in $item"))
-      estimatedNewPrice <- ZIO
-        .fromOption(item.estimatedNewPrice)
-        .orElseFail(AmendmentDataFailure(s"No estimated new price in $item"))
+      estimatedNewPrice <-
+        ZIO
+          .fromOption(item.estimatedNewPrice)
+          .orElseFail(AmendmentDataFailure(s"No estimated new price in $item"))
       invoicePreviewTargetDate = startDate.plusMonths(13)
       subscriptionBeforeUpdate <- fetchSubscription(item)
-      invoicePreviewBeforeUpdate <- Zuora.fetchInvoicePreview(subscriptionBeforeUpdate.accountId,
-                                                              invoicePreviewTargetDate)
-      update <- ZIO.fromEither(ZuoraSubscriptionUpdate
-        .updateOfRatePlansToCurrent(newProductPricing, subscriptionBeforeUpdate, invoicePreviewBeforeUpdate, startDate))
+      invoicePreviewBeforeUpdate <-
+        Zuora.fetchInvoicePreview(subscriptionBeforeUpdate.accountId, invoicePreviewTargetDate)
+      update <- ZIO.fromEither(
+        ZuoraSubscriptionUpdate
+          .updateOfRatePlansToCurrent(
+            newProductPricing,
+            subscriptionBeforeUpdate,
+            invoicePreviewBeforeUpdate,
+            startDate
+          )
+      )
       newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
       subscriptionAfterUpdate <- fetchSubscription(item)
-      invoicePreviewAfterUpdate <- Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId,
-                                                             invoicePreviewTargetDate)
-      newPrice <- ZIO.fromEither(
-        AmendmentData.totalChargeAmount(subscriptionAfterUpdate, invoicePreviewAfterUpdate, startDate))
+      invoicePreviewAfterUpdate <-
+        Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)
+      newPrice <-
+        ZIO.fromEither(AmendmentData.totalChargeAmount(subscriptionAfterUpdate, invoicePreviewAfterUpdate, startDate))
       whenDone <- Time.thisInstant
-    } yield
-      SuccessfulAmendmentResult(
-        item.subscriptionName,
-        startDate,
-        oldPrice,
-        newPrice,
-        estimatedNewPrice,
-        newSubscriptionId,
-        whenDone
-      )
+    } yield SuccessfulAmendmentResult(
+      item.subscriptionName,
+      startDate,
+      oldPrice,
+      newPrice,
+      estimatedNewPrice,
+      newSubscriptionId,
+      whenDone
+    )
 
   private def fetchSubscription(item: CohortItem): ZIO[Zuora, Failure, ZuoraSubscription] =
     Zuora
@@ -83,7 +96,7 @@ object AmendmentHandler extends App with RequestHandler[Unit, Unit] {
 
   private def env(
       loggingService: Logging.Service
-  ) = {
+  ): ZLayer[Any, ConfigurationFailure, Logging with CohortTable with Zuora] = {
     val loggingLayer = ZLayer.succeed(loggingService)
     val cohortTableLayer =
       loggingLayer ++ EnvConfiguration.dynamoDbImpl >>>
@@ -97,19 +110,6 @@ object AmendmentHandler extends App with RequestHandler[Unit, Unit] {
       .tapError(e => loggingService.error(s"Failed to create service environment: $e"))
   }
 
-  private val runtime = Runtime.default
-
-  def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
-    main
-      .provideCustomLayer(
-        env(ConsoleLogging.service(Console.Service.live))
-      )
-      .exitCode
-
-  def handleRequest(unused: Unit, context: Context): Unit =
-    runtime.unsafeRun(
-      main.provideCustomLayer(
-        env(LambdaLogging.service(context))
-      )
-    )
+  def handle(input: CohortSpec, loggingService: Logging.Service): ZIO[ZEnv, Failure, HandlerOutput] =
+    main(input).provideCustomLayer(env(loggingService))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
@@ -1,0 +1,63 @@
+package pricemigrationengine.handlers
+
+import java.io.{InputStream, OutputStream}
+
+import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
+import pricemigrationengine.model._
+import pricemigrationengine.services._
+import ujson.Readable
+import upickle.default.{read, stream}
+import zio.console.Console
+import zio.{ExitCode, Runtime, ZEnv, ZIO}
+
+/**
+  * A CohortHandler can be run as the handler of an AWS lambda or as a standalone program.
+  */
+trait CohortHandler extends zio.App with RequestStreamHandler {
+
+  /**
+    * Makes implementation available in lambda or console context.
+    *
+    * @param input CohortSpec with specification for the particular cohort that this handler is running over.
+    * @param loggingService Implementation of Logging.Service, which will be context-specific.
+    *                       Eg. if running in a lambda or console.
+    * @return HandlerOutput if successful.
+    */
+  def handle(input: CohortSpec, loggingService: Logging.Service): ZIO[ZEnv, Failure, HandlerOutput]
+
+  private def go(loggingService: Logging.Service, input: Readable): ZIO[ZEnv, Failure, HandlerOutput] =
+    (for {
+      cohortSpec <-
+        ZIO
+          .effect(read[CohortSpec](input))
+          .bimap(e => InputFailure(s"Failed to parse json: $e"), Option(_))
+          .filterOrElse(_.exists(CohortSpec.isValid))(spec => ZIO.fail(InputFailure(s"Invalid cohort spec: $spec")))
+          .tap(spec => loggingService.info(s"Input: $spec"))
+      validSpec <- ZIO.fromOption(cohortSpec).orElseFail(InputFailure("No input"))
+      output <- handle(validSpec, loggingService)
+    } yield output).tapBoth(
+      e => loggingService.error(e.toString),
+      output => loggingService.info(s"Output: $output")
+    )
+
+  final def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] = {
+    val loggingService = ConsoleLogging.service(Console.Service.live)
+    (for {
+      input <-
+        ZIO
+          .fromOption(args.headOption)
+          .orElseFail(InputFailure("No input"))
+          .tapError(e => loggingService.error(e.toString))
+      _ <- go(loggingService, input)
+    } yield ()).exitCode
+  }
+
+  final def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit =
+    Runtime.default.unsafeRun {
+      for {
+        handlerOutput <- go(loggingService = LambdaLogging.service(context), input)
+        writable <- ZIO.effect(stream(handlerOutput))
+        _ <- ZIO.effect(writable.writeBytesTo(output))
+      } yield ()
+    }
+}

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -27,7 +27,7 @@ object EstimationHandler extends CohortHandler {
       _ <- cohortItems.take(batchSize).foreach(estimate(newProductPricing, cohortSpec.earliestPriceMigrationStartDate))
       itemsToGo <- fetchFromCohortTable
       numItemsToGo <- itemsToGo.take(1).runCount
-    } yield HandlerOutput(cohortSpec, isComplete = numItemsToGo == 0)
+    } yield HandlerOutput(isComplete = numItemsToGo == 0)
 
   private def fetchFromCohortTable = CohortTable.fetch(ReadyForEstimation, None)
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -30,7 +30,7 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
           )
       itemsToGo <- fetchFromCohortTable
       numItemsToGo <- itemsToGo.take(1).runCount
-    } yield HandlerOutput(cohortSpec, isComplete = numItemsToGo == 0)
+    } yield HandlerOutput(isComplete = numItemsToGo == 0)
 
   private def fetchFromCohortTable = CohortTable.fetch(AmendmentComplete, None)
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -1,46 +1,59 @@
 package pricemigrationengine.handlers
 
-import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import pricemigrationengine.model.CohortTableFilter.{AmendmentComplete, AmendmentWrittenToSalesforce}
-import pricemigrationengine.model.{CohortItem, Failure, SalesforcePriceRise, SalesforcePriceRiseWriteFailure}
+import pricemigrationengine.model._
 import pricemigrationengine.services._
 import zio.clock.Clock
-import zio.console.Console
-import zio.{ExitCode, IO, Runtime, ZEnv, ZIO, ZLayer}
+import zio.{IO, ZEnv, ZIO, ZLayer}
 
 /**
   * Updates Salesforce with evidence of the price-rise amendment that was applied in Zuora.
   */
-object SalesforceAmendmentUpdateHandler extends zio.App with RequestHandler[Unit, Unit] {
+object SalesforceAmendmentUpdateHandler extends CohortHandler {
 
-  private val main: ZIO[CohortTable with SalesforceClient with Clock with Logging, Failure, Unit] =
+  // TODO: move to config
+  private val batchSize = 1000
+
+  private def main(
+      cohortSpec: CohortSpec
+  ): ZIO[CohortTable with SalesforceClient with Clock with Logging, Failure, HandlerOutput] =
     for {
-      cohortItems <- CohortTable.fetch(AmendmentComplete, None)
-      _ <- cohortItems.foreach(
-        item =>
-          updateSfWithNewSubscriptionId(item).tapBoth(
-            e => Logging.error(s"Failed to update price rise record for ${item.subscriptionName}: $e"),
-            _ => Logging.info(s"Amendment of ${item.subscriptionName} recorded in Salesforce")
-        ))
-    } yield ()
+      cohortItems <- fetchFromCohortTable
+      _ <-
+        cohortItems
+          .take(batchSize)
+          .foreach(item =>
+            updateSfWithNewSubscriptionId(item).tapBoth(
+              e => Logging.error(s"Failed to update price rise record for ${item.subscriptionName}: $e"),
+              _ => Logging.info(s"Amendment of ${item.subscriptionName} recorded in Salesforce")
+            )
+          )
+      itemsToGo <- fetchFromCohortTable
+      numItemsToGo <- itemsToGo.take(1).runCount
+    } yield HandlerOutput(cohortSpec, isComplete = numItemsToGo == 0)
+
+  private def fetchFromCohortTable = CohortTable.fetch(AmendmentComplete, None)
 
   private def updateSfWithNewSubscriptionId(
       item: CohortItem
   ): ZIO[CohortTable with SalesforceClient with Clock with Logging, Failure, Unit] =
     for {
       priceRise <- ZIO.fromEither(buildPriceRise(item))
-      salesforcePriceRiseId <- IO
-        .fromOption(item.salesforcePriceRiseId)
-        .orElseFail(SalesforcePriceRiseWriteFailure("salesforcePriceRiseId is required to update Salesforce"))
+      salesforcePriceRiseId <-
+        IO
+          .fromOption(item.salesforcePriceRiseId)
+          .orElseFail(SalesforcePriceRiseWriteFailure("salesforcePriceRiseId is required to update Salesforce"))
       _ <- SalesforceClient.updatePriceRise(salesforcePriceRiseId, priceRise)
       now <- Time.thisInstant
-      _ <- CohortTable
-        .update(
-          CohortItem(
-            subscriptionName = item.subscriptionName,
-            processingStage = AmendmentWrittenToSalesforce,
-            whenAmendmentWrittenToSalesforce = Some(now)
-          ))
+      _ <-
+        CohortTable
+          .update(
+            CohortItem(
+              subscriptionName = item.subscriptionName,
+              processingStage = AmendmentWrittenToSalesforce,
+              whenAmendmentWrittenToSalesforce = Some(now)
+            )
+          )
     } yield ()
 
   private def buildPriceRise(
@@ -52,7 +65,7 @@ object SalesforceAmendmentUpdateHandler extends zio.App with RequestHandler[Unit
 
   private def env(
       loggingService: Logging.Service
-  ): ZLayer[Any, Any, Logging with CohortTable with SalesforceClient with Clock] = {
+  ): ZLayer[Any, Failure, Logging with CohortTable with SalesforceClient with Clock] = {
     val loggingLayer = ZLayer.succeed(loggingService)
     loggingLayer ++ EnvConfiguration.dynamoDbImpl >>>
       DynamoDBClient.dynamoDB ++ loggingLayer >>>
@@ -61,17 +74,6 @@ object SalesforceAmendmentUpdateHandler extends zio.App with RequestHandler[Unit
         .tapError(e => loggingService.error(s"Failed to create service environment: $e"))
   }
 
-  def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
-    main
-      .provideSomeLayer(
-        env(ConsoleLogging.service(Console.Service.live))
-      )
-      .exitCode
-
-  def handleRequest(unused: Unit, context: Context): Unit =
-    Runtime.default.unsafeRun(
-      main.provideSomeLayer(
-        env(LambdaLogging.service(context))
-      )
-    )
+  def handle(input: CohortSpec, loggingService: Logging.Service): ZIO[ZEnv, Failure, HandlerOutput] =
+    main(input).provideCustomLayer(env(loggingService))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -1,20 +1,27 @@
 package pricemigrationengine.handlers
 
-import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiceCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
 import zio.clock.Clock
-import zio.console.Console
-import zio.{App, ExitCode, IO, Runtime, ZEnv, ZIO, ZLayer}
+import zio.{IO, ZEnv, ZIO, ZLayer}
 
-object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, Unit] {
+object SalesforcePriceRiseCreationHandler extends CohortHandler {
 
-  val main: ZIO[Logging with CohortTable with SalesforceClient with Clock, Failure, Unit] =
+  // TODO: move to config
+  private val batchSize = 1000
+
+  private[handlers] def main(
+      cohortSpec: CohortSpec
+  ): ZIO[Logging with CohortTable with SalesforceClient with Clock, Failure, HandlerOutput] =
     for {
-      cohortItems <- CohortTable.fetch(EstimationComplete, None)
-      _ <- cohortItems.foreach(createSalesforcePriceRise)
-    } yield ()
+      cohortItems <- fetchFromCohortTable
+      _ <- cohortItems.take(batchSize).foreach(createSalesforcePriceRise)
+      itemsToGo <- fetchFromCohortTable
+      numItemsToGo <- itemsToGo.take(1).runCount
+    } yield HandlerOutput(cohortSpec, isComplete = numItemsToGo == 0)
+
+  private def fetchFromCohortTable = CohortTable.fetch(EstimationComplete, None)
 
   private def createSalesforcePriceRise(
       item: CohortItem
@@ -41,16 +48,17 @@ object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, 
     for {
       subscription <- SalesforceClient.getSubscriptionByName(cohortItem.subscriptionName)
       priceRise <- buildPriceRise(cohortItem, subscription)
-      result <- cohortItem.salesforcePriceRiseId
-        .fold(
-          SalesforceClient
-            .createPriceRise(priceRise)
-            .map[Option[String]](response => Some(response.id))
-        ) { priceRiseId =>
-          SalesforceClient
-            .updatePriceRise(priceRiseId, priceRise)
-            .as(None)
-        }
+      result <-
+        cohortItem.salesforcePriceRiseId
+          .fold(
+            SalesforceClient
+              .createPriceRise(priceRise)
+              .map[Option[String]](response => Some(response.id))
+          ) { priceRiseId =>
+            SalesforceClient
+              .updatePriceRise(priceRiseId, priceRise)
+              .as(None)
+          }
     } yield result
   }
 
@@ -59,29 +67,31 @@ object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, 
       subscription: SalesforceSubscription
   ): IO[SalesforcePriceRiseWriteFailure, SalesforcePriceRise] = {
     for {
-      currentPrice <- ZIO
-        .fromOption(cohortItem.oldPrice)
-        .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have an oldPrice"))
-      newPrice <- ZIO
-        .fromOption(cohortItem.estimatedNewPrice)
-        .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have an estimatedNewPrice"))
-      priceRiseDate <- ZIO
-        .fromOption(cohortItem.startDate)
-        .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have a startDate"))
-    } yield
-      SalesforcePriceRise(
-        Some(subscription.Name),
-        Some(subscription.Buyer__c),
-        Some(currentPrice),
-        Some(newPrice),
-        Some(priceRiseDate),
-        Some(subscription.Id)
-      )
+      currentPrice <-
+        ZIO
+          .fromOption(cohortItem.oldPrice)
+          .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have an oldPrice"))
+      newPrice <-
+        ZIO
+          .fromOption(cohortItem.estimatedNewPrice)
+          .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have an estimatedNewPrice"))
+      priceRiseDate <-
+        ZIO
+          .fromOption(cohortItem.startDate)
+          .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have a startDate"))
+    } yield SalesforcePriceRise(
+      Some(subscription.Name),
+      Some(subscription.Buyer__c),
+      Some(currentPrice),
+      Some(newPrice),
+      Some(priceRiseDate),
+      Some(subscription.Id)
+    )
   }
 
   private def env(
       loggingService: Logging.Service
-  ): ZLayer[Any, Any, Logging with CohortTable with SalesforceClient with Clock] = {
+  ): ZLayer[Any, Failure, Logging with CohortTable with SalesforceClient with Clock] = {
     val loggingLayer = ZLayer.succeed(loggingService)
     loggingLayer ++ EnvConfiguration.dynamoDbImpl >>>
       DynamoDBClient.dynamoDB ++ loggingLayer >>>
@@ -90,19 +100,6 @@ object SalesforcePriceRiseCreationHandler extends App with RequestHandler[Unit, 
         .tapError(e => loggingService.error(s"Failed to create service environment: $e"))
   }
 
-  private val runtime = Runtime.default
-
-  def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
-    main
-      .provideSomeLayer(
-        env(ConsoleLogging.service(Console.Service.live))
-      )
-      .exitCode
-
-  def handleRequest(unused: Unit, context: Context): Unit =
-    runtime.unsafeRun(
-      main.provideSomeLayer(
-        env(LambdaLogging.service(context))
-      )
-    )
+  def handle(input: CohortSpec, loggingService: Logging.Service): ZIO[ZEnv, Failure, HandlerOutput] =
+    main(input).provideCustomLayer(env(loggingService))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -19,7 +19,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
       _ <- cohortItems.take(batchSize).foreach(createSalesforcePriceRise)
       itemsToGo <- fetchFromCohortTable
       numItemsToGo <- itemsToGo.take(1).runCount
-    } yield HandlerOutput(cohortSpec, isComplete = numItemsToGo == 0)
+    } yield HandlerOutput(isComplete = numItemsToGo == 0)
 
   private def fetchFromCohortTable = CohortTable.fetch(EstimationComplete, None)
 

--- a/lambda/src/main/scala/pricemigrationengine/model/HandlerOutput.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/HandlerOutput.scala
@@ -9,10 +9,6 @@ import upickle.default.{ReadWriter, macroRW}
   */
 case class HandlerOutput(
     /**
-      * Specification that was the input to the handler.
-      */
-    cohortSpec: CohortSpec,
-    /**
       * True iff the process completed in the time available to the handler.
       */
     isComplete: Boolean

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -29,7 +29,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
   )
 
   private val expectedHandlerOutput = HandlerOutput(
-    isComplete = false
+    isComplete = true
   )
 
   def createStubCohortTable(updatedResultsWrittenToCohortTable: ArrayBuffer[CohortItem], cohortItem: CohortItem) = {

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -29,7 +29,6 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
   )
 
   private val expectedHandlerOutput = HandlerOutput(
-    cohortSpec = stubCohortSpec,
     isComplete = false
   )
 

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -85,6 +85,8 @@ Resources:
                 "Type": "Task",
                 "Comment": "Calculating start date and new price for each sub in this cohort.",
                 "Resource": "${EstimatingLambdaArn}",
+                "InputPath": "$.cohortSpec",
+                "ResultPath": "$.result",
                 "Retry": [
                   {
                     "ErrorEquals": [
@@ -102,7 +104,7 @@ Resources:
                 "Comment": "Is the estimating step complete?",
                 "Choices": [
                 {
-                  "Variable": "$.isComplete",
+                  "Variable": "$.result.isComplete",
                   "BooleanEquals": false,
                   "Next": "Estimating"
                 }
@@ -113,6 +115,8 @@ Resources:
                 "Type": "Task",
                 "Comment": "Inserting a price-rise record for each sub in this cohort into Salesforce.",
                 "Resource": "${CreatingSalesforceRecordsLambdaArn}",
+                "InputPath": "$.cohortSpec",
+                "ResultPath": "$.result",
                 "Retry": [
                   {
                     "ErrorEquals": [
@@ -138,7 +142,7 @@ Resources:
                 "Comment": "Is the creating Salesforce records step complete?",
                 "Choices": [
                 {
-                  "Variable": "$.isComplete",
+                  "Variable": "$.result.isComplete",
                   "BooleanEquals": false,
                   "Next": "CreatingSalesforceRecords"
                 }
@@ -149,6 +153,8 @@ Resources:
                 "Type": "Task",
                 "Comment": "Applying price-rise amendment in Zuora on each sub in this cohort.",
                 "Resource": "${AmendingLambdaArn}",
+                "InputPath": "$.cohortSpec",
+                "ResultPath": "$.result",
                 "Retry": [
                   {
                     "ErrorEquals": [
@@ -174,7 +180,7 @@ Resources:
                 "Comment": "Is the amending step complete?",
                 "Choices": [
                 {
-                  "Variable": "$.isComplete",
+                  "Variable": "$.result.isComplete",
                   "BooleanEquals": false,
                   "Next": "Amending"
                 }
@@ -185,6 +191,8 @@ Resources:
                 "Type": "Task",
                 "Comment": "Updating price-rise record for each sub in this cohort with amendment evidence.",
                 "Resource": "${UpdatingSalesforceWithAmendsLambdaArn}",
+                "InputPath": "$.cohortSpec",
+                "ResultPath": "$.result",
                 "Retry": [
                   {
                     "ErrorEquals": [
@@ -210,7 +218,7 @@ Resources:
                 "Comment": "Is the updating Salesforce with amendments step complete?",
                 "Choices": [
                 {
-                  "Variable": "$.isComplete",
+                  "Variable": "$.result.isComplete",
                   "BooleanEquals": false,
                   "Next": "UpdatingSalesforceWithAmendments"
                 }

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -120,14 +120,6 @@ Resources:
                 "Retry": [
                   {
                     "ErrorEquals": [
-                      "Lambda.Unknown"
-                    ],
-                    "IntervalSeconds": 10,
-                    "MaxAttempts": 25000,
-                    "BackoffRate": 1.0
-                  },
-                  {
-                    "ErrorEquals": [
                       "States.ALL"
                     ],
                     "IntervalSeconds": 30,
@@ -158,14 +150,6 @@ Resources:
                 "Retry": [
                   {
                     "ErrorEquals": [
-                      "Lambda.Unknown"
-                    ],
-                    "IntervalSeconds": 10,
-                    "MaxAttempts": 25000,
-                    "BackoffRate": 1.0
-                  },
-                  {
-                    "ErrorEquals": [
                       "States.ALL"
                     ],
                     "IntervalSeconds": 30,
@@ -194,14 +178,6 @@ Resources:
                 "InputPath": "$.cohortSpec",
                 "ResultPath": "$.result",
                 "Retry": [
-                  {
-                    "ErrorEquals": [
-                      "Lambda.Unknown"
-                    ],
-                    "IntervalSeconds": 10,
-                    "MaxAttempts": 25000,
-                    "BackoffRate": 1.0
-                  },
                   {
                     "ErrorEquals": [
                       "States.ALL"

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -131,7 +131,19 @@ Resources:
                     "BackoffRate": 2.0
                   }
                 ],
-                "Next": "Amending"
+                "Next": "IsCreatingSalesforceRecordsComplete"
+              },
+              "IsCreatingSalesforceRecordsComplete": {
+                "Type": "Choice",
+                "Comment": "Is the creating Salesforce records step complete?",
+                "Choices": [
+                {
+                  "Variable": "$.isComplete",
+                  "BooleanEquals": false,
+                  "Next": "CreatingSalesforceRecords"
+                }
+                ],
+                "Default": "Amending"
               },
               "Amending": {
                 "Type": "Task",
@@ -155,7 +167,19 @@ Resources:
                     "BackoffRate": 2.0
                   }
                 ],
-                "Next": "UpdatingSalesforceWithAmendments"
+                "Next": "IsAmendingComplete"
+              },
+              "IsAmendingComplete": {
+                "Type": "Choice",
+                "Comment": "Is the amending step complete?",
+                "Choices": [
+                {
+                  "Variable": "$.isComplete",
+                  "BooleanEquals": false,
+                  "Next": "Amending"
+                }
+                ],
+                "Default": "UpdatingSalesforceWithAmendments"
               },
               "UpdatingSalesforceWithAmendments": {
                 "Type": "Task",
@@ -179,7 +203,23 @@ Resources:
                     "BackoffRate": 2.0
                   }
                 ],
-                "End": true
+                "Next": "IsUpdatingSalesforceWithAmendmentsComplete"
+              },
+              "IsUpdatingSalesforceWithAmendmentsComplete": {
+                "Type": "Choice",
+                "Comment": "Is the updating Salesforce with amendments step complete?",
+                "Choices": [
+                {
+                  "Variable": "$.isComplete",
+                  "BooleanEquals": false,
+                  "Next": "UpdatingSalesforceWithAmendments"
+                }
+                ],
+                "Default": "Complete"
+              },
+              "Complete": {
+                "Type": "Succeed",
+                "Comment": "All steps are complete."
               }
             }
           }


### PR DESCRIPTION
This gives each step a value to specify if it's complete, which the state machine then uses to decide if to repeat the step.
This is the same as has been done for the `EstimatingLambda` in #120 but for all the other steps.

Also the input is no longer returned as part of the output of the lambdas as that's redundant.  It's passed through by default by the state machine.
See https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultpath.html#input-output-resultpath-append.

The state machine now looks like this:

![stepfunctions_graph](https://user-images.githubusercontent.com/1722550/87299026-2e43f200-c503-11ea-8491-26332063ec76.png)
