### PR TITLE
Configure lambda that kicks off state machines

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
@@ -6,23 +6,28 @@ import com.amazonaws.regions.Regions.EU_WEST_1
 import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder
 import com.amazonaws.services.stepfunctions.model.{StartExecutionRequest, StartExecutionResult}
 import pricemigrationengine.model._
-import upickle.default.write
+import upickle.default.{ReadWriter, macroRW, write}
 import zio.blocking.Blocking
 import zio.{IO, ZLayer}
 
 object CohortStateMachineLive {
 
+  private case class StateMachineInput(cohortSpec: CohortSpec)
+  private implicit val rw: ReadWriter[StateMachineInput] = macroRW
+
   val impl
-    : ZLayer[CohortStateMachineConfiguration with Logging with Blocking, ConfigurationFailure, CohortStateMachine] = {
+      : ZLayer[CohortStateMachineConfiguration with Logging with Blocking, ConfigurationFailure, CohortStateMachine] = {
 
     val stateMachine = AWSStepFunctionsClientBuilder.standard.withRegion(EU_WEST_1).build
 
-    ZLayer.fromServicesM[CohortStateMachineConfiguration.Service,
-                         Logging.Service,
-                         Blocking.Service,
-                         Any,
-                         ConfigurationFailure,
-                         CohortStateMachine.Service] { (configuration, logging, blocking) =>
+    ZLayer.fromServicesM[
+      CohortStateMachineConfiguration.Service,
+      Logging.Service,
+      Blocking.Service,
+      Any,
+      ConfigurationFailure,
+      CohortStateMachine.Service
+    ] { (configuration, logging, blocking) =>
       configuration.config map { config =>
         new CohortStateMachine.Service {
           def startExecution(date: LocalDate)(spec: CohortSpec): IO[CohortStateMachineFailure, StartExecutionResult] =
@@ -32,7 +37,9 @@ object CohortStateMachineLive {
                   new StartExecutionRequest()
                     .withStateMachineArn(config.stateMachineArn)
                     .withName(s"${spec.cohortName}-$date")
-                    .withInput(write(spec))))
+                    .withInput(write(StateMachineInput(spec)))
+                )
+              )
               .mapError(e => CohortStateMachineFailure(s"Failed to start execution: $e"))
               .tap(result => logging.info(s"Started execution: $result"))
         }

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -60,6 +60,73 @@ Resources:
                 Resource:
                   - "*"
 
+  PriceMigrationLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: LambdaPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/price-migration-lambda-${Stage}:log-stream:*"
+        - PolicyName: CohortSpecTablePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/price-migration-engine-cohort-spec-${Stage}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/price-migration-engine-cohort-spec-${Stage}/*"
+        - PolicyName: CohortStateMachinePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - states:StartExecution
+                Resource:
+                  - !Ref CohortStateMachine
+
+  PriceMigrationLambda:
+    Type: AWS::Lambda::Function
+    DependsOn:
+      - PriceMigrationLambdaRole
+      - CohortStateMachine
+    Properties:
+      Description: Kicks off state machines to process each cohort.
+      FunctionName:
+        !Sub price-migration-lambda-${Stage}
+      Code:
+        S3Bucket: membership-dist
+        S3Key: !Sub membership/${Stage}/price-migration-engine-lambda/price-migration-engine-lambda.jar
+      Handler: pricemigrationengine.handlers.MigrationHandler::handleRequest
+      Environment:
+        Variables:
+          stage: !Ref Stage
+          cohortStateMachineArn: !Ref CohortStateMachine
+      Role:
+        Fn::GetAtt:
+          - PriceMigrationLambdaRole
+          - Arn
+      MemorySize: 1536
+      Runtime: java8
+      Timeout: 900
+
   CohortStateMachine:
     Type: AWS::StepFunctions::StateMachine
     DependsOn:


### PR DESCRIPTION
This configures [the lambda that checks for active cohorts and kicks off their processing](https://github.com/guardian/price-migration-engine/blob/master/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala).

I've put the configuration for this lambda in [the state machine stack](https://github.com/guardian/price-migration-engine/blob/master/stateMachine/cfn/cfn.yaml) because it works at a higher level than all the other lambdas.  The others work specifically on a single cohort whereas this one looks for cohorts and delegates them to a state machine.  If I didn't do this I would also have to export a reference to the state machine and create a circular dependency between the state machine stack and the lambda stack.
