### PR TITLE
Find cohort table name in cohort specification

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -14,7 +14,7 @@ object AmendmentHandler extends CohortHandler {
   // TODO: move to config
   private val batchSize = 150
 
-  def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora with Clock, Failure, HandlerOutput] =
+  val main: ZIO[Logging with CohortTable with Zuora with Clock, Failure, HandlerOutput] =
     for {
       newProductPricing <- Zuora.fetchProductCatalogue.map(ZuoraProductCatalogue.productPricingMap)
       cohortItems <- CohortTable.fetch(NotificationSendDateWrittenToSalesforce, None)
@@ -92,6 +92,7 @@ object AmendmentHandler extends CohortHandler {
       .filterOrFail(_.status != "Cancelled")(CancelledSubscriptionFailure(item.subscriptionName))
 
   private def env(
+      cohortSpec: CohortSpec,
       loggingService: Logging.Service
   ): ZLayer[Any, ConfigurationFailure, Logging with CohortTable with Zuora] = {
     val loggingLayer = ZLayer.succeed(loggingService)
@@ -99,7 +100,7 @@ object AmendmentHandler extends CohortHandler {
       loggingLayer ++ EnvConfiguration.dynamoDbImpl >>>
         DynamoDBClient.dynamoDB ++ loggingLayer >>>
         DynamoDBZIOLive.impl ++ loggingLayer ++ EnvConfiguration.cohortTableImp ++ EnvConfiguration.stageImp >>>
-        CohortTableLive.impl
+        CohortTableLive.impl(cohortSpec.tableName)
     val zuoraLayer =
       EnvConfiguration.zuoraImpl ++ loggingLayer >>>
         ZuoraLive.impl
@@ -108,5 +109,5 @@ object AmendmentHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec, loggingService: Logging.Service): ZIO[ZEnv, Failure, HandlerOutput] =
-    main(input).provideCustomLayer(env(loggingService))
+    main.provideCustomLayer(env(input, loggingService))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -105,6 +105,7 @@ object EstimationHandler extends CohortHandler {
   }
 
   private def env(
+      cohortSpec: CohortSpec,
       loggingService: Logging.Service
   ): ZLayer[Any, ConfigurationFailure, Logging with CohortTable with Zuora with Random] = {
     val loggingLayer = ZLayer.succeed(loggingService)
@@ -112,7 +113,7 @@ object EstimationHandler extends CohortHandler {
       loggingLayer ++ EnvConfiguration.dynamoDbImpl andTo
         DynamoDBClient.dynamoDB andTo
         DynamoDBZIOLive.impl ++ loggingLayer ++ EnvConfiguration.cohortTableImp ++ EnvConfiguration.stageImp andTo
-        CohortTableLive.impl
+        CohortTableLive.impl(cohortSpec.tableName)
     val zuoraLayer =
       EnvConfiguration.zuoraImpl ++ loggingLayer >>>
         ZuoraLive.impl
@@ -121,5 +122,5 @@ object EstimationHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec, loggingService: Logging.Service): ZIO[ZEnv, Failure, HandlerOutput] =
-    main(input).provideCustomLayer(env(loggingService))
+    main(input).provideCustomLayer(env(input, loggingService))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -1,16 +1,24 @@
 package pricemigrationengine.handlers
 
-import com.amazonaws.services.lambda.runtime.Context
-import pricemigrationengine.model.CohortTableFilter.{Cancelled, NotificationSendComplete, NotificationSendProcessingOrError, SalesforcePriceRiceCreationComplete}
-import pricemigrationengine.model.membershipworkflow.{EmailMessage, EmailPayload, EmailPayloadContactAttributes, EmailPayloadSubscriberAttributes}
-import pricemigrationengine.model.{CohortItem, CohortTableFilter, EmailSenderFailure, Failure, NotificationHandlerFailure, SalesforceSubscription}
+import pricemigrationengine.model.CohortTableFilter.{
+  Cancelled,
+  NotificationSendComplete,
+  NotificationSendProcessingOrError,
+  SalesforcePriceRiceCreationComplete
+}
+import pricemigrationengine.model._
+import pricemigrationengine.model.membershipworkflow.{
+  EmailMessage,
+  EmailPayload,
+  EmailPayloadContactAttributes,
+  EmailPayloadSubscriberAttributes
+}
 import pricemigrationengine.services._
 import zio.clock.Clock
-import zio.console.Console
-import zio.stream.ZStream
-import zio.{Runtime, ZEnv, ZIO, ZLayer, clock}
+import zio.{ZEnv, ZIO, ZLayer}
 
-object NotificationHandler {
+object NotificationHandler extends CohortHandler {
+
   //Mapping to environment specific braze campaign id is provided by membership-workflow:
   //https://github.com/guardian/membership-workflow/blob/master/conf/PROD.public.conf#L39
   val BrazeCampaignName = "SV_VO_Pricerise_Q22020"
@@ -22,26 +30,28 @@ object NotificationHandler {
 
   private val NotificationLeadTimeDays = 37
 
-  val main: ZIO[Logging with CohortTable with SalesforceClient with Clock with EmailSender, Failure, Unit] = {
+  val main: ZIO[Logging with CohortTable with SalesforceClient with Clock with EmailSender, Failure, HandlerOutput] = {
     for {
       today <- Time.today
       subscriptions <- CohortTable.fetch(
         SalesforcePriceRiceCreationComplete,
         Some(today.plusDays(NotificationLeadTimeDays))
       )
-      count <- subscriptions
-        .mapM(sendNotification)
-        .fold(0) { (sum, count) => sum + count }
-      _ <- Logging.info(s"Successfully sent $count prices rise notifications")
-    } yield ()
+      count <-
+        subscriptions
+          .mapM(sendNotification)
+          .fold(0) { (sum, count) => sum + count }
+      _ <- Logging.info(s"Successfully sent $count price rise notifications")
+    } yield HandlerOutput(isComplete = true)
   }
 
   def sendNotification(
-    cohortItem: CohortItem
+      cohortItem: CohortItem
   ): ZIO[EmailSender with SalesforceClient with CohortTable with Clock with Logging, Failure, Int] = {
     val result = for {
-      sfSubscription <- SalesforceClient
-        .getSubscriptionByName(cohortItem.subscriptionName)
+      sfSubscription <-
+        SalesforceClient
+          .getSubscriptionByName(cohortItem.subscriptionName)
       count <-
         if (sfSubscription.Status__c != Cancelled_Status) {
           sendNotification(cohortItem, sfSubscription)
@@ -58,8 +68,8 @@ object NotificationHandler {
   }
 
   def sendNotification(
-    cohortItem: CohortItem,
-    sfSubscription: SalesforceSubscription
+      cohortItem: CohortItem,
+      sfSubscription: SalesforceSubscription
   ): ZIO[EmailSender with SalesforceClient with CohortTable with Clock with Logging, Failure, Int] =
     for {
       _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
@@ -128,59 +138,49 @@ object NotificationHandler {
   def updateCohortItemStatus(subscriptionNumber: String, processingStage: CohortTableFilter) = {
     for {
       now <- Time.thisInstant
-      _ <- CohortTable
-        .update(
-          CohortItem(
-            subscriptionName = subscriptionNumber,
-            processingStage = processingStage,
-            whenNotificationSent = Some(now)
+      _ <-
+        CohortTable
+          .update(
+            CohortItem(
+              subscriptionName = subscriptionNumber,
+              processingStage = processingStage,
+              whenNotificationSent = Some(now)
+            )
           )
-        )
-        .mapError { error =>
-          NotificationHandlerFailure(s"Failed set status CohortItem $subscriptionNumber to $processingStage: $error")
-        }
+          .mapError { error =>
+            NotificationHandlerFailure(s"Failed set status CohortItem $subscriptionNumber to $processingStage: $error")
+          }
     } yield ()
   }
 
   def putSubIntoCancelledStatus(subscriptionName: String): ZIO[Logging with CohortTable, Failure, Int] =
     for {
-      _ <- CohortTable
-        .update(
-          CohortItem(
-            subscriptionName = subscriptionName,
-            processingStage = Cancelled,
+      _ <-
+        CohortTable
+          .update(
+            CohortItem(
+              subscriptionName = subscriptionName,
+              processingStage = Cancelled
+            )
           )
-        )
       _ <- Logging.error(s"Subscription $subscriptionName has been cancelled, price rise notification not sent")
     } yield 0
 
   private def env(
+      cohortSpec: CohortSpec,
       loggingService: Logging.Service
-  ): ZLayer[Any, Any, Logging with CohortTable with SalesforceClient with Clock with EmailSender] = {
+  ): ZLayer[Any, Failure, Logging with CohortTable with SalesforceClient with Clock with EmailSender] = {
     val loggingLayer = ZLayer.succeed(loggingService)
     val cohortTableLayer =
       loggingLayer ++ EnvConfiguration.dynamoDbImpl >>>
         DynamoDBClient.dynamoDB ++ loggingLayer >>>
         DynamoDBZIOLive.impl ++ loggingLayer ++ EnvConfiguration.cohortTableImp ++
           EnvConfiguration.stageImp ++ EnvConfiguration.salesforceImp ++ EnvConfiguration.emailSenderImp >>>
-        CohortTableLive.impl ++ SalesforceClientLive.impl ++ Clock.live ++ EmailSenderLive.impl
+        CohortTableLive.impl(cohortSpec.tableName) ++ SalesforceClientLive.impl ++ Clock.live ++ EmailSenderLive.impl
     (loggingLayer ++ cohortTableLayer)
       .tapError(e => loggingService.error(s"Failed to create service environment: $e"))
   }
 
-  private val runtime = Runtime.default
-
-  def run(args: List[String]): ZIO[ZEnv, Nothing, Int] =
-    main
-      .provideSomeLayer(
-        env(ConsoleLogging.service(Console.Service.live))
-      )
-      .fold(_ => 1, _ => 0)
-
-  def handleRequest(unused: Unit, context: Context): Unit =
-    runtime.unsafeRun(
-      main.provideSomeLayer(
-        env(LambdaLogging.service(context))
-      )
-    )
+  def handle(input: CohortSpec, loggingService: Logging.Service): ZIO[ZEnv, Failure, HandlerOutput] =
+    main.provideCustomLayer(env(input, loggingService))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
@@ -2,21 +2,20 @@ package pricemigrationengine.handlers
 
 import java.io.{InputStream, InputStreamReader}
 
-import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import org.apache.commons.csv.{CSVFormat, CSVParser}
 import pricemigrationengine.model.CohortTableFilter.ReadyForEstimation
 import pricemigrationengine.model._
 import pricemigrationengine.services._
-import zio.console.Console
 import zio.stream.ZStream
-import zio.{App, ExitCode, IO, Runtime, ZEnv, ZIO, ZLayer}
+import zio.{IO, ZEnv, ZIO, ZLayer}
 
 import scala.jdk.CollectionConverters._
 
-object SubscriptionIdUploadHandler extends App with RequestHandler[Unit, Unit] {
+object SubscriptionIdUploadHandler extends CohortHandler {
+
   private val csvFormat = CSVFormat.DEFAULT.withFirstRecordAsHeader()
 
-  val main: ZIO[CohortTable with Logging with S3 with StageConfiguration, Failure, Unit] = {
+  val main: ZIO[CohortTable with Logging with S3 with StageConfiguration, Failure, HandlerOutput] = {
     for {
       config <- StageConfiguration.stageConfig
       exclusionsManagedStream <- S3.getObject(
@@ -35,7 +34,7 @@ object SubscriptionIdUploadHandler extends App with RequestHandler[Unit, Unit] {
       )
       count <- subscriptionIdsManagedStream.use(stream => writeSubscriptionIdsToCohortTable(stream, exclusions))
       _ <- Logging.info(s"Wrote $count subscription ids to the cohort table")
-    } yield ()
+    } yield HandlerOutput(isComplete = true)
   }
 
   def parseExclusions(inputStream: InputStream): IO[SubscriptionIdUploadFailure, Set[String]] = {
@@ -77,30 +76,20 @@ object SubscriptionIdUploadHandler extends App with RequestHandler[Unit, Unit] {
       .runCount
   }
 
-  private def env(loggingService: Logging.Service) = {
+  private def env(
+      cohortSpec: CohortSpec,
+      loggingService: Logging.Service
+  ): ZLayer[Any, Failure, Logging with CohortTable with S3 with StageConfiguration] = {
     val loggingLayer = ZLayer.succeed(loggingService)
     val cohortTableLayer =
       loggingLayer ++ EnvConfiguration.dynamoDbImpl >>>
         DynamoDBClient.dynamoDB ++ loggingLayer >>>
         DynamoDBZIOLive.impl ++ loggingLayer ++ EnvConfiguration.stageImp ++ EnvConfiguration.cohortTableImp >>>
-        CohortTableLive.impl ++ S3Live.impl ++ EnvConfiguration.stageImp
+        CohortTableLive.impl(cohortSpec.tableName) ++ S3Live.impl ++ EnvConfiguration.stageImp
     (loggingLayer ++ cohortTableLayer)
       .tapError(e => loggingService.error(s"Failed to create service environment: $e"))
   }
 
-  private val runtime = Runtime.default
-
-  def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
-    main
-      .provideSomeLayer(
-        env(ConsoleLogging.service(Console.Service.live))
-      )
-      .exitCode
-
-  def handleRequest(unused: Unit, context: Context): Unit =
-    runtime.unsafeRun(
-      main.provideSomeLayer(
-        env(LambdaLogging.service(context))
-      )
-    )
+  def handle(input: CohortSpec, loggingService: Logging.Service): ZIO[ZEnv, Failure, HandlerOutput] =
+    main.provideCustomLayer(env(input, loggingService))
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -8,17 +8,26 @@ import upickle.default.{ReadWriter, macroRW}
   * Specification of a cohort.
   *
   * @param cohortName Name that uniquely identifies a cohort, eg. "Vouchers 2020"
+  * @param importStartDate Date on which to start importing data from the source S3 bucket.
   * @param earliestPriceMigrationStartDate Earliest date on which any sub in the cohort can have price migrated.
   *                                        The actual date for any sub will depend on its billing dates.
-  * @param importStartDate Date on which to start importing data from the source S3 bucket.
   * @param migrationCompleteDate Date on which the final step in the price migration was complete for every sub in the cohort.
+  *
+  * @param tmpTableName A temporary value for the special case where
+  *                     the table name can't be derived from the cohort name.
   */
 case class CohortSpec(
     cohortName: String,
-    earliestPriceMigrationStartDate: LocalDate,
     importStartDate: LocalDate,
-    migrationCompleteDate: Option[LocalDate]
-)
+    earliestPriceMigrationStartDate: LocalDate,
+    migrationCompleteDate: Option[LocalDate],
+    tmpTableName: Option[String] = None // TODO: remove when price migration 2020 complete
+) {
+  val tableName: String = tmpTableName getOrElse {
+    val transformed = cohortName.replaceAll("[^A-Za-z0-9-_]", "")
+    s"PriceRise-$transformed"
+  }
+}
 
 object CohortSpec {
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -15,15 +15,15 @@ import scala.collection.mutable.ArrayBuffer
 
 class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
   val expectedSubscriptionName = "Sub-0001"
-  val expectedWhenEmailSentDate = LocalDate.of(2020,3,23)
+  val expectedWhenEmailSentDate = LocalDate.of(2020, 3, 23)
   val expectedPriceRiseId = "price-rise-id"
 
-  def createStubCohortTable(updatedResultsWrittenToCohortTable:ArrayBuffer[CohortItem], cohortItem: CohortItem) = {
+  def createStubCohortTable(updatedResultsWrittenToCohortTable: ArrayBuffer[CohortItem], cohortItem: CohortItem) = {
     ZLayer.succeed(
       new CohortTable.Service {
         override def fetch(
-          filter: CohortTableFilter,
-          beforeDateInclusive: Option[LocalDate]
+            filter: CohortTableFilter,
+            beforeDateInclusive: Option[LocalDate]
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
           assertEquals(filter, NotificationSendComplete)
           IO.succeed(ZStream(cohortItem))
@@ -40,7 +40,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
   }
 
   private def stubSFClient(
-    updatedPriceRises: ArrayBuffer[SalesforcePriceRise]
+      updatedPriceRises: ArrayBuffer[SalesforcePriceRise]
   ) = {
     ZLayer.succeed(
       new SalesforceClient.Service {
@@ -53,7 +53,8 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
         ): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResponse] = ???
 
         override def updatePriceRise(
-            priceRiseId: String, priceRise: SalesforcePriceRise
+            priceRiseId: String,
+            priceRise: SalesforcePriceRise
         ): IO[SalesforceClientFailure, Unit] = {
           updatedPriceRises.addOne(priceRise)
           ZIO.unit
@@ -87,7 +88,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
             TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ StubClock.clock
           )
       ),
-      Success(())
+      Success(HandlerOutput(isComplete = true))
     )
 
     assertEquals(updatedPriceRises.size, 1)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -21,13 +21,6 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
   val expectedOldPrice = BigDecimal(11.11)
   val expectedEstimatedNewPrice = BigDecimal(22.22)
 
-  private val stubCohortSpec = CohortSpec(
-    cohortName = "cohortName",
-    earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1),
-    importStartDate = LocalDate.of(2020, 1, 1),
-    migrationCompleteDate = None
-  )
-
   private val expectedHandlerOutput = HandlerOutput(
     isComplete = true
   )
@@ -115,8 +108,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        SalesforcePriceRiseCreationHandler
-          .main(stubCohortSpec)
+        SalesforcePriceRiseCreationHandler.main
           .provideLayer(
             TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ StubClock.clock
           )
@@ -175,8 +167,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        SalesforcePriceRiseCreationHandler
-          .main(stubCohortSpec)
+        SalesforcePriceRiseCreationHandler.main
           .provideLayer(
             TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ StubClock.clock
           )

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -33,10 +33,9 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
         override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] =
           IO.effect {
-              subscriptionsWrittenToCohortTable.addOne(cohortItem)
-              ()
-            }
-            .orElseFail(CohortUpdateFailure(""))
+            subscriptionsWrittenToCohortTable.addOne(cohortItem)
+            ()
+          }.orElseFail(CohortUpdateFailure(""))
       }
     )
 
@@ -50,12 +49,13 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
             .mapError(ex => S3Failure(s"Failed to load test resource: $ex"))
         }
 
-        override def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream] = s3Location match {
-          case S3Location("price-migration-engine-dev", "excluded-subscription-ids.csv") =>
-            loadTestResource("/SubscriptionExclusions.csv")
-          case S3Location("price-migration-engine-dev", "salesforce-subscription-id-report.csv") =>
-            loadTestResource("/SubscriptionIds.csv")
-        }
+        override def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream] =
+          s3Location match {
+            case S3Location("price-migration-engine-dev", "excluded-subscription-ids.csv") =>
+              loadTestResource("/SubscriptionExclusions.csv")
+            case S3Location("price-migration-engine-dev", "salesforce-subscription-id-report.csv") =>
+              loadTestResource("/SubscriptionIds.csv")
+          }
       }
     )
 
@@ -66,7 +66,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
             TestLogging.logging ++ stubConfiguration ++ stubCohortTable ++ stubS3
           )
       ),
-      Success(())
+      Success(HandlerOutput(isComplete = true))
     )
     assertEquals(subscriptionsWrittenToCohortTable.size, 2)
     assertEquals(subscriptionsWrittenToCohortTable(0).subscriptionName, "A-S123456")

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -10,11 +10,12 @@ class CohortSpecTest extends munit.FunSuite {
   private def isActive(onDay: LocalDate, migrationComplete: Option[LocalDate] = Some(migrationCompleteDate)) =
     CohortSpec.isActive(
       CohortSpec(
-        "name",
-        LocalDate.of(2021, 1, 1),
+        cohortName = "name",
         importStartDate,
+        earliestPriceMigrationStartDate = LocalDate.of(2021, 1, 1),
         migrationComplete
-      ))(onDay)
+      )
+    )(onDay)
 
   test("isActive: should be false when given date is before import start date") {
     assertEquals(isActive(importStartDate.minusDays(3)), false)
@@ -38,5 +39,27 @@ class CohortSpecTest extends munit.FunSuite {
 
   test("isActive: should be true when given date is after import start date and migration isn't complete") {
     assertEquals(isActive(importStartDate.plusDays(3), migrationComplete = None), true)
+  }
+
+  test("tableName: should be tmpTableName field value when present") {
+    val cohortSpec = CohortSpec(
+      cohortName = "name",
+      importStartDate = LocalDate.of(2020, 1, 1),
+      earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1),
+      migrationCompleteDate = None,
+      tmpTableName = Some("givenName")
+    )
+    assertEquals(cohortSpec.tableName, "givenName")
+  }
+
+  test("tableName: should be transformed cohort name when tmpTableName field value not present") {
+    val cohortSpec = CohortSpec(
+      cohortName = "Home Delivery 2018",
+      importStartDate = LocalDate.of(2020, 1, 1),
+      earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1),
+      migrationCompleteDate = None,
+      tmpTableName = None
+    )
+    assertEquals(cohortSpec.tableName, "PriceRise-HomeDelivery2018")
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -14,6 +14,9 @@ import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 class CohortTableLiveTest extends munit.FunSuite {
+
+  private val tableNameFixture = "PriceMigrationEngineDEV"
+
   val stubCohortTableConfiguration = ZLayer.succeed(
     new CohortTableConfiguration.Service {
       override val config: IO[ConfigurationFailure, CohortTableConfig] =
@@ -36,16 +39,15 @@ class CohortTableLiveTest extends munit.FunSuite {
   val expectedNewPrice = Random.nextDouble()
   val expectedEstimatedNewPrice = Random.nextDouble()
   val expectedBillingPeriod = "Monthly"
-  val expectedWhenEstimationDone =  Instant.ofEpochMilli(Random.nextLong())
+  val expectedWhenEstimationDone = Instant.ofEpochMilli(Random.nextLong())
   val expectedPriceRiseId = "price-rise-id"
-  val expectedSfShowEstimate =  Instant.ofEpochMilli(Random.nextLong())
+  val expectedSfShowEstimate = Instant.ofEpochMilli(Random.nextLong())
   val expectedNewSubscriptionId = "new-sub-id"
   val expectedWhenAmendmentDone = Instant.ofEpochMilli(Random.nextLong())
   val expectedWhenNotificationSent = Instant.ofEpochMilli(Random.nextLong())
   val expectedWhenNotificationSentWrittenToSalesforce = Instant.ofEpochMilli(Random.nextLong())
   val item1 = CohortItem("subscription-1", ReadyForEstimation)
   val item2 = CohortItem("subscription-2", ReadyForEstimation)
-
 
   test("Query the PriceMigrationEngine with the correct filter and parse the results") {
     var receivedRequest: Option[QueryRequest] = None
@@ -61,13 +63,13 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZStream(item1, item2).mapM(item => IO.effect(item.asInstanceOf[A]).orElseFail(DynamoDBZIOError("")))
         }
 
-        override def update[A, B](table: String, key: A, value: B)(
-            implicit keySerializer: DynamoDBSerialiser[A],
+        override def update[A, B](table: String, key: A, value: B)(implicit
+            keySerializer: DynamoDBSerialiser[A],
             valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String, value: A)(
-            implicit valueSerializer: DynamoDBSerialiser[A]
+        override def put[A](table: String, value: A)(implicit
+            valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = ???
       }
     )
@@ -75,12 +77,13 @@ class CohortTableLiveTest extends munit.FunSuite {
     assertEquals(
       Runtime.default.unsafeRunSync(
         for {
-          result <- CohortTable
-            .fetch(ReadyForEstimation, None)
-            .provideLayer(
-              stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
-                CohortTableLive.impl
-            )
+          result <-
+            CohortTable
+              .fetch(ReadyForEstimation, None)
+              .provideLayer(
+                stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
+                  CohortTableLive.impl(tableNameFixture)
+              )
           resultList <- result.run(Sink.collectAll[CohortItem])
           _ = assertEquals(resultList, List(item1, item2))
         } yield ()
@@ -88,7 +91,7 @@ class CohortTableLiveTest extends munit.FunSuite {
       Success(())
     )
 
-    assertEquals(receivedRequest.get.getTableName, "PriceMigrationEngineDEV")
+    assertEquals(receivedRequest.get.getTableName, tableNameFixture)
     assertEquals(receivedRequest.get.getIndexName, "ProcessingStageIndexV2")
     assertEquals(receivedRequest.get.getKeyConditionExpression, "processingStage = :processingStage")
     assertEquals(
@@ -115,12 +118,13 @@ class CohortTableLiveTest extends munit.FunSuite {
             "whenAmendmentDone" -> new AttributeValue().withS(formatTimestamp(expectedWhenAmendmentDone)),
             "whenNotificationSent" -> new AttributeValue().withS(formatTimestamp(expectedWhenNotificationSent)),
             "whenNotificationSentWrittenToSalesforce" ->
-              new AttributeValue().withS(formatTimestamp(expectedWhenNotificationSentWrittenToSalesforce)),
+              new AttributeValue().withS(formatTimestamp(expectedWhenNotificationSentWrittenToSalesforce))
           ).asJava
         )
       ),
       Success(
-        CohortItem(subscriptionName = expectedSubscriptionId,
+        CohortItem(
+          subscriptionName = expectedSubscriptionId,
           processingStage = expectedProcessingStage,
           startDate = Some(expectedStartDate),
           currency = Some(expectedCurrency),
@@ -134,7 +138,7 @@ class CohortTableLiveTest extends munit.FunSuite {
           newSubscriptionId = Some(expectedNewSubscriptionId),
           whenAmendmentDone = Some(expectedWhenAmendmentDone),
           whenNotificationSent = Some(expectedWhenNotificationSent),
-          whenNotificationSentWrittenToSalesforce = Some(expectedWhenNotificationSentWrittenToSalesforce),
+          whenNotificationSentWrittenToSalesforce = Some(expectedWhenNotificationSentWrittenToSalesforce)
         )
       )
     )
@@ -153,13 +157,13 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZStream(item1).mapM(item => IO.effect(item.asInstanceOf[A]).orElseFail(DynamoDBZIOError("")))
         }
 
-        override def update[A, B](table: String, key: A, value: B)(
-            implicit keySerializer: DynamoDBSerialiser[A],
+        override def update[A, B](table: String, key: A, value: B)(implicit
+            keySerializer: DynamoDBSerialiser[A],
             valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String, value: A)(
-            implicit valueSerializer: DynamoDBSerialiser[A]
+        override def put[A](table: String, value: A)(implicit
+            valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = ???
       }
     )
@@ -167,12 +171,13 @@ class CohortTableLiveTest extends munit.FunSuite {
     assertEquals(
       Runtime.default.unsafeRunSync(
         for {
-          result <- CohortTable
-            .fetch(ReadyForEstimation, Some(expectedLatestDate))
-            .provideLayer(
-              stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
-                CohortTableLive.impl
-            )
+          result <-
+            CohortTable
+              .fetch(ReadyForEstimation, Some(expectedLatestDate))
+              .provideLayer(
+                stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
+                  CohortTableLive.impl(tableNameFixture)
+              )
           resultList <- result.run(Sink.collectAll[CohortItem])
           _ = assertEquals(resultList, List(item1))
         } yield ()
@@ -180,9 +185,12 @@ class CohortTableLiveTest extends munit.FunSuite {
       Success(())
     )
 
-    assertEquals(receivedRequest.get.getTableName, "PriceMigrationEngineDEV")
+    assertEquals(receivedRequest.get.getTableName, tableNameFixture)
     assertEquals(receivedRequest.get.getIndexName, "ProcessingStageStartDateIndexV1")
-    assertEquals(receivedRequest.get.getKeyConditionExpression, "processingStage = :processingStage AND startDate <= :latestStartDateInclusive")
+    assertEquals(
+      receivedRequest.get.getKeyConditionExpression,
+      "processingStage = :processingStage AND startDate <= :latestStartDateInclusive"
+    )
     assertEquals(
       receivedRequest.get.getExpressionAttributeValues,
       Map(
@@ -201,12 +209,12 @@ class CohortTableLiveTest extends munit.FunSuite {
 
     val stubDynamoDBZIO = ZLayer.succeed(
       new DynamoDBZIO.Service {
-        override def query[A](query: QueryRequest)(
-            implicit deserializer: DynamoDBDeserialiser[A]
+        override def query[A](query: QueryRequest)(implicit
+            deserializer: DynamoDBDeserialiser[A]
         ): ZStream[Any, DynamoDBZIOError, A] = ???
 
-        override def update[A, B](table: String, key: A, value: B)(
-            implicit keySerializer: DynamoDBSerialiser[A],
+        override def update[A, B](table: String, key: A, value: B)(implicit
+            keySerializer: DynamoDBSerialiser[A],
             valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = {
           tableUpdated = Some(table)
@@ -217,12 +225,11 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def put[A](table: String, value: A)(
-            implicit valueSerializer: DynamoDBSerialiser[A]
+        override def put[A](table: String, value: A)(implicit
+            valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = ???
       }
     )
-
 
     val cohortItem = CohortItem(
       subscriptionName = expectedSubscriptionId,
@@ -248,13 +255,13 @@ class CohortTableLiveTest extends munit.FunSuite {
           .update(cohortItem)
           .provideLayer(
             stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
-              CohortTableLive.impl
+              CohortTableLive.impl(tableNameFixture)
           )
       ),
       Success(())
     )
 
-    assertEquals(tableUpdated.get, "PriceMigrationEngineDEV")
+    assertEquals(tableUpdated.get, tableNameFixture)
     assertEquals(receivedKey.get.subscriptionNumber, expectedSubscriptionId)
     assertEquals(
       receivedKeySerialiser.get.serialise(receivedKey.get),
@@ -356,12 +363,12 @@ class CohortTableLiveTest extends munit.FunSuite {
 
     val stubDynamoDBZIO = ZLayer.succeed(
       new DynamoDBZIO.Service {
-        override def query[A](query: QueryRequest)(
-            implicit deserializer: DynamoDBDeserialiser[A]
+        override def query[A](query: QueryRequest)(implicit
+            deserializer: DynamoDBDeserialiser[A]
         ): ZStream[Any, DynamoDBZIOError, A] = ???
 
-        override def update[A, B](table: String, key: A, value: B)(
-            implicit keySerializer: DynamoDBSerialiser[A],
+        override def update[A, B](table: String, key: A, value: B)(implicit
+            keySerializer: DynamoDBSerialiser[A],
             valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = {
           receivedValueSerialiser = Some(valueSerializer.asInstanceOf[DynamoDBUpdateSerialiser[CohortItem]])
@@ -369,8 +376,8 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def put[A](table: String, value: A)(
-            implicit valueSerializer: DynamoDBSerialiser[A]
+        override def put[A](table: String, value: A)(implicit
+            valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = ???
       }
     )
@@ -389,7 +396,7 @@ class CohortTableLiveTest extends munit.FunSuite {
           .update(cohortItem)
           .provideLayer(
             stubStageConfiguration ++ stubCohortTableConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
-              CohortTableLive.impl
+              CohortTableLive.impl(tableNameFixture)
           )
       ),
       Success(())
@@ -420,17 +427,17 @@ class CohortTableLiveTest extends munit.FunSuite {
 
     val stubDynamoDBZIO = ZLayer.succeed(
       new DynamoDBZIO.Service {
-        override def query[A](query: QueryRequest)(
-            implicit deserializer: DynamoDBDeserialiser[A]
+        override def query[A](query: QueryRequest)(implicit
+            deserializer: DynamoDBDeserialiser[A]
         ): ZStream[Any, DynamoDBZIOError, A] = ???
 
-        override def update[A, B](table: String, key: A, value: B)(
-            implicit keySerializer: DynamoDBSerialiser[A],
+        override def update[A, B](table: String, key: A, value: B)(implicit
+            keySerializer: DynamoDBSerialiser[A],
             valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String, value: A)(
-            implicit valueSerializer: DynamoDBSerialiser[A]
+        override def put[A](table: String, value: A)(implicit
+            valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = {
           tableUpdated = Some(table)
           receivedInsert = Some(value.asInstanceOf[CohortItem])
@@ -448,13 +455,13 @@ class CohortTableLiveTest extends munit.FunSuite {
           .put(cohortItem)
           .provideLayer(
             stubStageConfiguration ++ stubCohortTableConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
-              CohortTableLive.impl
+              CohortTableLive.impl(tableNameFixture)
           )
       ),
       Success(())
     )
 
-    assertEquals(tableUpdated.get, "PriceMigrationEngineDEV")
+    assertEquals(tableUpdated.get, tableNameFixture)
     val insert = receivedSerialiser.get.serialise(receivedInsert.get)
     assertEquals(insert.get("subscriptionNumber"), new AttributeValue().withS("Subscription-id"))
     assertEquals(insert.get("processingStage"), new AttributeValue().withS("ReadyForEstimation"))


### PR DESCRIPTION
This removes hardcoded references to the current price migration so that the engine is capable of running any future migration.

The [table name](https://github.com/guardian/price-migration-engine/compare/kc-table-name?expand=1#diff-c726d67550dea8510c75c93bc9014cd3R26-R29) is now a field of the `CohortSpec`. So multiple state machines can run over different cohorts.

By default the table name is derived from the cohort name.  If the cohort is called `Home Delivery 2018`, for example, the table will be expected to be called `PriceRise-HomeDelivery2018`.  This is independent of stage as non-prod stages will have their own test names for cohorts.  The cohort table is designed to be a disposable resource, put up at the start of the price rise and taken down at the end.
