### PR TITLE
Log estimation errors explicitly

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -2,7 +2,7 @@ package pricemigrationengine.model
 
 import java.time.{Instant, LocalDate}
 
-import pricemigrationengine.model.CohortTableFilter.{AmendmentComplete, Cancelled}
+import pricemigrationengine.model.CohortTableFilter.{AmendmentComplete, Cancelled, EstimationComplete, EstimationFailed}
 
 case class CohortItem(
     subscriptionName: String,
@@ -25,14 +25,33 @@ case class CohortItem(
 
 object CohortItem {
 
-  def fromSuccessfulAmendmentResult(result: SuccessfulAmendmentResult): CohortItem = CohortItem(
-    result.subscriptionNumber,
-    processingStage = AmendmentComplete,
-    startDate = Some(result.startDate),
-    newPrice = Some(result.newPrice),
-    newSubscriptionId = Some(result.newSubscriptionId),
-    whenAmendmentDone = Some(result.whenDone)
-  )
+  def fromSuccessfulEstimationResult(result: SuccessfulEstimationResult): CohortItem =
+    CohortItem(
+      result.subscriptionName,
+      processingStage = EstimationComplete,
+      oldPrice = Some(result.oldPrice),
+      estimatedNewPrice = Some(result.estimatedNewPrice),
+      currency = Some(result.currency),
+      startDate = Some(result.startDate),
+      billingPeriod = Some(result.billingPeriod),
+      whenEstimationDone = Some(Instant.now())
+    )
+
+  def fromFailedEstimationResult(result: FailedEstimationResult): CohortItem =
+    CohortItem(result.subscriptionNumber, EstimationFailed)
+
+  def fromCancelledEstimationResult(result: CancelledEstimationResult): CohortItem =
+    CohortItem(result.subscriptionNumber, Cancelled)
+
+  def fromSuccessfulAmendmentResult(result: SuccessfulAmendmentResult): CohortItem =
+    CohortItem(
+      result.subscriptionNumber,
+      processingStage = AmendmentComplete,
+      startDate = Some(result.startDate),
+      newPrice = Some(result.newPrice),
+      newSubscriptionId = Some(result.newSubscriptionId),
+      whenAmendmentDone = Some(result.whenDone)
+    )
 
   def fromCancelledAmendmentResult(result: CancelledAmendmentResult): CohortItem =
     CohortItem(result.subscriptionNumber, Cancelled)

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -2,14 +2,16 @@ package pricemigrationengine.model
 
 import java.time.LocalDate
 
-case class EstimationResult(
+trait EstimationResult
+
+case class SuccessfulEstimationResult(
     subscriptionName: String,
     startDate: LocalDate,
     currency: Currency,
     oldPrice: BigDecimal,
     estimatedNewPrice: BigDecimal,
     billingPeriod: String
-)
+) extends EstimationResult
 
 object EstimationResult {
 
@@ -18,9 +20,9 @@ object EstimationResult {
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,
       earliestStartDate: LocalDate
-  ): Either[AmendmentDataFailure, EstimationResult] =
+  ): Either[AmendmentDataFailure, SuccessfulEstimationResult] =
     AmendmentData(newProductPricing, subscription, invoiceList, earliestStartDate) map { amendmentData =>
-      EstimationResult(
+      SuccessfulEstimationResult(
         subscription.subscriptionNumber,
         amendmentData.startDate,
         amendmentData.priceData.currency,
@@ -30,3 +32,7 @@ object EstimationResult {
       )
     }
 }
+
+case class FailedEstimationResult(subscriptionNumber: String) extends EstimationResult
+
+case class CancelledEstimationResult(subscriptionNumber: String) extends EstimationResult


### PR DESCRIPTION
Fatal errors were being logged when ZIO failed but not explicitly as errors.  So a search for 'ERROR' in the logs wouldn't find them.