### PR TITLE
Get Braze campaign name from cohort spec

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -11,6 +11,9 @@ import upickle.default.{ReadWriter, macroRW}
   * Specification of a cohort.
   *
   * @param cohortName Name that uniquely identifies a cohort, eg. "Vouchers 2020"
+  * @param brazeCampaignName Name of the Braze campaign for this cohort.<br />
+  *                          Mapping to environment-specific Braze campaign ID is provided by membership-workflow:<br />
+  *                          See https://github.com/guardian/membership-workflow/blob/master/conf/PROD.public.conf#L39
   * @param importStartDate Date on which to start importing data from the source S3 bucket.
   * @param earliestPriceMigrationStartDate Earliest date on which any sub in the cohort can have price migrated.
   *                                        The actual date for any sub will depend on its billing dates.
@@ -21,6 +24,7 @@ import upickle.default.{ReadWriter, macroRW}
   */
 case class CohortSpec(
     cohortName: String,
+    brazeCampaignName: String,
     importStartDate: LocalDate,
     earliestPriceMigrationStartDate: LocalDate,
     migrationCompleteDate: Option[LocalDate] = None,
@@ -42,12 +46,14 @@ object CohortSpec {
   def fromDynamoDbItem(values: util.Map[String, AttributeValue]): Either[CohortSpecFetchFailure, CohortSpec] =
     (for {
       cohortName <- getStringFromResults(values, "cohortName")
+      brazeCampaignName <- getStringFromResults(values, "brazeCampaignName")
       importStartDate <- getDateFromResults(values, "importStartDate")
       earliestPriceMigrationStartDate <- getDateFromResults(values, "earliestPriceMigrationStartDate")
       migrationCompleteDate <- getOptionalDateFromResults(values, "migrationCompleteDate")
       tmpTableName <- getOptionalStringFromResults(values, "tmpTableName")
     } yield CohortSpec(
       cohortName,
+      brazeCampaignName,
       importStartDate,
       earliestPriceMigrationStartDate,
       migrationCompleteDate,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -44,6 +44,8 @@ class NotificationHandlerTest extends munit.FunSuite {
   val mailingAddressPostalCode = "buyer1MailPostalCode"
   val mailingAddressCountry = "buyer1MailCountry"
 
+  val brazeCampaignName = "SV_VO_Pricerise_Q22020"
+
   def createStubCohortTable(updatedResultsWrittenToCohortTable: ArrayBuffer[CohortItem], cohortItem: CohortItem) = {
     ZLayer.succeed(
       new CohortTable.Service {
@@ -183,7 +185,8 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler.main
+        NotificationHandler
+          .main(brazeCampaignName)
           .provideLayer(
             TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
           )
@@ -248,7 +251,8 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler.main
+        NotificationHandler
+          .main(brazeCampaignName)
           .provideLayer(
             TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
           )
@@ -280,7 +284,8 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler.main
+        NotificationHandler
+          .main(brazeCampaignName)
           .provideLayer(
             TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
           )
@@ -304,7 +309,8 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler.main
+        NotificationHandler
+          .main(brazeCampaignName)
           .provideLayer(
             TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
           )
@@ -324,7 +330,8 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler.main
+        NotificationHandler
+          .main(brazeCampaignName)
           .provideLayer(
             TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ failingStubEmailSender
           )
@@ -353,7 +360,8 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler.main
+        NotificationHandler
+          .main(brazeCampaignName)
           .provideLayer(
             TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
           )

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -15,6 +15,7 @@ class CohortSpecTest extends munit.FunSuite {
     CohortSpec.isActive(
       CohortSpec(
         cohortName = "name",
+        brazeCampaignName = "cmp123",
         importStartDate,
         earliestPriceMigrationStartDate = LocalDate.of(2021, 1, 1),
         migrationComplete
@@ -48,6 +49,7 @@ class CohortSpecTest extends munit.FunSuite {
   test("tableName: should be tmpTableName field value when present") {
     val cohortSpec = CohortSpec(
       cohortName = "name",
+      brazeCampaignName = "cmp123",
       importStartDate = LocalDate.of(2020, 1, 1),
       earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1),
       migrationCompleteDate = None,
@@ -59,6 +61,7 @@ class CohortSpecTest extends munit.FunSuite {
   test("tableName: should be transformed cohort name when tmpTableName field value not present") {
     val cohortSpec = CohortSpec(
       cohortName = "Home Delivery 2018",
+      brazeCampaignName = "cmp123",
       importStartDate = LocalDate.of(2020, 1, 1),
       earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1),
       migrationCompleteDate = None,
@@ -70,6 +73,7 @@ class CohortSpecTest extends munit.FunSuite {
   test("fromDynamoDbItem: should include all fields") {
     val item = Map(
       "cohortName" -> new AttributeValue().withS("Home Delivery 2018"),
+      "brazeCampaignName" -> new AttributeValue().withS("cmp123"),
       "importStartDate" -> new AttributeValue().withS("2020-01-01"),
       "earliestPriceMigrationStartDate" -> new AttributeValue().withS("2020-01-01"),
       "tmpTableName" -> new AttributeValue().withS("tmpName")
@@ -80,6 +84,7 @@ class CohortSpecTest extends munit.FunSuite {
       Right(
         CohortSpec(
           cohortName = "Home Delivery 2018",
+          brazeCampaignName = "cmp123",
           importStartDate = LocalDate.of(2020, 1, 1),
           earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1),
           migrationCompleteDate = None,

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -17,6 +17,7 @@ class CohortTableLiveTest extends munit.FunSuite {
 
   private val cohortSpec = CohortSpec(
     cohortName = "name",
+    brazeCampaignName = "cmp123",
     importStartDate = LocalDate.of(2020, 1, 1),
     earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1)
   )


### PR DESCRIPTION
This change allows the campaign name to vary by cohort.


