### PR TITLE
Import subs from a cohort-specific location

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/services/S3.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/S3.scala
@@ -5,12 +5,12 @@ import java.io.{File, InputStream}
 import com.amazonaws.services.s3.model.PutObjectResult
 import pricemigrationengine.model.S3Failure
 import zio.{IO, ZIO, ZManaged}
-case class S3Location(bucket: String, path: String)
+case class S3Location(bucket: String, key: String)
 
 object S3 {
   trait Service {
-    def getObject(s3Location: S3Location) : ZManaged[Any, S3Failure, InputStream]
-    def putObject(s3Location: S3Location, localFile: File) : IO[S3Failure, PutObjectResult]
+    def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream]
+    def putObject(s3Location: S3Location, localFile: File): IO[S3Failure, PutObjectResult]
   }
 
   def getObject(s3Location: S3Location): ZIO[S3, S3Failure, ZManaged[Any, S3Failure, InputStream]] =

--- a/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
@@ -9,26 +9,27 @@ import pricemigrationengine.model.S3Failure
 import zio.{IO, ZLayer, ZManaged}
 
 object S3Live {
-  val impl: ZLayer[Logging, Nothing, S3] = ZLayer.fromFunction { dependencies =>
+  val impl: ZLayer[Any, Nothing, S3] = ZLayer.succeed {
     val s3 = AmazonS3ClientBuilder.standard.withRegion(Regions.EU_WEST_1).build
 
+    //noinspection ConvertExpressionToSAM
     new S3.Service {
       override def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream] = {
-        ZManaged.makeEffect(
-          s3
-            .getObject(s3Location.bucket, s3Location.path)
-            .getObjectContent()
-        ) { objectContent: InputStream =>
-          objectContent.close()
-        }.mapError(ex => S3Failure(s"Failed to get $s3Location: $ex" ))
+        ZManaged
+          .makeEffect(
+            s3
+              .getObject(s3Location.bucket, s3Location.key)
+              .getObjectContent()
+          ) { objectContent: InputStream =>
+            objectContent.close()
+          }
+          .mapError(ex => S3Failure(s"Failed to get $s3Location: $ex"))
       }
 
       override def putObject(s3Location: S3Location, localFile: File): IO[S3Failure, PutObjectResult] =
         IO.effect(
-          s3.putObject(s3Location.bucket, s3Location.path, localFile)
-        ).mapError(
-          ex => S3Failure(s"Failed to write s3 object $s3Location: ${ex.getMessage}")
-        )
+          s3.putObject(s3Location.bucket, s3Location.key, localFile)
+        ).mapError(ex => S3Failure(s"Failed to write s3 object $s3Location: ${ex.getMessage}"))
     }
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -53,9 +53,9 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
 
         override def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream] =
           s3Location match {
-            case S3Location("price-migration-engine-dev", "excluded-subscription-ids.csv") =>
+            case S3Location("price-migration-engine-dev", "cohortName/excluded-subscription-ids.csv") =>
               loadTestResource("/SubscriptionExclusions.csv")
-            case S3Location("price-migration-engine-dev", "salesforce-subscription-id-report.csv") =>
+            case S3Location("price-migration-engine-dev", "cohortName/salesforce-subscription-id-report.csv") =>
               loadTestResource("/SubscriptionIds.csv")
           }
 
@@ -65,7 +65,15 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        SubscriptionIdUploadHandler.main
+        SubscriptionIdUploadHandler
+          .main(
+            CohortSpec(
+              cohortName = "cohortName",
+              brazeCampaignName = "cmp123",
+              importStartDate = LocalDate.of(2020, 1, 1),
+              earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1)
+            )
+          )
           .provideLayer(
             TestLogging.logging ++ stubConfiguration ++ stubCohortTable ++ stubS3
           )


### PR DESCRIPTION
The import of subs is going to be the second step in the state machine after the creation of the cohort table.

This PR changes [the location from which subscription names are imported](https://github.com/guardian/price-migration-engine/compare/kc-import?expand=1#diff-e18cb17f719bc556c7a9480d39b35fe1R44) so that it's cohort-specific.
If the location doesn't exist, we [assume that the cohort has already been imported](https://github.com/guardian/price-migration-engine/compare/kc-import?expand=1#diff-e18cb17f719bc556c7a9480d39b35fe1R21-R26).

There will be a further action in the handler to delete the source location once the cohort has been fully imported.

To cover the import failing partway through, will also probably need to treat the failed import of an item, because it already exists, as a success.
