### PR TITLE
Export cohort table to s3

### DIFF
--- a/lambda/DatalakeExport.MD
+++ b/lambda/DatalakeExport.MD
@@ -1,0 +1,37 @@
+# Price Migration Engine Data-Lake Export
+
+This describes the solution and the reasoning behind it for the export of CohortItems, the information about the processing of price rises by the price migration engine.
+
+## Possible Approaches
+### Solution1 - Zuora/Salesforce approach
+This approach starts with us exporting a ‘raw’ file to a s3 bucket, containing data from any active cohorts. The file would contain the complete set of data for all active cohorts. This data is merged, by a spark etl job, with existing data in a ‘clean’ bucket and written in ORC to the clean bucket.
+- Pros
+  - This is the same as all our other jobs
+  - Possible future requirements for transformation/filtering can be done in the etl pipeline
+  - Alerting in the normal way, ie when no data shows up in the raw directory, would be easy and work well. 
+-Cons
+  - The etl job is triggered by a single file appearing in s3. This may not be the case as we may have multiple cohorts running at the same time. We would need to either:
+    - Write data for all active cohorts in a single file, which adds complexity to the export job and to the scheduling of the export job.
+    - Trigger the job in airflow using a Cron schedule ie just run the etl job at a particular time each day regardless of whether a file has been uploaded
+  - Depending on how the job is triggered, this might be wasteful in terms of cost of running EMR resources. It would be difficult to stop the triggering of the etl job when no cohorts were ‘Active’
+    - We could always write a file and leave it empty if there are no active cohorts. This could cause the unnecessary startup of a EMR cluster.
+    - We could not write a file if there is no data. This would make alerting difficult as we would not know if the process was broken or if there was no data.
+
+### Solution 2 - Writing individual cohort files
+This approach would run the export job as part of the state machine processing each cohort. The export would write a file with a name specific to that cohort. The file would be written to the ‘clean’ directory in s3 overwriting any previous file for that particular cohort.
+
+- Pros
+  - Simple to implement in the export code. 
+  - No ETL code needs to be written.
+  - Does not require any etl code to merge data as this is taken care of by partitioning, ie using separate files for each cohort.
+- Cons
+  - We would need to rely on alerting of failures in the price migration engine for monitoring as there would be no real active processing in the etl pipeline to provide altering. It would also, as above, be difficult to distinguish in the datalake code, between there being no data and something being broken.
+  - Its the preference of the data tech team that we write the files in ORC/parquet which is slightly more complicated than csv.
+  - Possible future requirements around filtering/transformation of the data in etl would be more difficult as the etl code would need to be implemented, including solving the difficulties around having multiple files with different names arriving an a ‘raw’ bucket
+
+
+## Proposal
+
+The proposed solution is to use solution 2 as it is the simplest solution and eliminates unnecessary expense.
+
+Writing ORC/Parquet is an additional complication, the first cohort generates a 13m csv file, which doesnt warrant the addition effort in implementing ORC/Parquet

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -164,3 +164,7 @@ too late in the day to resolve it.
 
 In an attempt to make it simpler to resolve this in the future we are sending billing_address_2 all the way though 
 sqs/membership-workflow/braze/latcham but we are populating it with an empty string in the NotificationHandler.
+
+## Datalake Export
+
+The data for each cohort is exported each day to the data lake. See [DatalakeExport.MD](DatalakeExport.MD) for more details.

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -27,7 +27,7 @@ Mappings:
       SecretsVersion: "b069693b-69dd-40ee-a586-70d409778d2b"
       BucketName: price-migration-engine-prod
       SQSQueueName: direct-mail-PROD
-      ExportBucketName: price-migration-engine-prod
+      ExportBucketName: ophan-clean-price-migration-engine-cohort-items
 
 Resources:
 

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -17,14 +17,17 @@ Mappings:
       SecretsVersion: "4db851a7-5832-4ce2-9356-b4c412d80f30"
       BucketName: price-migration-engine-dev
       SQSQueueName: direct-mail-CODE
