### PR TITLE
Retry calls to fetch invoice preview after updating subscription

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -3,7 +3,9 @@ package pricemigrationengine.handlers
 import pricemigrationengine.model.CohortTableFilter.NotificationSendDateWrittenToSalesforce
 import pricemigrationengine.model._
 import pricemigrationengine.services._
+import zio.Schedule.{exponential, recurs}
 import zio.clock.Clock
+import zio.duration._
 import zio.{ZEnv, ZIO, ZLayer}
 
 /**
@@ -72,7 +74,9 @@ object AmendmentHandler extends CohortHandler {
       newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
       subscriptionAfterUpdate <- fetchSubscription(item)
       invoicePreviewAfterUpdate <-
-        Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)
+        Zuora
+          .fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)
+          .retry(exponential(1.second) && recurs(5)) // to work around StaleObjectStateException in Zuora response
       newPrice <-
         ZIO.fromEither(AmendmentData.totalChargeAmount(subscriptionAfterUpdate, invoicePreviewAfterUpdate, startDate))
       whenDone <- Time.thisInstant


### PR DESCRIPTION
The call to fetch the invoice preview after updating a subscription occasionally fails with a `StaleObjectStateException`.
This should attempt it up to 5 times with an exponential backoff.
