### PR TITLE
Modify logic of recipient's title and first name

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 2.6.2
+version = 2.6.4
 
 maxColumn = 120

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -74,7 +74,9 @@ object NotificationHandler extends CohortHandler {
     for {
       _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
       contact <- SalesforceClient.getContact(sfSubscription.Buyer__c)
-      firstName <- requiredField(contact.FirstName, "Contact.FirstName")
+      firstName <- requiredField(contact.FirstName, "Contact.FirstName").orElse(
+        requiredField(contact.Salutation, "Contact.Salutation")
+      )
       lastName <- requiredField(contact.LastName, "Contact.LastName")
       targetAddress <- requiredField(contact.OtherAddress, "Contact.OtherAddress").orElse(
         requiredField(contact.MailingAddress, "Contact.MailingAddress")
@@ -97,7 +99,9 @@ object NotificationHandler extends CohortHandler {
             Address = contact.Email,
             ContactAttributes = EmailPayloadContactAttributes(
               SubscriberAttributes = EmailPayloadSubscriberAttributes(
-                title = contact.Salutation,
+                title = contact.FirstName flatMap (_ =>
+                  contact.Salutation
+                ), // if no first name, we use salutation as first name and leave this field empty
                 first_name = firstName,
                 last_name = lastName,
                 billing_address_1 = street,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   private val zioVersion = "1.0.0-RC21-2"
-  private val awsSdkVersion = "1.11.820"
+  private val awsSdkVersion = "1.11.825"
 
   lazy val awsDynamoDb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
   lazy val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion
@@ -10,7 +10,7 @@ object Dependencies {
   lazy val awsStateMachine = "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsSdkVersion
   lazy val zio = "dev.zio" %% "zio" % zioVersion
   lazy val zioStreams = "dev.zio" %% "zio-streams" % zioVersion
-  lazy val upickle = "com.lihaoyi" %% "upickle" % "1.1.0"
+  lazy val upickle = "com.lihaoyi" %% "upickle" % "1.2.0"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"
   lazy val munit = "org.scalameta" %% "munit" % "0.7.9"


### PR DESCRIPTION
The letter template expects a first name.  So when there's no first name, we use the title as the first name and leave the title field empty.