+      ExportBucketName: price-migration-engine-dev
     CODE:
       SecretsVersion: "4c808606-4f2b-4925-bf71-8fd75a102e2b"
       BucketName: price-migration-engine-code
       SQSQueueName: direct-mail-CODE
+      ExportBucketName: price-migration-engine-code
     PROD:
       SecretsVersion: "b069693b-69dd-40ee-a586-70d409778d2b"
       BucketName: price-migration-engine-prod
       SQSQueueName: direct-mail-PROD
+      ExportBucketName: price-migration-engine-prod
 
 Resources:
 
@@ -658,6 +661,7 @@ Resources:
         Variables:
           stage: !Ref Stage
           batchSize: 100
+          exportBucketName: !FindInMap [StageMap, !Ref Stage, ExportBucketName]
       Role:
         Fn::GetAtt:
           - PriceMigrationEngineCohortTableDatalakeExportLambdaRole

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -702,3 +702,7 @@ Outputs:
     Value: !GetAtt PriceMigrationEngineSalesforceAmendmentUpdateLambda.Arn
     Export:
       Name: !Sub "${AWS::StackName}-UpdatingSalesforceWithAmendsLambda"
+  PriceMigrationEngineCohortTableDatalakeExportLambdaOutput:
+    Value: !GetAtt PriceMigrationEngineCohortTableDatalakeExportLambda.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-ExportingCohortTableToDatalakeLambda"

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -4,6 +4,7 @@ import java.io.{File, OutputStream, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 
+import com.amazonaws.services.s3.model.CannedAccessControlList
 import org.apache.commons.csv.{CSVFormat, CSVPrinter, QuoteMode}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
@@ -41,7 +42,7 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
         }
 
         putResult <-
