### PR TITLE
Import subs safely

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -15,7 +15,10 @@ case class CohortSpecFetchFailure(reason: String) extends Failure
 case class CohortSpecUpdateFailure(reason: String) extends Failure
 
 case class CohortTableCreateFailure(reason: String) extends Failure
+
 case class CohortFetchFailure(reason: String) extends Failure
+case class CohortCreateFailure(reason: String) extends Failure
+case class CohortItemAlreadyPresentFailure(reason: String) extends Failure
 case class CohortUpdateFailure(reason: String) extends Failure
 
 case class ZuoraFetchFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -17,7 +17,7 @@ object CohortTable {
 
     def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
 
-    def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit]
+    def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit]
 
     def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit]
   }
@@ -31,8 +31,8 @@ object CohortTable {
   def fetchAll(): ZIO[CohortTable, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
     ZIO.accessM(_.get.fetchAll())
 
-  def put(subscription: CohortItem): ZIO[CohortTable, CohortUpdateFailure, Unit] =
-    ZIO.accessM(_.get.put(subscription))
+  def create(subscription: CohortItem): ZIO[CohortTable, CohortUpdateFailure, Unit] =
+    ZIO.accessM(_.get.create(subscription))
 
   def update(result: CohortItem): ZIO[CohortTable, CohortUpdateFailure, Unit] =
     ZIO.accessM(_.get.update(result))

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -17,7 +17,7 @@ object CohortTable {
 
     def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
 
-    def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit]
+    def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit]
 
     def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit]
   }
