### PR TITLE
Give lambdas access to all cohort tables

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -40,8 +40,8 @@ Resources:
               - dynamodb:UpdateItem
               - dynamodb:PutItem
             Resource:
-              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigrationEngine${Stage}"
-              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigrationEngine${Stage}/*"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigration*"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigration*/*"
       Roles:
         - Ref: PriceMigrationEngineEstimationLambdaRole
         - Ref: PriceMigrationEngineSalesforcePriceCreationLambdaRole

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -40,8 +40,10 @@ Resources:
               - dynamodb:UpdateItem
               - dynamodb:PutItem
             Resource:
-              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigration*"
-              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigration*/*"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigrationEngine${Stage}"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigrationEngine${Stage}/*"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigration-${Stage}-*"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/PriceMigration-${Stage}-*/*"
       Roles:
         - Ref: PriceMigrationEngineEstimationLambdaRole
         - Ref: PriceMigrationEngineSalesforcePriceCreationLambdaRole

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -95,12 +95,9 @@ object AmendmentHandler extends CohortHandler {
       .fetchSubscription(item.subscriptionName)
       .filterOrFail(_.status != "Cancelled")(CancelledSubscriptionFailure(item.subscriptionName))
 
-  private def env(
-      cohortSpec: CohortSpec
-  ): ZLayer[Logging, ConfigurationFailure, CohortTable with Zuora with Logging] = {
-    (LiveLayer.cohortTable(cohortSpec.tableName) and LiveLayer.zuora and LiveLayer.logging)
+  private def env(cohortSpec: CohortSpec): ZLayer[Logging, ConfigurationFailure, CohortTable with Zuora with Logging] =
+    (LiveLayer.cohortTable(cohortSpec) and LiveLayer.zuora and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
-  }
 
   def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =
     main.provideSomeLayer[ZEnv with Logging](env(input))

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableCreationHandler.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.model.{CohortSpec, ConfigurationFailure, Failure, HandlerOutput}
-import pricemigrationengine.services.{CohortTableDdl, Logging}
+import pricemigrationengine.services.{CohortTableDdl, EnvConfiguration, Logging, StageConfiguration}
 import zio.{ZEnv, ZIO, ZLayer}
 
 /**
@@ -9,14 +9,14 @@ import zio.{ZEnv, ZIO, ZLayer}
   */
 object CohortTableCreationHandler extends CohortHandler {
 
-  def main(tableName: String): ZIO[CohortTableDdl with Logging, Failure, HandlerOutput] =
+  def main(cohortSpec: CohortSpec): ZIO[CohortTableDdl with Logging, Failure, HandlerOutput] =
     CohortTableDdl
-      .createTable(tableName)
+      .createTable(cohortSpec)
       .tapBoth(
-        e => Logging.error(s"Failed to create table '$tableName': $e"),
+        e => Logging.error(s"Failed to create table for $cohortSpec: $e"),
         {
-          case None         => Logging.info(s"No action. Table '$tableName' already exists.")
-          case Some(result) => Logging.info(s"Created table '$tableName': $result")
+          case None         => Logging.info(s"No action. Table for $cohortSpec already exists.")
+          case Some(result) => Logging.info(s"Created table: $result")
         }
       )
       .as(HandlerOutput(isComplete = true))
@@ -26,5 +26,5 @@ object CohortTableCreationHandler extends CohortHandler {
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
   def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =
-    main(input.tableName).provideSomeLayer[ZEnv with Logging](env)
+    main(input).provideSomeLayer[ZEnv with Logging](env)
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -105,7 +105,7 @@ object EstimationHandler extends CohortHandler {
   }
 
   private def env(cohortSpec: CohortSpec): ZLayer[Logging, ConfigurationFailure, CohortTable with Zuora with Logging] =
-    (LiveLayer.cohortTable(cohortSpec.tableName) and LiveLayer.zuora and LiveLayer.logging)
+    (LiveLayer.cohortTable(cohortSpec) and LiveLayer.zuora and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
   def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =

--- a/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.model.{ConfigurationFailure, EmailSenderFailure, SalesforceClientFailure}
+import pricemigrationengine.model.{CohortSpec, ConfigurationFailure, EmailSenderFailure, SalesforceClientFailure}
 import pricemigrationengine.services._
 import zio.blocking.Blocking
 import zio.clock.Clock
@@ -13,13 +13,13 @@ object LiveLayer {
   private val dynamoDbClient: ZLayer[Logging, ConfigurationFailure, DynamoDBClient] =
     EnvConfiguration.dynamoDbImpl and logging to DynamoDBClient.dynamoDB
 
-  def cohortTable(tableName: String): ZLayer[Logging, ConfigurationFailure, CohortTable] =
-    dynamoDbClient and logging to
-      DynamoDBZIOLive.impl and EnvConfiguration.cohortTableImp and EnvConfiguration.stageImp and logging to
-      CohortTableLive.impl(tableName)
+  def cohortTable(cohortSpec: CohortSpec): ZLayer[Logging, ConfigurationFailure, CohortTable] =
+    dynamoDbClient and logging andTo
+      DynamoDBZIOLive.impl and EnvConfiguration.cohortTableImp and EnvConfiguration.stageImp to
+      CohortTableLive.impl(cohortSpec)
 
   val cohortTableDdl: ZLayer[Logging, ConfigurationFailure, CohortTableDdl] =
-    Clock.live and dynamoDbClient and logging to CohortTableDdlLive.impl
+    Clock.live and dynamoDbClient and EnvConfiguration.stageImp and logging to CohortTableDdlLive.impl
 
   val cohortSpecTable: ZLayer[Logging, ConfigurationFailure, CohortSpecTable] =
     dynamoDbClient and EnvConfiguration.stageImp and logging to CohortSpecTableLive.impl

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -180,8 +180,7 @@ object NotificationHandler extends CohortHandler {
   private def env(
       cohortSpec: CohortSpec
   ): ZLayer[Logging, Failure, CohortTable with SalesforceClient with EmailSender with Logging] =
-    (LiveLayer.cohortTable(cohortSpec.tableName) and LiveLayer.salesforce and LiveLayer.emailSender and ZLayer
-      .identity[Logging])
+    (LiveLayer.cohortTable(cohortSpec) and LiveLayer.salesforce and LiveLayer.emailSender and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
   def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -59,7 +59,7 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
       .toRight(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have a newSubscriptionId field"))
 
   private def env(cohortSpec: CohortSpec): ZLayer[Logging, Failure, CohortTable with SalesforceClient with Logging] =
-    (LiveLayer.cohortTable(cohortSpec.tableName) and LiveLayer.salesforce and LiveLayer.logging)
+    (LiveLayer.cohortTable(cohortSpec) and LiveLayer.salesforce and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
   def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
@@ -70,7 +70,7 @@ object SalesforceNotificationDateUpdateHandler extends CohortHandler {
   }
 
   private def env(cohortSpec: CohortSpec): ZLayer[Logging, Failure, CohortTable with SalesforceClient with Logging] =
-    (LiveLayer.cohortTable(cohortSpec.tableName) and LiveLayer.salesforce and LiveLayer.logging)
+    (LiveLayer.cohortTable(cohortSpec) and LiveLayer.salesforce and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
   def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -84,7 +84,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
   }
 
   private def env(cohortSpec: CohortSpec): ZLayer[Logging, Failure, CohortTable with SalesforceClient with Logging] =
-    (LiveLayer.cohortTable(cohortSpec.tableName) and LiveLayer.salesforce and LiveLayer.logging)
+    (LiveLayer.cohortTable(cohortSpec) and LiveLayer.salesforce and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
   def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
@@ -79,7 +79,7 @@ object SubscriptionIdUploadHandler extends CohortHandler {
   private def env(
       cohortSpec: CohortSpec
   ): ZLayer[Logging, Failure, CohortTable with S3 with StageConfiguration with Logging] =
-    (LiveLayer.cohortTable(cohortSpec.tableName) and LiveLayer.s3 and EnvConfiguration.stageImp and LiveLayer.logging)
+    (LiveLayer.cohortTable(cohortSpec) and LiveLayer.s3 and EnvConfiguration.stageImp and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
   def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -24,7 +24,7 @@ case class CohortSpec(
     tmpTableName: Option[String] = None // TODO: remove when price migration 2020 complete
 ) {
   val normalisedCohortName: String = cohortName.replaceAll("[^A-Za-z0-9-_]", "")
-  val tableName: String = tmpTableName getOrElse s"PriceMigration-$normalisedCohortName"
+  def tableName(stage: String): String = tmpTableName getOrElse s"PriceMigration-$stage-$normalisedCohortName"
 }
 
 object CohortSpec {

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
@@ -5,16 +5,18 @@ import java.time.format.DateTimeFormatter
 
 import com.amazonaws.regions.Regions.EU_WEST_1
 import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder
-import com.amazonaws.services.stepfunctions.model.StartExecutionRequest
+import com.amazonaws.services.stepfunctions.model.{StartExecutionRequest, StartExecutionResult}
 import pricemigrationengine.handlers.Time
 import pricemigrationengine.model._
 import upickle.default.{ReadWriter, macroRW, write}
-import zio.{ZIO, ZLayer}
 import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.{ZIO, ZLayer}
 
 object CohortStateMachineLive {
 
   private case class StateMachineInput(cohortSpec: CohortSpec)
+
   private implicit val rw: ReadWriter[StateMachineInput] = macroRW
 
   val impl
@@ -30,26 +32,32 @@ object CohortStateMachineLive {
       ConfigurationFailure,
       CohortStateMachine.Service
     ] { (configuration, logging, blocking) =>
-      configuration.config map { config => spec =>
-        for {
-          time <- Time.thisInstant.mapError(e => CohortStateMachineFailure(e.toString))
-          timeStr <-
-            ZIO
-              .effect(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm").withZone(ZoneId.systemDefault).format(time))
-              .mapError(e => CohortStateMachineFailure(e.toString))
-          result <-
-            blocking
-              .effectBlocking(
-                stateMachine.startExecution(
-                  new StartExecutionRequest()
-                    .withStateMachineArn(config.stateMachineArn)
-                    .withName(s"${spec.normalisedCohortName}-$timeStr")
-                    .withInput(write(StateMachineInput(spec)))
-                )
-              )
-              .mapError(e => CohortStateMachineFailure(s"Failed to start execution: $e"))
-              .tap(result => logging.info(s"Started execution: $result"))
-        } yield result
+      configuration.config map { config =>
+        //noinspection ConvertExpressionToSAM
+        new CohortStateMachine.Service {
+
+          def startExecution(spec: CohortSpec): ZIO[Clock, CohortStateMachineFailure, StartExecutionResult] =
+            for {
+              _ <- logging.info(s"Starting execution with input: ${spec.toString} ...")
+              time <- Time.thisInstant.mapError(e => CohortStateMachineFailure(e.toString))
+              timeStr <-
+                ZIO
+                  .effect(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm").withZone(ZoneId.systemDefault).format(time))
+                  .mapError(e => CohortStateMachineFailure(e.toString))
+              result <-
+                blocking
+                  .effectBlocking(
+                    stateMachine.startExecution(
+                      new StartExecutionRequest()
+                        .withStateMachineArn(config.stateMachineArn)
+                        .withName(s"${spec.normalisedCohortName}-$timeStr")
+                        .withInput(write(StateMachineInput(spec)))
+                    )
+                  )
+                  .mapError(e => CohortStateMachineFailure(s"Failed to start execution: $e"))
+                  .tap(result => logging.info(s"Started execution: $result"))
+            } yield result
+        }
       }
     }
   }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdl.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdl.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.services
 
 import com.amazonaws.services.dynamodbv2.model.CreateTableResult
-import pricemigrationengine.model.CohortTableCreateFailure
+import pricemigrationengine.model.{CohortSpec, CohortTableCreateFailure}
 import zio.{IO, ZIO}
 
 object CohortTableDdl {
@@ -13,12 +13,12 @@ object CohortTableDdl {
   trait Service {
 
     /**
-      * Create a table if it doesn't already exist.
+      * Create a table for the given CohortSpec if it doesn't already exist.
       * Otherwise do nothing.
       */
-    def createTable(tableName: String): IO[CohortTableCreateFailure, Option[CreateTableResult]]
+    def createTable(cohortSpec: CohortSpec): IO[CohortTableCreateFailure, Option[CreateTableResult]]
   }
 
-  def createTable(tableName: String): ZIO[CohortTableDdl, CohortTableCreateFailure, Option[CreateTableResult]] =
-    ZIO.accessM(_.get.createTable(tableName))
+  def createTable(cohortSpec: CohortSpec): ZIO[CohortTableDdl, CohortTableCreateFailure, Option[CreateTableResult]] =
+    ZIO.accessM(_.get.createTable(cohortSpec))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdlLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdlLive.scala
@@ -4,11 +4,11 @@ import com.amazonaws.services.dynamodbv2.model.BillingMode.PAY_PER_REQUEST
 import com.amazonaws.services.dynamodbv2.model.KeyType.{HASH, RANGE}
 import com.amazonaws.services.dynamodbv2.model.ProjectionType.ALL
 import com.amazonaws.services.dynamodbv2.model._
-import pricemigrationengine.model.CohortTableCreateFailure
+import pricemigrationengine.model.{CohortSpec, CohortTableCreateFailure, ConfigurationFailure}
 import zio.Schedule.{exponential, recurs}
-import zio.{ZIO, ZLayer}
 import zio.clock.Clock
 import zio.duration._
+import zio.{IO, ZIO, ZLayer}
 
 object CohortTableDdlLive {
 
@@ -22,61 +22,73 @@ object CohortTableDdlLive {
 
   private val stringType = "S"
 
-  val impl: ZLayer[DynamoDBClient with Clock with Logging, Nothing, CohortTableDdl] =
-    ZLayer.fromFunction { modules: DynamoDBClient with Clock with Logging => tableName =>
-      {
-
-        val create: ZIO[DynamoDBClient, CohortTableCreateFailure, CreateTableResult] = {
-          val createRequest = new CreateTableRequest()
-            .withTableName(tableName)
-            .withKeySchema(new KeySchemaElement().withAttributeName(partitionKey).withKeyType(HASH))
-            .withAttributeDefinitions(
-              new AttributeDefinition().withAttributeName(partitionKey).withAttributeType(stringType),
-              new AttributeDefinition().withAttributeName(stageAttribute).withAttributeType(stringType),
-              new AttributeDefinition().withAttributeName(startDateAttribute).withAttributeType(stringType)
-            )
-            .withGlobalSecondaryIndexes(
-              new GlobalSecondaryIndex()
-                .withIndexName(stageIndex)
-                .withKeySchema(new KeySchemaElement().withAttributeName(stageAttribute).withKeyType(HASH))
-                .withProjection(new Projection().withProjectionType(ALL)),
-              new GlobalSecondaryIndex()
-                .withIndexName(stageAndStartDateIndex)
-                .withKeySchema(
-                  new KeySchemaElement().withAttributeName(stageAttribute).withKeyType(HASH),
-                  new KeySchemaElement().withAttributeName(startDateAttribute).withKeyType(RANGE)
-                )
-                .withProjection(new Projection().withProjectionType(ALL))
-            )
-            .withBillingMode(PAY_PER_REQUEST)
-
-          DynamoDBClient.createTable(createRequest).mapError(e => CohortTableCreateFailure(e.toString))
-        }
-
-        val enableContinuousBackups
-            : ZIO[DynamoDBClient with Logging with Clock, CohortTableCreateFailure, UpdateContinuousBackupsResult] = {
-          val enableBackups =
-            new UpdateContinuousBackupsRequest()
+  val impl
+      : ZLayer[DynamoDBClient with StageConfiguration with Clock with Logging, ConfigurationFailure, CohortTableDdl] =
+    ZLayer.fromFunctionM { modules: DynamoDBClient with StageConfiguration with Clock with Logging =>
+      StageConfiguration.stageConfig
+        .map { stageConfig =>
+          def create(tableName: String): ZIO[DynamoDBClient, CohortTableCreateFailure, CreateTableResult] = {
+            val createRequest = new CreateTableRequest()
               .withTableName(tableName)
-              .withPointInTimeRecoverySpecification(
-                new PointInTimeRecoverySpecification().withPointInTimeRecoveryEnabled(true)
+              .withKeySchema(new KeySchemaElement().withAttributeName(partitionKey).withKeyType(HASH))
+              .withAttributeDefinitions(
+                new AttributeDefinition().withAttributeName(partitionKey).withAttributeType(stringType),
+                new AttributeDefinition().withAttributeName(stageAttribute).withAttributeType(stringType),
+                new AttributeDefinition().withAttributeName(startDateAttribute).withAttributeType(stringType)
               )
+              .withGlobalSecondaryIndexes(
+                new GlobalSecondaryIndex()
+                  .withIndexName(stageIndex)
+                  .withKeySchema(new KeySchemaElement().withAttributeName(stageAttribute).withKeyType(HASH))
+                  .withProjection(new Projection().withProjectionType(ALL)),
+                new GlobalSecondaryIndex()
+                  .withIndexName(stageAndStartDateIndex)
+                  .withKeySchema(
+                    new KeySchemaElement().withAttributeName(stageAttribute).withKeyType(HASH),
+                    new KeySchemaElement().withAttributeName(startDateAttribute).withKeyType(RANGE)
+                  )
+                  .withProjection(new Projection().withProjectionType(ALL))
+              )
+              .withBillingMode(PAY_PER_REQUEST)
 
-          val result = DynamoDBClient
-            .updateContinuousBackups(enableBackups)
-            .tapError(_ => Logging.info(s"Waiting to enable continuous backups ..."))
-            .retry(
-              exponential(1.second) && recurs(8)
-            ) // have to wait for table to be created before enabling backups
+            DynamoDBClient.createTable(createRequest).mapError(e => CohortTableCreateFailure(e.toString))
+          }
 
-          result.mapError(e => CohortTableCreateFailure(e.toString))
+          def enableContinuousBackups(tableName: String): ZIO[
+            DynamoDBClient with Logging with Clock,
+            CohortTableCreateFailure,
+            UpdateContinuousBackupsResult
+          ] = {
+            val enableBackups =
+              new UpdateContinuousBackupsRequest()
+                .withTableName(tableName)
+                .withPointInTimeRecoverySpecification(
+                  new PointInTimeRecoverySpecification().withPointInTimeRecoveryEnabled(true)
+                )
+
+            val result = DynamoDBClient
+              .updateContinuousBackups(enableBackups)
+              .tapError(_ => Logging.info(s"Waiting to enable continuous backups ..."))
+              .retry(
+                exponential(1.second) && recurs(8)
+              ) // have to wait for table to be created before enabling backups
+
+            result.mapError(e => CohortTableCreateFailure(e.toString))
+          }
+
+          //noinspection ConvertExpressionToSAM
+          new CohortTableDdl.Service {
+            def createTable(cohortSpec: CohortSpec): IO[CohortTableCreateFailure, Option[CreateTableResult]] = {
+              val tableName = cohortSpec.tableName(stageConfig.stage)
+              (for {
+                // if table can be described, it must already exist and therefore not need to be created
+                result <-
+                  DynamoDBClient.describeTable(tableName).foldM(_ => create(tableName).map(Some(_)), _ => ZIO.none)
+                _ <- enableContinuousBackups(tableName)
+              } yield result).provide(modules)
+            }
+          }
         }
-
-        for {
-          // if table can be described, it must already exist and therefore not need to be created
-          result <- DynamoDBClient.describeTable(tableName).foldM(_ => create.map(Some(_)), _ => ZIO.none)
-          _ <- enableContinuousBackups
-        } yield result
-      }.provide(modules)
+        .provide(modules)
     }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -5,7 +5,6 @@ import java.time.LocalDate
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, QueryRequest}
 import pricemigrationengine.model._
 import pricemigrationengine.model.dynamodb.Conversions._
-import pricemigrationengine.services.CohortTable.Service
 import zio.stream.ZStream
 import zio.{IO, ZIO, ZLayer}
 
@@ -107,70 +106,78 @@ object CohortTableLive {
         stringUpdate("processingStage", cohortItem.processingStage.value)
       ).asJava
 
-  def impl(
-      tableName: String
-  ): ZLayer[DynamoDBZIO with StageConfiguration with CohortTableConfiguration with Logging, Nothing, CohortTable] =
-    ZLayer.fromFunction {
+  def impl(cohortSpec: CohortSpec): ZLayer[
+    DynamoDBZIO with StageConfiguration with CohortTableConfiguration with Logging,
+    ConfigurationFailure,
+    CohortTable
+  ] = {
+    ZLayer.fromFunctionM {
       dependencies: DynamoDBZIO with StageConfiguration with CohortTableConfiguration with Logging =>
-        new Service {
-          override def fetch(
-              filter: CohortTableFilter,
-              latestStartDateInclusive: Option[LocalDate]
-          ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
-            for {
-              cohortTableConfig <-
-                CohortTableConfiguration.cohortTableConfig
-                  .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
-              indexName =
-                latestStartDateInclusive
-                  .fold(ProcessingStageIndexName)(_ => ProcessingStageAndStartDateIndexName)
-              queryRequest = new QueryRequest()
-                .withTableName(tableName)
-                .withIndexName(indexName)
-                .withKeyConditionExpression(
-                  "processingStage = :processingStage" + latestStartDateInclusive.fold("") { _ =>
-                    " AND startDate <= :latestStartDateInclusive"
-                  }
-                )
-                .withExpressionAttributeValues(
-                  List(
-                    Some(":processingStage" -> new AttributeValue(filter.value)),
-                    latestStartDateInclusive.map { latestStartDateInclusive =>
-                      ":latestStartDateInclusive" -> new AttributeValue(latestStartDateInclusive.toString)
-                    }
-                  ).flatten.toMap.asJava
-                )
-                .withLimit(cohortTableConfig.batchSize)
-              queryResults <-
-                DynamoDBZIO
-                  .query(
-                    queryRequest
+        StageConfiguration.stageConfig
+          .map(config => cohortSpec.tableName(config.stage))
+          .map { tableName =>
+            new CohortTable.Service {
+              override def fetch(
+                  filter: CohortTableFilter,
+                  latestStartDateInclusive: Option[LocalDate]
+              ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
+                for {
+                  cohortTableConfig <-
+                    CohortTableConfiguration.cohortTableConfig
+                      .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
+                  indexName =
+                    latestStartDateInclusive
+                      .fold(ProcessingStageIndexName)(_ => ProcessingStageAndStartDateIndexName)
+                  queryRequest = new QueryRequest()
+                    .withTableName(tableName)
+                    .withIndexName(indexName)
+                    .withKeyConditionExpression(
+                      "processingStage = :processingStage" + latestStartDateInclusive.fold("") { _ =>
+                        " AND startDate <= :latestStartDateInclusive"
+                      }
+                    )
+                    .withExpressionAttributeValues(
+                      List(
+                        Some(":processingStage" -> new AttributeValue(filter.value)),
+                        latestStartDateInclusive.map { latestStartDateInclusive =>
+                          ":latestStartDateInclusive" -> new AttributeValue(latestStartDateInclusive.toString)
+                        }
+                      ).flatten.toMap.asJava
+                    )
+                    .withLimit(cohortTableConfig.batchSize)
+                  queryResults <-
+                    DynamoDBZIO
+                      .query(
+                        queryRequest
+                      )
+                      .map(_.mapError(error => CohortFetchFailure(error.toString)))
+                } yield queryResults
+              }.provide(dependencies)
+
+              override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
+                for {
+                  result <-
+                    DynamoDBZIO
+                      .put(table = tableName, value = cohortItem)
+                      .mapError(error => CohortUpdateFailure(error.toString))
+                } yield result
+              }.provide(dependencies)
+
+              override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
+                (for {
+                  result <-
+                    DynamoDBZIO
+                      .update(table = tableName, key = CohortTableKey(result.subscriptionName), value = result)
+                      .mapError(error => CohortUpdateFailure(error.toString))
+                } yield result)
+                  .tapBoth(
+                    e => Logging.error(s"Failed to update Cohort table: $e"),
+                    _ => Logging.info(s"Wrote $result to Cohort table")
                   )
-                  .map(_.mapError(error => CohortFetchFailure(error.toString)))
-            } yield queryResults
-          }.provide(dependencies)
-
-          override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
-            for {
-              result <-
-                DynamoDBZIO
-                  .put(table = tableName, value = cohortItem)
-                  .mapError(error => CohortUpdateFailure(error.toString))
-            } yield result
-          }.provide(dependencies)
-
-          override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
-            (for {
-              result <-
-                DynamoDBZIO
-                  .update(table = tableName, key = CohortTableKey(result.subscriptionName), value = result)
-                  .mapError(error => CohortUpdateFailure(error.toString))
-            } yield result)
-              .tapBoth(
-                e => Logging.error(s"Failed to update Cohort table: $e"),
-                _ => Logging.info(s"Wrote $result to Cohort table")
-              )
-          }.provide(dependencies)
-        }
+              }.provide(dependencies)
+            }
+          }
+          .provide(dependencies)
     }
+  }
 }

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -49,7 +49,7 @@ class CohortSpecTest extends munit.FunSuite {
       migrationCompleteDate = None,
       tmpTableName = Some("givenName")
     )
-    assertEquals(cohortSpec.tableName, "givenName")
+    assertEquals(cohortSpec.tableName(stage = "DEV"), "givenName")
   }
 
   test("tableName: should be transformed cohort name when tmpTableName field value not present") {
@@ -60,6 +60,6 @@ class CohortSpecTest extends munit.FunSuite {
       migrationCompleteDate = None,
       tmpTableName = None
     )
-    assertEquals(cohortSpec.tableName, "PriceMigration-HomeDelivery2018")
+    assertEquals(cohortSpec.tableName(stage = "PROD"), "PriceMigration-PROD-HomeDelivery2018")
   }
 }


### PR DESCRIPTION
There are two changes here:
* [permissions to access all cohort tables](https://github.com/guardian/price-migration-engine/compare/kc-perms?expand=1#diff-367b63a358fded148863253f23ab34b0R45-R46)
* [cohort table names are stage-specific](https://github.com/guardian/price-migration-engine/compare/kc-perms?expand=1#diff-c726d67550dea8510c75c93bc9014cd3R27) to avoid cross-stage collisions

There are changes to the two places where table names are referred to, in the implementation of [CohortTableDdl](https://github.com/guardian/price-migration-engine/compare/kc-perms?expand=1#diff-15ce2f172646831236137c0be3a80abbR28-R29) and the implementation of [CohortTable](https://github.com/guardian/price-migration-engine/compare/kc-perms?expand=1#diff-0a02d7fd1683c92d607be4bb7cc9d76bR116-R118).

The rest is updates to the call sites.