-          S3.putObject(s3Location, filePath.toFile)
+          S3.putObject(s3Location, filePath.toFile, Some(CannedAccessControlList.BucketOwnerRead))
             .mapError { failure =>
               CohortTableDatalakeExportFailure(s"Failed to write CohortItems to s3: ${failure.reason}")
             }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -79,23 +79,23 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
     managedCSVPrinter(
       outputStream,
       List(
-        "cohortName",
-        "subscriptionName",
-        "processingStage",
-        "startDate",
+        "cohort_name",
+        "subscription_name",
+        "processing_stage",
+        "start_date",
         "currency",
-        "oldPrice",
-        "estimatedNewPrice",
-        "billingPeriod",
-        "whenEstimationDone",
-        "salesforcePriceRiseId",
-        "whenSfShowEstimate",
-        "newPrice",
-        "newSubscriptionId",
-        "whenAmendmentDone",
-        "whenNotificationSent",
-        "whenNotificationSentWrittenToSalesforce",
-        "whenAmendmentWrittenToSalesforce"
+        "old_price",
+        "estimated_new_price",
+        "billing_period",
+        "when_estimation_done",
+        "salesforce_price_rise_id",
+        "when_sf_show_estimate",
+        "new_price",
+        "new_subscription_id",
+        "when_amendment_done",
+        "when_notification_sent",
+        "when_notification_sent_written_to_salesforce",
+        "when_amendment_written_to_salesforce"
       )
     ).use { printer =>
       cohortItems.mapM { cohortItem =>

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -25,7 +25,7 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
       records <- CohortTable.fetchAll()
       s3Location = S3Location(
         config.exportBucketName,
-        s"/data/${cohortSpec.cohortName}.csv"
+        s"data/${cohortSpec.cohortName}.csv"
       )
       _ <- writeCsvToS3(records, s3Location, cohortSpec)
     } yield HandlerOutput(isComplete = true)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
@@ -39,6 +39,6 @@ object LiveLayer {
   val s3: ZLayer[Logging, ConfigurationFailure, S3] =
     logging to S3Live.impl
 
-  val stageConfig: ZLayer[Any, Nothing, StageConfiguration] =
-    EnvConfiguration.stageImp
+  val exportConfig: ZLayer[Any, ConfigurationFailure, ExportConfiguration] =
+    EnvConfiguration.exportConfigImpl
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
@@ -26,3 +26,7 @@ case class SalesforceConfig(
 case class EmailSenderConfig(sqsEmailQueueName: String)
 
 case class CohortStateMachineConfig(stateMachineArn: String)
+
+case class ExportConfig(
+    exportBucketName: String
+)

--- a/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
@@ -67,8 +67,8 @@ object CohortStateMachineConfiguration {
 
 object ExportConfiguration {
   trait Service {
-    val config: IO[ConfigurationFailure, ExportConfig]
+    val config: ExportConfig
   }
   val exportConfig: ZIO[ExportConfiguration, ConfigurationFailure, ExportConfig] =
-    ZIO.accessM(_.get.config)
+    ZIO.access(_.get.config)
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
@@ -64,3 +64,11 @@ object CohortStateMachineConfiguration {
   val cohortStateMachineConfig: ZIO[CohortStateMachineConfiguration, ConfigurationFailure, CohortStateMachineConfig] =
     ZIO.accessM(_.get.config)
 }
+
+object ExportConfiguration {
+  trait Service {
+    val config: IO[ConfigurationFailure, ExportConfig]
+  }
+  val exportConfig: ZIO[ExportConfiguration, ConfigurationFailure, ExportConfig] =
+    ZIO.accessM(_.get.config)
+}

--- a/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.services
 import java.lang.System.getenv
 
 import pricemigrationengine.model._
-import zio.{IO, ZIO, ZLayer}
+import zio.{IO, UIO, ZIO, ZLayer}
 
 object EnvConfiguration {
   def env(name: String): IO[ConfigurationFailure, String] =
@@ -113,8 +113,8 @@ object EnvConfiguration {
   val exportConfigImpl: ZLayer[Any, ConfigurationFailure, ExportConfiguration] = ZLayer.fromEffect {
     env("exportBucketName") map { exportBucketName =>
       new ExportConfiguration.Service {
-        val config: IO[ConfigurationFailure, ExportConfig] =
-          ZIO.succeed(ExportConfig(exportBucketName = exportBucketName))
+        val config: ExportConfig =
+          ExportConfig(exportBucketName = exportBucketName)
       }
     }
   }

--- a/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
@@ -109,4 +109,13 @@ object EnvConfiguration {
       }
     }
   }
+
+  val exportConfigImpl: ZLayer[Any, ConfigurationFailure, ExportConfiguration] = ZLayer.fromEffect {
+    env("exportBucketName") map { exportBucketName =>
+      new ExportConfiguration.Service {
+        val config: IO[ConfigurationFailure, ExportConfig] =
+          ZIO.succeed(ExportConfig(exportBucketName = exportBucketName))
+      }
+    }
+  }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/S3.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/S3.scala
@@ -2,7 +2,7 @@ package pricemigrationengine.services
 
 import java.io.{File, InputStream}
 
-import com.amazonaws.services.s3.model.PutObjectResult
+import com.amazonaws.services.s3.model.{CannedAccessControlList, PutObjectResult}
 import pricemigrationengine.model.S3Failure
 import zio.{IO, ZIO, ZManaged}
 case class S3Location(bucket: String, path: String)
@@ -10,12 +10,12 @@ case class S3Location(bucket: String, path: String)
 object S3 {
   trait Service {
     def getObject(s3Location: S3Location) : ZManaged[Any, S3Failure, InputStream]
-    def putObject(s3Location: S3Location, localFile: File) : IO[S3Failure, PutObjectResult]
+    def putObject(s3Location: S3Location, localFile: File, cannedAcl: Option[CannedAccessControlList]) : IO[S3Failure, PutObjectResult]
   }
 
   def getObject(s3Location: S3Location): ZIO[S3, S3Failure, ZManaged[Any, S3Failure, InputStream]] =
     ZIO.access(_.get.getObject(s3Location))
 
-  def putObject(s3Location: S3Location, localFile: File): ZIO[S3, S3Failure, PutObjectResult] =
-    ZIO.accessM(_.get.putObject(s3Location, localFile))
+  def putObject(s3Location: S3Location, localFile: File, cannedAcl: Option[CannedAccessControlList]): ZIO[S3, S3Failure, PutObjectResult] =
+    ZIO.accessM(_.get.putObject(s3Location, localFile, cannedAcl))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
@@ -4,7 +4,7 @@ import java.io.{File, InputStream}
 
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.amazonaws.services.s3.model.PutObjectResult
+import com.amazonaws.services.s3.model.{CannedAccessControlList, PutObjectRequest, PutObjectResult}
 import pricemigrationengine.model.S3Failure
 import zio.{IO, ZLayer, ZManaged}
 
@@ -23,10 +23,20 @@ object S3Live {
         }.mapError(ex => S3Failure(s"Failed to get $s3Location: $ex" ))
       }
 
-      override def putObject(s3Location: S3Location, localFile: File): IO[S3Failure, PutObjectResult] =
-        IO.effect(
-          s3.putObject(s3Location.bucket, s3Location.path, localFile)
-        ).mapError(
+      override def putObject(s3Location: S3Location, localFile: File, cannedAcl: Option[CannedAccessControlList]): IO[S3Failure, PutObjectResult] =
+        IO.effect {
+          s3.putObject(
+            cannedAcl.foldLeft(
+              new PutObjectRequest(
+                s3Location.bucket,
+                s3Location.path,
+                localFile
+              )
+            ) { (putRequest, cal) =>
+                putRequest.withCannedAcl(cal)
+            }
+          )
+        }.mapError(
           ex => S3Failure(s"Failed to write s3 object $s3Location: ${ex.getMessage}")
         )
     }

--- a/lambda/src/main/scala/pricemigrationengine/services/package.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/package.scala
@@ -12,6 +12,7 @@ package object services {
   type StageConfiguration = Has[StageConfiguration.Service]
   type EmailSenderConfiguration = Has[EmailSenderConfiguration.Service]
   type CohortStateMachineConfiguration = Has[CohortStateMachineConfiguration.Service]
+  type ExportConfiguration = Has[ExportConfiguration.Service]
 
   type CohortStateMachine = Has[CohortStateMachine.Service]
   type CohortSpecTable = Has[CohortSpecTable.Service]

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -102,7 +102,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
     assertEquals(expectedS3ExportBucketName, actualS3Location.bucket)
     assertEquals(s"/data/${expectedCohortName}.csv", actualS3Location.path)
     assertEquals(
-      """"cohortName","subscriptionName","processingStage","startDate","currency","oldPrice","estimatedNewPrice","billingPeriod","whenEstimationDone","salesforcePriceRiseId","whenSfShowEstimate","newPrice","newSubscriptionId","whenAmendmentDone","whenNotificationSent","whenNotificationSentWrittenToSalesforce","whenAmendmentWrittenToSalesforce"
+      """"cohort_name","subscription_name","processing_stage","start_date","currency","old_price","estimated_new_price","billing_period","when_estimation_done","salesforce_price_rise_id","when_sf_show_estimate","new_price","new_subscription_id","when_amendment_done","when_notification_sent","when_notification_sent_written_to_salesforce","when_amendment_written_to_salesforce"
         |"expected cohort name","subscription 1","NotificationSendComplete","2020-01-01","USD","1.0","2.0","quarter","2020-01-01T01:01:01Z","salesForcePriceRiseId1","2020-01-02T01:01:01Z","3.0","zuoraSubId1","2020-01-03T01:01:01Z","2020-01-04T01:01:01Z","2020-01-05T01:01:01Z","2020-01-06T01:01:01Z"""".stripMargin,
       actualFileContents
     )
@@ -137,7 +137,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
     assertEquals(expectedS3ExportBucketName, actualS3Location.bucket)
     assertEquals(s"/data/${expectedCohortName}.csv", actualS3Location.path)
     assertEquals(
-      """"cohortName","subscriptionName","processingStage","startDate","currency","oldPrice","estimatedNewPrice","billingPeriod","whenEstimationDone","salesforcePriceRiseId","whenSfShowEstimate","newPrice","newSubscriptionId","whenAmendmentDone","whenNotificationSent","whenNotificationSentWrittenToSalesforce","whenAmendmentWrittenToSalesforce"
+      """"cohort_name","subscription_name","processing_stage","start_date","currency","old_price","estimated_new_price","billing_period","when_estimation_done","salesforce_price_rise_id","when_sf_show_estimate","new_price","new_subscription_id","when_amendment_done","when_notification_sent","when_notification_sent_written_to_salesforce","when_amendment_written_to_salesforce"
         |"expected cohort name","subscription 2","ReadyForEstimation","","","","","","","","","","","","","",""""".stripMargin,
       actualFileContents
     )

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -1,0 +1,145 @@
+package pricemigrationengine.handlers
+
+import java.io.{File, InputStream}
+import java.time._
+
+import com.amazonaws.services.s3.model.PutObjectResult
+import pricemigrationengine.model.CohortTableFilter._
+import pricemigrationengine.model._
+import pricemigrationengine.services._
+import pricemigrationengine.{StubClock, TestLogging}
+import zio.Exit.Success
+import zio.Runtime.default
+import zio._
+import zio.stream.ZStream
+
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
+class CohortTableExportHandlerTest extends munit.FunSuite {
+
+  def createStubCohortTable(cohortItems: List[CohortItem]) = {
+    ZLayer.succeed(
+      new CohortTable.Service {
+        override def fetch(
+            filter: CohortTableFilter,
+            beforeDateInclusive: Option[LocalDate]
+        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
+
+        override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+
+        override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+
+        override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
+          IO.succeed(ZStream.fromIterable(cohortItems))
+        }
+      }
+    )
+  }
+
+  def createStubS3(filesWrittenToS3: ArrayBuffer[(S3Location, String)]): Layer[Nothing, Has[S3.Service]] = ZLayer.succeed(
+    new S3.Service {
+      override def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream] = ???
+
+      override def putObject(s3Location: S3Location, file: File): IO[S3Failure, PutObjectResult] =
+        for {
+          fileContents <- ZIO.effectTotal(Source.fromFile(file, "UTF-8").getLines().mkString("\n"))
+          _ <- ZIO.effectTotal(filesWrittenToS3.addOne((s3Location, fileContents)))
+        } yield new PutObjectResult()
+    }
+  )
+
+  val expectedS3ExportBucketName = "export-s3-bucket-name"
+
+  val stubConfig = ZLayer.succeed(
+    new ExportConfiguration.Service {
+      override val config: IO[ConfigurationFailure, ExportConfig] =
+        IO.succeed(ExportConfig(expectedS3ExportBucketName))
+    }
+  )
+
+  test("CohortTableExportHandler should write cohort items to s3 as CSV") {
+    val expectedCohortName = "expected cohort name"
+    val cohortSpec = new CohortSpec(expectedCohortName, "", LocalDate.now(), LocalDate.now())
+    val uploadedFiles = ArrayBuffer[(S3Location, String)]()
+    val stubS3 = createStubS3(uploadedFiles)
+
+    val cohortItem = CohortItem(
+      subscriptionName = "subscription 1",
+      processingStage = NotificationSendComplete,
+      startDate = Some(LocalDate.of(2020,1,1)),
+      currency = Some("USD"),
+      oldPrice = Some(1.00),
+      estimatedNewPrice = Some(2.00),
+      billingPeriod = Some("quarter"),
+      whenEstimationDone = Some(Instant.parse("2020-01-01T01:01:01Z")),
+      salesforcePriceRiseId = Some("salesForcePriceRiseId1"),
+      whenSfShowEstimate = Some(Instant.parse("2020-01-02T01:01:01Z")),
+      newPrice = Some(3.00),
+      newSubscriptionId = Some("zuoraSubId1"),
+      whenAmendmentDone = Some(Instant.parse("2020-01-03T01:01:01Z")),
+      whenNotificationSent = Some(Instant.parse("2020-01-04T01:01:01Z")),
+      whenNotificationSentWrittenToSalesforce = Some(Instant.parse("2020-01-05T01:01:01Z")),
+      whenAmendmentWrittenToSalesforce = Some(Instant.parse("2020-01-06T01:01:01Z"))
+    )
+
+    val stubCohortTable = createStubCohortTable(List(cohortItem))
+
+    assertEquals(
+      default.unsafeRunSync(
+        CohortTableDatalakeExportHandler
+          .main(cohortSpec)
+          .provideLayer(
+            TestLogging.logging ++ stubCohortTable ++ stubS3 ++ stubConfig
+          )
+      ),
+      Success(HandlerOutput(isComplete = true))
+    )
+
+    assertEquals(1, uploadedFiles.size)
+    assertEquals(expectedS3ExportBucketName, uploadedFiles(0)._1.bucket)
+    val (actualS3Location, actualFileContents) = uploadedFiles(0)
+    assertEquals(expectedS3ExportBucketName, actualS3Location.bucket)
+    assertEquals(s"/data/${expectedCohortName}.csv", actualS3Location.path)
+    assertEquals(
+      """"cohortName","subscriptionName","processingStage","startDate","currency","oldPrice","estimatedNewPrice","billingPeriod","whenEstimationDone","salesforcePriceRiseId","whenSfShowEstimate","newPrice","newSubscriptionId","whenAmendmentDone","whenNotificationSent","whenNotificationSentWrittenToSalesforce","whenAmendmentWrittenToSalesforce"
+        |"expected cohort name","subscription 1","NotificationSendComplete","2020-01-01","USD","1.0","2.0","quarter","2020-01-01T01:01:01Z","salesForcePriceRiseId1","2020-01-02T01:01:01Z","3.0","zuoraSubId1","2020-01-03T01:01:01Z","2020-01-04T01:01:01Z","2020-01-05T01:01:01Z","2020-01-06T01:01:01Z"""".stripMargin,
+      actualFileContents
+    )
+  }
+  test("CohortTableExportHandler should write cohort items with missing optional values to s3 as CSV") {
+    val expectedCohortName = "expected cohort name"
+    val cohortSpec = new CohortSpec(expectedCohortName, "", LocalDate.now(), LocalDate.now())
+    val uploadedFiles = ArrayBuffer[(S3Location, String)]()
+    val stubS3 = createStubS3(uploadedFiles)
+
+    val cohortItem = CohortItem(
+      subscriptionName = "subscription 2",
+      processingStage = ReadyForEstimation,
+    )
+
+    val stubCohortTable = createStubCohortTable(List(cohortItem))
+
+    assertEquals(
+      default.unsafeRunSync(
+        CohortTableDatalakeExportHandler
+          .main(cohortSpec)
+          .provideLayer(
+            TestLogging.logging ++ stubCohortTable ++ stubS3 ++ stubConfig
+          )
+      ),
+      Success(HandlerOutput(isComplete = true))
+    )
+
+    assertEquals(1, uploadedFiles.size)
+    assertEquals(expectedS3ExportBucketName, uploadedFiles(0)._1.bucket)
+    val (actualS3Location, actualFileContents) = uploadedFiles(0)
+    assertEquals(expectedS3ExportBucketName, actualS3Location.bucket)
+    assertEquals(s"/data/${expectedCohortName}.csv", actualS3Location.path)
+    assertEquals(
+      """"cohortName","subscriptionName","processingStage","startDate","currency","oldPrice","estimatedNewPrice","billingPeriod","whenEstimationDone","salesforcePriceRiseId","whenSfShowEstimate","newPrice","newSubscriptionId","whenAmendmentDone","whenNotificationSent","whenNotificationSentWrittenToSalesforce","whenAmendmentWrittenToSalesforce"
+        |"expected cohort name","subscription 2","ReadyForEstimation","","","","","","","","","","","","","",""""".stripMargin,
+      actualFileContents
+    )
+  }
+}

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -104,7 +104,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
     assertEquals(expectedS3ExportBucketName, uploadedFiles(0)._1.bucket)
     val (actualS3Location, actualFileContents) = uploadedFiles(0)
     assertEquals(expectedS3ExportBucketName, actualS3Location.bucket)
-    assertEquals(s"/data/${expectedCohortName}.csv", actualS3Location.key)
+    assertEquals(s"data/${expectedCohortName}.csv", actualS3Location.key)
     assertEquals(
       """"cohort_name","subscription_name","processing_stage","start_date","currency","old_price","estimated_new_price","billing_period","when_estimation_done","salesforce_price_rise_id","when_sf_show_estimate","new_price","new_subscription_id","when_amendment_done","when_notification_sent","when_notification_sent_written_to_salesforce","when_amendment_written_to_salesforce"
         |"expected cohort name","subscription 1","NotificationSendComplete","2020-01-01","USD","1.0","2.0","quarter","2020-01-01T01:01:01Z","salesForcePriceRiseId1","2020-01-02T01:01:01Z","3.0","zuoraSubId1","2020-01-03T01:01:01Z","2020-01-04T01:01:01Z","2020-01-05T01:01:01Z","2020-01-06T01:01:01Z"""".stripMargin,
@@ -139,7 +139,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
     assertEquals(expectedS3ExportBucketName, uploadedFiles(0)._1.bucket)
     val (actualS3Location, actualFileContents) = uploadedFiles(0)
     assertEquals(expectedS3ExportBucketName, actualS3Location.bucket)
-    assertEquals(s"/data/${expectedCohortName}.csv", actualS3Location.key)
+    assertEquals(s"data/${expectedCohortName}.csv", actualS3Location.key)
     assertEquals(
       """"cohort_name","subscription_name","processing_stage","start_date","currency","old_price","estimated_new_price","billing_period","when_estimation_done","salesforce_price_rise_id","when_sf_show_estimate","new_price","new_subscription_id","when_amendment_done","when_notification_sent","when_notification_sent_written_to_salesforce","when_amendment_written_to_salesforce"
         |"expected cohort name","subscription 2","ReadyForEstimation","","","","","","","","","","","","","",""""".stripMargin,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.handlers
 import java.io.{File, InputStream}
 import java.time._
 
-import com.amazonaws.services.s3.model.PutObjectResult
+import com.amazonaws.services.s3.model.{CannedAccessControlList, PutObjectResult}
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.services._
@@ -41,7 +41,11 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
     new S3.Service {
       override def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream] = ???
 
-      override def putObject(s3Location: S3Location, file: File): IO[S3Failure, PutObjectResult] =
+      override def putObject(
+        s3Location: S3Location,
+        file: File,
+        cannedAccessControlList: Option[CannedAccessControlList]
+      ): IO[S3Failure, PutObjectResult] =
         for {
           fileContents <- ZIO.effectTotal(Source.fromFile(file, "UTF-8").getLines().mkString("\n"))
           _ <- ZIO.effectTotal(filesWrittenToS3.addOne((s3Location, fileContents)))

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -57,8 +57,8 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
 
   val stubConfig = ZLayer.succeed(
     new ExportConfiguration.Service {
-      override val config: IO[ConfigurationFailure, ExportConfig] =
-        IO.succeed(ExportConfig(expectedS3ExportBucketName))
+      override val config: ExportConfig =
+        ExportConfig(expectedS3ExportBucketName)
     }
   )
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -26,7 +26,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
             beforeDateInclusive: Option[LocalDate]
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
 
-        override def put(cohortItem: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
+        override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.handlers
 import java.io.{File, InputStream}
 import java.time.LocalDate
 
-import com.amazonaws.services.s3.model.PutObjectResult
+import com.amazonaws.services.s3.model.{CannedAccessControlList, PutObjectResult}
 import pricemigrationengine.TestLogging
 import pricemigrationengine.model._
 import pricemigrationengine.services._
@@ -59,7 +59,11 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
               loadTestResource("/SubscriptionIds.csv")
           }
 
-        override def putObject(s3Location: S3Location, file: File): IO[S3Failure, PutObjectResult] = ???
+        override def putObject(
+          s3Location: S3Location,
+          file: File,
+          cannedAccessControlList: Option[CannedAccessControlList]
+        ): IO[S3Failure, PutObjectResult] = ???
       }
     )
 

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -51,6 +51,7 @@ Resources:
                   - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-UpdatingSalesforceWithNotificationsLambda
                   - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-AmendingLambda
                   - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-UpdatingSalesforceWithAmendsLambda
+                  - Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-ExportingCohortTableToDatalakeLambda
         - PolicyName: LoggingPolicy
           PolicyDocument:
             Statement:
@@ -281,6 +282,26 @@ Resources:
                   "Next": "UpdatingSalesforceWithAmendments"
                 }
                 ],
+                "Default": "ExportingCohortTableToDatalake"
+              },
+              "ExportingCohortTableToDatalake": {
+                "Type": "Task",
+                "Comment": "Exporting cohort data to the datalake.",
+                "Resource": "${ExportingCohortTableToDatalakeLambdaArn}",
+                "InputPath": "$.cohortSpec",
+                "ResultPath": "$.result",
+                "Next": "IsUpdatingSalesforceWithAmendmentsComplete"
+              },
+              "IsExportingCohortTableToDatalakeComplete": {
+                "Type": "Choice",
+                "Comment": "Is the exporting cohort data to the datalake step complete?",
+                "Choices": [
+                {
+                  "Variable": "$.result.isComplete",
+                  "BooleanEquals": false,
+                  "Next": "ExportingCohortTableToDatalake"
+                }
+                ],
                 "Default": "Complete"
               },
               "Complete": {
@@ -303,3 +324,5 @@ Resources:
             Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-AmendingLambda
           UpdatingSalesforceWithAmendsLambdaArn:
             Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-UpdatingSalesforceWithAmendsLambda
+          ExportingCohortTableToDatalakeLambdaArn:
+            Fn::ImportValue: !Sub membership-${Stage}-${ResourceNamePrefix}-lambda-ExportingCohortTableToDatalakeLambda

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -290,7 +290,7 @@ Resources:
                 "Resource": "${ExportingCohortTableToDatalakeLambdaArn}",
                 "InputPath": "$.cohortSpec",
                 "ResultPath": "$.result",
-                "Next": "IsUpdatingSalesforceWithAmendmentsComplete"
+                "Next": "IsExportingCohortTableToDatalakeComplete"
               },
               "IsExportingCohortTableToDatalakeComplete": {
                 "Type": "Choice",


### PR DESCRIPTION
This PR contains the code to complete the exporting of the CohortTable to the datalake.

Each Cohort will export a separate file of the form <cohort name>.csv to the s3://ophan-clean-price-migration-engine-cohort-items/data bucket.

At mid-day every day those files are sync over to the google 'datalake' platform at which point they become available to be queried using the google tools.

These changes include:
- State machine config to add the export step
- Making export bucket configurable, this just currently points at the price-migration-engine-STAGE bucket but will be changed to the appropriate bucket in prod once its been created.
- Updating s3 put method to take an optional CannedAcl so the files permissions can be set correctly for the exported file.
- Updating CSV header names for consistency with field names in the datalake
- Tests for the export handler
