### PR TITLE
Use tmpTableName field for cohort table if present

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
@@ -5,12 +5,13 @@ import java.time.format.DateTimeFormatter
 
 import com.amazonaws.regions.Regions.EU_WEST_1
 import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder
-import com.amazonaws.services.stepfunctions.model.StartExecutionRequest
+import com.amazonaws.services.stepfunctions.model.{StartExecutionRequest, StartExecutionResult}
 import pricemigrationengine.handlers.Time
 import pricemigrationengine.model._
 import upickle.default.{ReadWriter, macroRW, write}
-import zio.{ZIO, ZLayer}
 import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.{ZIO, ZLayer}
 
 object CohortStateMachineLive {
 
@@ -30,26 +31,32 @@ object CohortStateMachineLive {
       ConfigurationFailure,
       CohortStateMachine.Service
     ] { (configuration, logging, blocking) =>
-      configuration.config map { config => spec =>
-        for {
-          time <- Time.thisInstant.mapError(e => CohortStateMachineFailure(e.toString))
-          timeStr <-
-            ZIO
-              .effect(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm").withZone(ZoneId.systemDefault).format(time))
-              .mapError(e => CohortStateMachineFailure(e.toString))
-          result <-
-            blocking
-              .effectBlocking(
-                stateMachine.startExecution(
-                  new StartExecutionRequest()
-                    .withStateMachineArn(config.stateMachineArn)
-                    .withName(s"${spec.normalisedCohortName}-$timeStr")
-                    .withInput(write(StateMachineInput(spec)))
-                )
-              )
-              .mapError(e => CohortStateMachineFailure(s"Failed to start execution: $e"))
-              .tap(result => logging.info(s"Started execution: $result"))
-        } yield result
+      configuration.config map { config =>
+        //noinspection ConvertExpressionToSAM
+        new CohortStateMachine.Service {
+
+          def startExecution(spec: CohortSpec): ZIO[Clock, CohortStateMachineFailure, StartExecutionResult] =
+            for {
+              _ <- logging.info(s"Starting execution with input: ${spec.toString} ...")
+              time <- Time.thisInstant.mapError(e => CohortStateMachineFailure(e.toString))
+              timeStr <-
+                ZIO
+                  .effect(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm").withZone(ZoneId.systemDefault).format(time))
+                  .mapError(e => CohortStateMachineFailure(e.toString))
+              result <-
+                blocking
+                  .effectBlocking(
+                    stateMachine.startExecution(
+                      new StartExecutionRequest()
+                        .withStateMachineArn(config.stateMachineArn)
+                        .withName(s"${spec.normalisedCohortName}-$timeStr")
+                        .withInput(write(StateMachineInput(spec)))
+                    )
+                  )
+                  .mapError(e => CohortStateMachineFailure(s"Failed to start execution: $e"))
+                  .tap(result => logging.info(s"Started execution: $result"))
+            } yield result
+        }
       }
     }
   }

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -2,6 +2,10 @@ package pricemigrationengine.model
 
 import java.time.LocalDate
 
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+
+import scala.jdk.CollectionConverters._
+
 class CohortSpecTest extends munit.FunSuite {
 
   private val importStartDate = LocalDate.of(2020, 5, 1)
@@ -61,5 +65,27 @@ class CohortSpecTest extends munit.FunSuite {
       tmpTableName = None
     )
     assertEquals(cohortSpec.tableName, "PriceMigration-HomeDelivery2018")
+  }
+
+  test("fromDynamoDbItem: should include all fields") {
+    val item = Map(
+      "cohortName" -> new AttributeValue().withS("Home Delivery 2018"),
+      "importStartDate" -> new AttributeValue().withS("2020-01-01"),
+      "earliestPriceMigrationStartDate" -> new AttributeValue().withS("2020-01-01"),
+      "tmpTableName" -> new AttributeValue().withS("tmpName")
+    ).asJava
+    val cohortSpec = CohortSpec.fromDynamoDbItem(item)
+    assertEquals(
+      cohortSpec,
+      Right(
+        CohortSpec(
+          cohortName = "Home Delivery 2018",
+          importStartDate = LocalDate.of(2020, 1, 1),
+          earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1),
+          migrationCompleteDate = None,
+          tmpTableName = Some("tmpName")
+        )
+      )
+    )
   }
 }


### PR DESCRIPTION
I'd missed out the `tmpTableName` field in the parsing of the DynamoDB item [here](https://github.com/guardian/price-migration-engine/blob/master/lambda/src/main/scala/pricemigrationengine/services/CohortSpecTableLive.scala#L16-L30).