@@ -31,7 +31,7 @@ object CohortTable {
   def fetchAll(): ZIO[CohortTable, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
     ZIO.accessM(_.get.fetchAll())
 
-  def create(subscription: CohortItem): ZIO[CohortTable, CohortUpdateFailure, Unit] =
+  def create(subscription: CohortItem): ZIO[CohortTable, Failure, Unit] =
     ZIO.accessM(_.get.create(subscription))
 
   def update(result: CohortItem): ZIO[CohortTable, CohortUpdateFailure, Unit] =

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -11,48 +11,49 @@ import zio.{IO, ZIO, ZLayer}
 import scala.jdk.CollectionConverters._
 
 object CohortTableLive {
-  private val ProcessingStageIndexName = "ProcessingStageIndexV2"
 
+  private val keyAttribName = "subscriptionNumber"
+
+  private val ProcessingStageIndexName = "ProcessingStageIndexV2"
   private val ProcessingStageAndStartDateIndexName = "ProcessingStageStartDateIndexV1"
 
   private implicit val cohortItemDeserialiser: DynamoDBDeserialiser[CohortItem] = { cohortItem =>
-    import scala.language.implicitConversions
-    implicit def errorMapped[A](orig: Either[String, A]): IO[DynamoDBZIOError, A] =
-      ZIO.fromEither(orig).mapError(DynamoDBZIOError)
-    for {
-      subscriptionNumber <- getStringFromResults(cohortItem, "subscriptionNumber")
-      processingStage <- getCohortTableFilter(cohortItem, "processingStage")
-      startDate <- getOptionalDateFromResults(cohortItem, "startDate")
-      currency <- getOptionalStringFromResults(cohortItem, "currency")
-      oldPrice <- getOptionalBigDecimalFromResults(cohortItem, "oldPrice")
-      estimatedNewPrice <- getOptionalBigDecimalFromResults(cohortItem, "estimatedNewPrice")
-      billingPeriod <- getOptionalStringFromResults(cohortItem, "billingPeriod")
-      whenEstimationDone <- getOptionalInstantFromResults(cohortItem, "whenEstimationDone")
-      salesforcePriceRiseId <- getOptionalStringFromResults(cohortItem, "salesforcePriceRiseId")
-      whenSfShowEstimate <- getOptionalInstantFromResults(cohortItem, "whenSfShowEstimate")
-      newPrice <- getOptionalBigDecimalFromResults(cohortItem, "newPrice")
-      newSubscriptionId <- getOptionalStringFromResults(cohortItem, "newSubscriptionId")
-      whenAmendmentDone <- getOptionalInstantFromResults(cohortItem, "whenAmendmentDone")
-      whenNotificationSent <- getOptionalInstantFromResults(cohortItem, "whenNotificationSent")
-      whenNotificationSentWrittenToSalesforce <-
-        getOptionalInstantFromResults(cohortItem, "whenNotificationSentWrittenToSalesforce")
-    } yield CohortItem(
-      subscriptionName = subscriptionNumber,
-      processingStage = processingStage,
-      startDate = startDate,
-      currency = currency,
-      oldPrice = oldPrice,
-      estimatedNewPrice = estimatedNewPrice,
-      billingPeriod = billingPeriod,
-      whenEstimationDone = whenEstimationDone,
-      salesforcePriceRiseId = salesforcePriceRiseId,
-      whenSfShowEstimate = whenSfShowEstimate,
-      newPrice = newPrice,
-      newSubscriptionId = newSubscriptionId,
-      whenAmendmentDone = whenAmendmentDone,
-      whenNotificationSent = whenNotificationSent,
-      whenNotificationSentWrittenToSalesforce = whenNotificationSentWrittenToSalesforce
-    )
+    IO.fromEither(
+      for {
+        subscriptionNumber <- getStringFromResults(cohortItem, keyAttribName)
+        processingStage <- getCohortTableFilter(cohortItem, "processingStage")
+        startDate <- getOptionalDateFromResults(cohortItem, "startDate")
+        currency <- getOptionalStringFromResults(cohortItem, "currency")
+        oldPrice <- getOptionalBigDecimalFromResults(cohortItem, "oldPrice")
+        estimatedNewPrice <- getOptionalBigDecimalFromResults(cohortItem, "estimatedNewPrice")
+        billingPeriod <- getOptionalStringFromResults(cohortItem, "billingPeriod")
+        whenEstimationDone <- getOptionalInstantFromResults(cohortItem, "whenEstimationDone")
+        salesforcePriceRiseId <- getOptionalStringFromResults(cohortItem, "salesforcePriceRiseId")
+        whenSfShowEstimate <- getOptionalInstantFromResults(cohortItem, "whenSfShowEstimate")
+        newPrice <- getOptionalBigDecimalFromResults(cohortItem, "newPrice")
+        newSubscriptionId <- getOptionalStringFromResults(cohortItem, "newSubscriptionId")
+        whenAmendmentDone <- getOptionalInstantFromResults(cohortItem, "whenAmendmentDone")
+        whenNotificationSent <- getOptionalInstantFromResults(cohortItem, "whenNotificationSent")
+        whenNotificationSentWrittenToSalesforce <-
+          getOptionalInstantFromResults(cohortItem, "whenNotificationSentWrittenToSalesforce")
+      } yield CohortItem(
+        subscriptionName = subscriptionNumber,
+        processingStage = processingStage,
+        startDate = startDate,
+        currency = currency,
+        oldPrice = oldPrice,
+        estimatedNewPrice = estimatedNewPrice,
+        billingPeriod = billingPeriod,
+        whenEstimationDone = whenEstimationDone,
+        salesforcePriceRiseId = salesforcePriceRiseId,
+        whenSfShowEstimate = whenSfShowEstimate,
+        newPrice = newPrice,
+        newSubscriptionId = newSubscriptionId,
+        whenAmendmentDone = whenAmendmentDone,
+        whenNotificationSent = whenNotificationSent,
+        whenNotificationSentWrittenToSalesforce = whenNotificationSentWrittenToSalesforce
+      )
+    ).mapError(DynamoDBZIOError)
   }
 
   private implicit val cohortItemUpdateSerialiser: DynamoDBUpdateSerialiser[CohortItem] =
@@ -97,12 +98,12 @@ object CohortTableLive {
       ).flatten.toMap.asJava
 
   private implicit val cohortTableKeySerialiser: DynamoDBSerialiser[CohortTableKey] =
-    key => Map(stringUpdate("subscriptionNumber", key.subscriptionNumber)).asJava
+    key => Map(stringUpdate(keyAttribName, key.subscriptionNumber)).asJava
 
   private implicit val cohortTableSerialiser: DynamoDBSerialiser[CohortItem] =
     cohortItem =>
       Map(
-        stringUpdate("subscriptionNumber", cohortItem.subscriptionName),
+        stringUpdate(keyAttribName, cohortItem.subscriptionName),
         stringUpdate("processingStage", cohortItem.processingStage.value)
       ).asJava
 
@@ -112,12 +113,13 @@ object CohortTableLive {
     CohortTable
   ] = {
     ZLayer.fromFunctionM {
-      dependencies: DynamoDBZIO with StageConfiguration with CohortTableConfiguration with Logging => {
-        for {
-         config <- StageConfiguration.stageConfig
-         tableName = cohortSpec.tableName(config.stage)
-         cohortTableConfig <- CohortTableConfiguration.cohortTableConfig
-        } yield new CohortTable.Service {
+      dependencies: DynamoDBZIO with StageConfiguration with CohortTableConfiguration with Logging =>
+        {
+          for {
+            config <- StageConfiguration.stageConfig
+            tableName = cohortSpec.tableName(config.stage)
+            cohortTableConfig <- CohortTableConfiguration.cohortTableConfig
+          } yield new CohortTable.Service {
             override def fetch(
                 filter: CohortTableFilter,
                 latestStartDateInclusive: Option[LocalDate]
@@ -146,11 +148,11 @@ object CohortTableLive {
               DynamoDBZIO.query(queryRequest).map(_.mapError(error => CohortFetchFailure(error.toString)))
             }.provide(dependencies)
 
-            override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
+            override def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
               for {
                 result <-
                   DynamoDBZIO
-                    .put(table = tableName, value = cohortItem)
+                    .create(table = tableName, keyName = keyAttribName, value = cohortItem)
                     .mapError(error => CohortUpdateFailure(error.toString))
               } yield result
             }.provide(dependencies)
@@ -170,22 +172,25 @@ object CohortTableLive {
 
             override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
               for {
-                cohortTableConfig <- CohortTableConfiguration.cohortTableConfig
-                  .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
-                stageConfig <- StageConfiguration.stageConfig
-                  .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
+                cohortTableConfig <-
+                  CohortTableConfiguration.cohortTableConfig
+                    .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
+                stageConfig <-
+                  StageConfiguration.stageConfig
+                    .mapError(error => CohortFetchFailure(s"Failed to get configuration:${error.reason}"))
                 queryRequest = new ScanRequest()
                   .withTableName(s"PriceMigrationEngine${stageConfig.stage}")
                   .withLimit(cohortTableConfig.batchSize)
-                queryResults <- DynamoDBZIO
-                  .scan(
-                    queryRequest
-                  )
-                  .map(_.mapError(error => CohortFetchFailure(error.toString)))
+                queryResults <-
+                  DynamoDBZIO
+                    .scan(
+                      queryRequest
+                    )
+                    .map(_.mapError(error => CohortFetchFailure(error.toString)))
               } yield queryResults
             }.provide(dependencies)
           }
-      }.provide(dependencies)
+        }.provide(dependencies)
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClient.scala
@@ -48,9 +48,10 @@ object DynamoDBClient {
     ZIO.accessM(client => ZIO.effect(client.get.updateItem(updateRequest)))
   }
 
-  def putItem(updateRequest: PutItemRequest): ZIO[DynamoDBClient, Throwable, PutItemResult] = {
-    ZIO.accessM(client => ZIO.effect(client.get.putItem(updateRequest)))
-  }
+  def createItem(createRequest: PutItemRequest, keyName: String): ZIO[DynamoDBClient, Throwable, PutItemResult] =
+    ZIO.accessM(client =>
+      ZIO.effect(client.get.putItem(createRequest.withConditionExpression(s"attribute_not_exists($keyName)")))
+    )
 
   def describeTable(tableName: String): ZIO[DynamoDBClient, Throwable, DescribeTableResult] =
     ZIO.accessM(client => ZIO.effect(client.get.describeTable(tableName)))

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIO.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIO.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.dynamodbv2.model.{AttributeValue, AttributeValueUp
 import zio.stream.ZStream
 import zio.{IO, URIO, ZIO}
 
-case class DynamoDBZIOError(message: String)
+case class DynamoDBZIOError(message: String, cause: Option[Throwable] = None)
 
 trait DynamoDBSerialiser[A] { def serialise(value: A): java.util.Map[String, AttributeValue] }
 trait DynamoDBUpdateSerialiser[A] { def serialise(value: A): java.util.Map[String, AttributeValueUpdate] }

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIO.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIO.scala
@@ -8,41 +8,43 @@ case class DynamoDBZIOError(message: String)
 
 trait DynamoDBSerialiser[A] { def serialise(value: A): java.util.Map[String, AttributeValue] }
 trait DynamoDBUpdateSerialiser[A] { def serialise(value: A): java.util.Map[String, AttributeValueUpdate] }
-trait DynamoDBDeserialiser[A] { def deserialise(value: java.util.Map[String, AttributeValue]): IO[DynamoDBZIOError, A]  }
+trait DynamoDBDeserialiser[A] { def deserialise(value: java.util.Map[String, AttributeValue]): IO[DynamoDBZIOError, A] }
 
 object DynamoDBZIO {
   trait Service {
-    def query[A](query: QueryRequest)
-                (implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A]
-    def scan[A](query: ScanRequest)
-                (implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A]
-    def update[A, B](table: String, key: A, value: B)
-                    (implicit keySerializer: DynamoDBSerialiser[A],
-                     valueSerializer: DynamoDBUpdateSerialiser[B]): IO[DynamoDBZIOError, Unit]
-    def put[A](table: String, value: A)
-              (implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit]
+    def query[A](query: QueryRequest)(implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A]
+    def scan[A](query: ScanRequest)(implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A]
+    def update[A, B](table: String, key: A, value: B)(implicit
+        keySerializer: DynamoDBSerialiser[A],
+        valueSerializer: DynamoDBUpdateSerialiser[B]
+    ): IO[DynamoDBZIOError, Unit]
+    def create[A](table: String, keyName: String, value: A)(implicit
+        valueSerializer: DynamoDBSerialiser[A]
+    ): IO[DynamoDBZIOError, Unit]
   }
 
   def query[A](
-    query: QueryRequest
+      query: QueryRequest
   )(implicit deserializer: DynamoDBDeserialiser[A]): URIO[DynamoDBZIO, ZStream[Any, DynamoDBZIOError, A]] = {
     ZIO.access(_.get.query(query))
   }
 
   def scan[A](
-    query: ScanRequest
+      query: ScanRequest
   )(implicit deserializer: DynamoDBDeserialiser[A]): URIO[DynamoDBZIO, ZStream[Any, DynamoDBZIOError, A]] = {
     ZIO.access(_.get.scan(query))
   }
 
-  def update[A, B](table: String, key: A, value: B)
-                  (implicit keySerializer: DynamoDBSerialiser[A],
-                   valueSerializer: DynamoDBUpdateSerialiser[B]): ZIO[DynamoDBZIO, DynamoDBZIOError, Unit] = {
+  def update[A, B](table: String, key: A, value: B)(implicit
+      keySerializer: DynamoDBSerialiser[A],
+      valueSerializer: DynamoDBUpdateSerialiser[B]
+  ): ZIO[DynamoDBZIO, DynamoDBZIOError, Unit] = {
     ZIO.accessM(_.get.update(table, key, value))
   }
 
-  def put[A](table: String, value: A)
-            (implicit keySerializer: DynamoDBSerialiser[A]): ZIO[DynamoDBZIO, DynamoDBZIOError, Unit] = {
-    ZIO.accessM(_.get.put(table, value))
+  def create[A](table: String, keyName: String, value: A)(implicit
+      keySerializer: DynamoDBSerialiser[A]
+  ): ZIO[DynamoDBZIO, DynamoDBZIOError, Unit] = {
+    ZIO.accessM(_.get.create(table, keyName, value))
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIOLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIOLive.scala
@@ -2,103 +2,111 @@ package pricemigrationengine.services
 
 import java.util
 
-import com.amazonaws.services.dynamodbv2.model.{AttributeValue, PutItemRequest, QueryRequest, QueryResult, ScanRequest, ScanResult, UpdateItemRequest}
-import pricemigrationengine.services.DynamoDBZIO.Service
+import com.amazonaws.services.dynamodbv2.model._
 import zio.stream.ZStream
 import zio.{IO, ZIO, ZLayer}
 
 import scala.jdk.CollectionConverters._
 
 object DynamoDBZIOLive {
-  val impl: ZLayer[DynamoDBClient with Logging , Nothing, DynamoDBZIO] =
+  val impl: ZLayer[DynamoDBClient with Logging, Nothing, DynamoDBZIO] =
     ZLayer.fromFunction { dependencies: DynamoDBClient with Logging =>
-      new Service {
+      new DynamoDBZIO.Service {
         override def query[A](
-          query: QueryRequest
+            query: QueryRequest
         )(implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A] =
           recursivelyExecuteQueryUntilAllResultsAreStreamed(query)
             .mapM(deserializer.deserialise)
 
         private def recursivelyExecuteQueryUntilAllResultsAreStreamed[A](
-          query: QueryRequest
+            query: QueryRequest
         ): ZStream[Any, DynamoDBZIOError, util.Map[String, AttributeValue]] = {
-          ZStream.unfoldM(Some(query).asInstanceOf[Option[QueryRequest]]) {
-            case Some(queryRequest) =>
-              for {
-                queryResult <- sendQueryRequest(queryRequest)
-                _ <- Logging.info(s"Received query results for batch with ${queryResult.getCount} items")
-                queryForNextBatch = Option(queryResult.getLastEvaluatedKey)
-                  .map(lastEvaluatedKey => queryRequest.clone().withExclusiveStartKey(lastEvaluatedKey))
-              } yield Some((queryResult.getItems().asScala, queryForNextBatch))
-            case None =>
-              ZIO.succeed(None)
-          }
+          ZStream
+            .unfoldM(Some(query).asInstanceOf[Option[QueryRequest]]) {
+              case Some(queryRequest) =>
+                for {
+                  queryResult <- sendQueryRequest(queryRequest)
+                  _ <- Logging.info(s"Received query results for batch with ${queryResult.getCount} items")
+                  queryForNextBatch = Option(queryResult.getLastEvaluatedKey)
+                    .map(lastEvaluatedKey => queryRequest.clone().withExclusiveStartKey(lastEvaluatedKey))
+                } yield Some((queryResult.getItems().asScala, queryForNextBatch))
+              case None =>
+                ZIO.none
+            }
             .flatMap(resultList => ZStream.fromIterable(resultList))
         }.provide(dependencies)
 
         private def sendQueryRequest[A](queryRequest: QueryRequest): ZIO[Any, DynamoDBZIOError, QueryResult] = {
           for {
             _ <- Logging.info(s"Starting query: $queryRequest")
-            results <- DynamoDBClient.query(queryRequest)
-              .mapError(ex => DynamoDBZIOError(s"Failed to execute query $queryRequest : $ex"))
+            results <-
+              DynamoDBClient
+                .query(queryRequest)
+                .mapError(ex => DynamoDBZIOError(s"Failed to execute query $queryRequest : $ex"))
           } yield results
         }.provide(dependencies)
 
-        override def scan[A](query: ScanRequest)(implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A] = {
+        override def scan[A](query: ScanRequest)(implicit
+            deserializer: DynamoDBDeserialiser[A]
+        ): ZStream[Any, DynamoDBZIOError, A] = {
           recursivelyExecuteScanUntilAllResultsAreStreamed(query)
             .mapM(deserializer.deserialise)
         }
 
         private def recursivelyExecuteScanUntilAllResultsAreStreamed[A](
-          query: ScanRequest
+            query: ScanRequest
         ): ZStream[Any, DynamoDBZIOError, util.Map[String, AttributeValue]] = {
-          ZStream.unfoldM(Some(query).asInstanceOf[Option[ScanRequest]]) {
-            case Some(queryRequest) =>
-              for {
-                scanResult <- sendScanRequest(queryRequest)
-                _ <- Logging.info(s"Received query results for batch with ${scanResult.getCount} items")
-                queryForNextBatch = Option(scanResult.getLastEvaluatedKey)
-                  .map(lastEvaluatedKey => queryRequest.clone().withExclusiveStartKey(lastEvaluatedKey))
-              } yield Some((scanResult.getItems().asScala, queryForNextBatch))
-            case None =>
-              ZIO.succeed(None)
-          }
+          ZStream
+            .unfoldM(Some(query).asInstanceOf[Option[ScanRequest]]) {
+              case Some(queryRequest) =>
+                for {
+                  scanResult <- sendScanRequest(queryRequest)
+                  _ <- Logging.info(s"Received query results for batch with ${scanResult.getCount} items")
+                  queryForNextBatch = Option(scanResult.getLastEvaluatedKey)
+                    .map(lastEvaluatedKey => queryRequest.clone().withExclusiveStartKey(lastEvaluatedKey))
+                } yield Some((scanResult.getItems().asScala, queryForNextBatch))
+              case None =>
+                ZIO.none
+            }
             .flatMap(resultList => ZStream.fromIterable(resultList))
         }.provide(dependencies)
 
         private def sendScanRequest[A](queryRequest: ScanRequest): ZIO[Any, DynamoDBZIOError, ScanResult] = {
           for {
             _ <- Logging.info(s"Starting scan: $queryRequest")
-            results <- DynamoDBClient.scan(queryRequest)
-              .mapError(ex => DynamoDBZIOError(s"Failed to execute scan $queryRequest : $ex"))
+            results <-
+              DynamoDBClient
+                .scan(queryRequest)
+                .mapError(ex => DynamoDBZIOError(s"Failed to execute scan $queryRequest : $ex"))
           } yield results
         }.provide(dependencies)
 
-        def update[A, B](table: String, key: A, value: B)
-                        (implicit keySerializer: DynamoDBSerialiser[A],
-                         valueSerializer: DynamoDBUpdateSerialiser[B]): IO[DynamoDBZIOError, Unit] =
-          DynamoDBClient.updateItem(
-            new UpdateItemRequest(
-              table,
-              keySerializer.serialise(key),
-              valueSerializer.serialise(value)
+        def update[A, B](table: String, key: A, value: B)(implicit
+            keySerializer: DynamoDBSerialiser[A],
+            valueSerializer: DynamoDBUpdateSerialiser[B]
+        ): IO[DynamoDBZIOError, Unit] =
+          DynamoDBClient
+            .updateItem(
+              new UpdateItemRequest(
+                table,
+                keySerializer.serialise(key),
+                valueSerializer.serialise(value)
+              )
             )
-          ).bimap(
-            ex => DynamoDBZIOError(s"Failed to write value '$value' to '$table': $ex"),
-            _ => ()
-          ).provide(dependencies)
+            .bimap(
+              ex => DynamoDBZIOError(s"Failed to write value '$value' to '$table': $ex"),
+              _ => ()
+            )
+            .provide(dependencies)
 
-        def put[A](table: String, value: A)
-                  (implicit valueSerializer: DynamoDBSerialiser[A]): IO[DynamoDBZIOError, Unit] =
-          DynamoDBClient.putItem(
-            new PutItemRequest(
-              table,
-              valueSerializer.serialise(value)
-            )
-          ).bimap(
-            ex => DynamoDBZIOError(s"Failed to write value '$value' to '$table': $ex"),
-            _ => ()
-          ).provide(dependencies)
+        def create[A](table: String, keyName: String, value: A)(implicit
+            valueSerializer: DynamoDBSerialiser[A]
+        ): IO[DynamoDBZIOError, Unit] =
+          DynamoDBClient
+            .createItem(new PutItemRequest(table, valueSerializer.serialise(value)), keyName)
+            .mapError(ex => DynamoDBZIOError(s"Failed to write value '$value' to '$table': $ex"))
+            .unit
+            .provide(dependencies)
       }
     }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIOLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIOLive.scala
@@ -104,7 +104,7 @@ object DynamoDBZIOLive {
         ): IO[DynamoDBZIOError, Unit] =
           DynamoDBClient
             .createItem(new PutItemRequest(table, valueSerializer.serialise(value)), keyName)
-            .mapError(ex => DynamoDBZIOError(s"Failed to write value '$value' to '$table': $ex"))
+            .mapError(ex => DynamoDBZIOError(s"Failed to write value '$value' to '$table': $ex", Some(ex)))
             .unit
             .provide(dependencies)
       }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -64,7 +64,7 @@ class NotificationHandlerTest extends munit.FunSuite {
           IO.succeed(ZStream(cohortItem))
         }
 
-        override def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -64,7 +64,7 @@ class NotificationHandlerTest extends munit.FunSuite {
           IO.succeed(ZStream(cohortItem))
         }
 
-        override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        override def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -29,7 +29,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
           IO.succeed(ZStream(cohortItem))
         }
 
-        override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        override def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -29,7 +29,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
           IO.succeed(ZStream(cohortItem))
         }
 
-        override def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -36,7 +36,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
           IO.succeed(ZStream(cohortItem))
         }
 
-        override def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???
 
         override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -36,7 +36,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
           IO.succeed(ZStream(cohortItem))
         }
 
-        override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        override def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
 
         override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -33,7 +33,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
         override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
-        override def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] =
+        override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] =
           IO.effect {
             subscriptionsWrittenToCohortTable.addOne(cohortItem)
             ()

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -33,7 +33,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
         override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
-        override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] =
+        override def create(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] =
           IO.effect {
             subscriptionsWrittenToCohortTable.addOne(cohortItem)
             ()

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -3,7 +3,13 @@ package pricemigrationengine.model
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDate, ZoneOffset}
 
-import com.amazonaws.services.dynamodbv2.model.{AttributeAction, AttributeValue, AttributeValueUpdate, QueryRequest, ScanRequest}
+import com.amazonaws.services.dynamodbv2.model.{
+  AttributeAction,
+  AttributeValue,
+  AttributeValueUpdate,
+  QueryRequest,
+  ScanRequest
+}
 import pricemigrationengine.model.CohortTableFilter.ReadyForEstimation
 import pricemigrationengine.services._
 import zio.Exit.Success
@@ -74,11 +80,13 @@ class CohortTableLiveTest extends munit.FunSuite {
             valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String, value: A)(implicit
+        override def create[A](table: String, keyName: String, value: A)(implicit
             valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def scan[A](query: ScanRequest)(implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A] = ???
+        override def scan[A](query: ScanRequest)(implicit
+            deserializer: DynamoDBDeserialiser[A]
+        ): ZStream[Any, DynamoDBZIOError, A] = ???
       }
     )
 
@@ -170,11 +178,13 @@ class CohortTableLiveTest extends munit.FunSuite {
             valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String, value: A)(implicit
+        override def create[A](table: String, keyName: String, value: A)(implicit
             valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def scan[A](query: ScanRequest)(implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A] = ???
+        override def scan[A](query: ScanRequest)(implicit
+            deserializer: DynamoDBDeserialiser[A]
+        ): ZStream[Any, DynamoDBZIOError, A] = ???
       }
     )
 
@@ -235,11 +245,13 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def put[A](table: String, value: A)(implicit
+        override def create[A](table: String, keyName: String, value: A)(implicit
             valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def scan[A](query: ScanRequest)(implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A] = ???
+        override def scan[A](query: ScanRequest)(implicit
+            deserializer: DynamoDBDeserialiser[A]
+        ): ZStream[Any, DynamoDBZIOError, A] = ???
       }
     )
 
@@ -388,11 +400,13 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def put[A](table: String, value: A)(implicit
+        override def create[A](table: String, keyName: String, value: A)(implicit
             valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def scan[A](query: ScanRequest)(implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A] = ???
+        override def scan[A](query: ScanRequest)(implicit
+            deserializer: DynamoDBDeserialiser[A]
+        ): ZStream[Any, DynamoDBZIOError, A] = ???
       }
     )
 
@@ -450,7 +464,7 @@ class CohortTableLiveTest extends munit.FunSuite {
             valueSerializer: DynamoDBUpdateSerialiser[B]
         ): IO[DynamoDBZIOError, Unit] = ???
 
-        override def put[A](table: String, value: A)(implicit
+        override def create[A](table: String, keyName: String, value: A)(implicit
             valueSerializer: DynamoDBSerialiser[A]
         ): IO[DynamoDBZIOError, Unit] = {
           tableUpdated = Some(table)
@@ -459,7 +473,9 @@ class CohortTableLiveTest extends munit.FunSuite {
           ZIO.effect(()).orElseFail(DynamoDBZIOError(""))
         }
 
-        override def scan[A](query: ScanRequest)(implicit deserializer: DynamoDBDeserialiser[A]): ZStream[Any, DynamoDBZIOError, A] = ???
+        override def scan[A](query: ScanRequest)(implicit
+            deserializer: DynamoDBDeserialiser[A]
+        ): ZStream[Any, DynamoDBZIOError, A] = ???
       }
     )
 
@@ -468,7 +484,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     assertEquals(
       Runtime.default.unsafeRunSync(
         CohortTable
-          .put(cohortItem)
+          .create(cohortItem)
           .provideLayer(
             stubStageConfiguration ++ stubCohortTableConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl >>>
               CohortTableLive.impl(cohortSpec)


### PR DESCRIPTION
Previously we were 'putting' new subs into the table, which meant items would be overwritten if they were already present.

This PR adds a condition to the put method to make [a new safe 'create' method](https://github.com/guardian/price-migration-engine/compare/kc-import?expand=1#diff-052261b41151e8ed656f54b901dbb3c0R51-R54), which won't overwrite an existing item.
Then in order to handle failures partway through an import, we ignore [any cases where an item already exists in the table](https://github.com/guardian/price-migration-engine/compare/kc-import?expand=1#diff-e18cb17f719bc556c7a9480d39b35fe1R87-R90) and just log them instead.  This should make the import lambda safely re-runnable.

This assumes import can be done in 15 mins.  Otherwise will have to do some kind of comparison of what's already in table with what's to be imported.
