### PR TITLE
New lambda to create cohort table

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
@@ -43,9 +43,15 @@ trait CohortHandler extends zio.App with RequestStreamHandler {
 
   final def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
     (for {
-      input <- ZIO.fromOption(args.headOption).orElseFail(InputFailure("No input"))
-      _ <- go(input).provideCustomLayer(ConsoleLogging.impl)
-    } yield ()).exitCode
+      input <-
+        ZIO
+          .fromOption(args.headOption)
+          .orElseFail(InputFailure("No input"))
+          .tapError(e => Logging.error(e.toString))
+      _ <- go(input)
+    } yield ())
+      .provideCustomLayer(ConsoleLogging.impl)
+      .exitCode
 
   final def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit =
     Runtime.default.unsafeRun {

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableCreationHandler.scala
@@ -1,0 +1,30 @@
+package pricemigrationengine.handlers
+
+import pricemigrationengine.model.{CohortSpec, ConfigurationFailure, Failure, HandlerOutput}
+import pricemigrationengine.services.{CohortTableDdl, Logging}
+import zio.{ZEnv, ZIO, ZLayer}
+
+/**
+  * Creates a new CohortTable if it doesn't already exist.
+  */
+object CohortTableCreationHandler extends CohortHandler {
+
+  def main(tableName: String): ZIO[CohortTableDdl with Logging, Failure, HandlerOutput] =
+    CohortTableDdl
+      .createTable(tableName)
+      .tapBoth(
+        e => Logging.error(s"Failed to create table '$tableName': $e"),
+        {
+          case None         => Logging.info(s"No action. Table '$tableName' already exists.")
+          case Some(result) => Logging.info(s"Created table '$tableName': $result")
+        }
+      )
+      .as(HandlerOutput(isComplete = true))
+
+  private val env: ZLayer[Logging, ConfigurationFailure, CohortTableDdl with Logging] =
+    (LiveLayer.cohortTableDdl and LiveLayer.logging)
+      .tapError(e => Logging.error(s"Failed to create service environment: $e"))
+
+  def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =
+    main(input.tableName).provideSomeLayer[ZEnv with Logging](env)
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -25,7 +25,7 @@ case class CohortSpec(
 ) {
   val tableName: String = tmpTableName getOrElse {
     val transformed = cohortName.replaceAll("[^A-Za-z0-9-_]", "")
-    s"PriceRise-$transformed"
+    s"PriceMigration-$transformed"
   }
 }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -14,6 +14,7 @@ case class CohortStateMachineFailure(reason: String) extends Failure
 case class CohortSpecFetchFailure(reason: String) extends Failure
 case class CohortSpecUpdateFailure(reason: String) extends Failure
 
+case class CohortTableCreateFailure(reason: String) extends Failure
 case class CohortFetchFailure(reason: String) extends Failure
 case class CohortUpdateFailure(reason: String) extends Failure
 

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdl.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdl.scala
@@ -1,0 +1,24 @@
+package pricemigrationengine.services
+
+import com.amazonaws.services.dynamodbv2.model.CreateTableResult
+import pricemigrationengine.model.CohortTableCreateFailure
+import zio.{IO, ZIO}
+
+object CohortTableDdl {
+
+  /**
+    * Service to run DDL statements on CohortTables.
+    * Creation and dropping, etc.
+    */
+  trait Service {
+
+    /**
+      * Create a table if it doesn't already exist.
+      * Otherwise do nothing.
+      */
+    def createTable(tableName: String): IO[CohortTableCreateFailure, Option[CreateTableResult]]
+  }
+
+  def createTable(tableName: String): ZIO[CohortTableDdl, CohortTableCreateFailure, Option[CreateTableResult]] =
+    ZIO.accessM(_.get.createTable(tableName))
+}

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdlLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdlLive.scala
@@ -1,0 +1,82 @@
+package pricemigrationengine.services
+
+import com.amazonaws.services.dynamodbv2.model.BillingMode.PAY_PER_REQUEST
+import com.amazonaws.services.dynamodbv2.model.KeyType.{HASH, RANGE}
+import com.amazonaws.services.dynamodbv2.model.ProjectionType.ALL
+import com.amazonaws.services.dynamodbv2.model._
+import pricemigrationengine.model.CohortTableCreateFailure
+import zio.Schedule.{exponential, recurs}
+import zio.{ZIO, ZLayer}
+import zio.clock.Clock
+import zio.duration._
+
+object CohortTableDdlLive {
+
+  private val partitionKey = "subscriptionNumber"
+
+  private val stageIndex = "ProcessingStageIndexV2"
+  private val stageAndStartDateIndex = "ProcessingStageStartDateIndexV1"
+
+  private val stageAttribute = "processingStage"
+  private val startDateAttribute = "startDate"
+
+  private val stringType = "S"
+
+  val impl: ZLayer[DynamoDBClient with Clock with Logging, Nothing, CohortTableDdl] =
+    ZLayer.fromFunction { modules: DynamoDBClient with Clock with Logging => tableName =>
+      {
+
+        val create: ZIO[DynamoDBClient, CohortTableCreateFailure, CreateTableResult] = {
+          val createRequest = new CreateTableRequest()
+            .withTableName(tableName)
+            .withKeySchema(new KeySchemaElement().withAttributeName(partitionKey).withKeyType(HASH))
+            .withAttributeDefinitions(
+              new AttributeDefinition().withAttributeName(partitionKey).withAttributeType(stringType),
+              new AttributeDefinition().withAttributeName(stageAttribute).withAttributeType(stringType),
+              new AttributeDefinition().withAttributeName(startDateAttribute).withAttributeType(stringType)
+            )
+            .withGlobalSecondaryIndexes(
+              new GlobalSecondaryIndex()
+                .withIndexName(stageIndex)
+                .withKeySchema(new KeySchemaElement().withAttributeName(stageAttribute).withKeyType(HASH))
+                .withProjection(new Projection().withProjectionType(ALL)),
+              new GlobalSecondaryIndex()
+                .withIndexName(stageAndStartDateIndex)
+                .withKeySchema(
+                  new KeySchemaElement().withAttributeName(stageAttribute).withKeyType(HASH),
+                  new KeySchemaElement().withAttributeName(startDateAttribute).withKeyType(RANGE)
+                )
+                .withProjection(new Projection().withProjectionType(ALL))
+            )
+            .withBillingMode(PAY_PER_REQUEST)
+
+          DynamoDBClient.createTable(createRequest).mapError(e => CohortTableCreateFailure(e.toString))
+        }
+
+        val enableContinuousBackups
+            : ZIO[DynamoDBClient with Logging with Clock, CohortTableCreateFailure, UpdateContinuousBackupsResult] = {
+          val enableBackups =
+            new UpdateContinuousBackupsRequest()
+              .withTableName(tableName)
+              .withPointInTimeRecoverySpecification(
+                new PointInTimeRecoverySpecification().withPointInTimeRecoveryEnabled(true)
+              )
+
+          val result = DynamoDBClient
+            .updateContinuousBackups(enableBackups)
+            .tapError(_ => Logging.info(s"Waiting to enable continuous backups ..."))
+            .retry(
+              exponential(1.second) && recurs(10)
+            ) // have to wait for table to be created before enabling backups
+
+          result.mapError(e => CohortTableCreateFailure(e.toString))
+        }
+
+        for {
+          // if table can be described, it must already exist and therefore not need to be created
+          result <- DynamoDBClient.describeTable(tableName).foldM(_ => create.map(Some(_)), _ => ZIO.none)
+          _ <- enableContinuousBackups
+        } yield result
+      }.provide(modules)
+    }
+}

--- a/lambda/src/main/scala/pricemigrationengine/services/package.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/package.scala
@@ -16,6 +16,7 @@ package object services {
   type CohortStateMachine = Has[CohortStateMachine.Service]
   type CohortSpecTable = Has[CohortSpecTable.Service]
   type CohortTable = Has[CohortTable.Service]
+  type CohortTableDdl = Has[CohortTableDdl.Service]
   type Zuora = Has[Zuora.Service]
   type Logging = Has[Logging.Service]
   type DynamoDBClient = Has[AmazonDynamoDB]

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -60,6 +60,6 @@ class CohortSpecTest extends munit.FunSuite {
       migrationCompleteDate = None,
       tmpTableName = None
     )
-    assertEquals(cohortSpec.tableName, "PriceRise-HomeDelivery2018")
+    assertEquals(cohortSpec.tableName, "PriceMigration-HomeDelivery2018")
   }
 }


### PR DESCRIPTION
This [handler](https://github.com/guardian/price-migration-engine/compare/kc-table-create?expand=1#diff-6d8b626deca57a029f2deeb5590af029R10-R30) will create a new cohort table if it doesn't already exist, which will be the first step in the orchestration engine.

There's a new service called [CohortTableDdl](https://github.com/guardian/price-migration-engine/compare/kc-table-create?expand=1#diff-986ffb33603216f628553ef1f1fa6aa7R7-R24) which deals with data-definition-language queries on tables.  I thought this was better than trying to shoehorn it into the `CohortTable.Service`.  So one service is for queries on a particular table and the other is for tables in general.
