### PR TITLE
Increase batch size of Salesforce amendment updates

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -12,7 +12,7 @@ import zio.{IO, ZEnv, ZIO, ZLayer}
 object SalesforceAmendmentUpdateHandler extends CohortHandler {
 
   // TODO: move to config
-  private val batchSize = 1000
+  private val batchSize = 2000
 
   private def main(
       cohortSpec: CohortSpec


### PR DESCRIPTION
We can get through 1000 in about 5 mins so seems safe to try 2000.