### PR TITLE
adding missing CohortTableFilter

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -24,8 +24,6 @@ object CohortTableFilter {
 
   case object AmendmentComplete extends CohortTableFilter { override val value: String = "AmendmentComplete" }
 
-  case object AmendmentFailed extends CohortTableFilter { override val value: String = "AmendmentFailed" }
-
   case object AmendmentWrittenToSalesforce extends CohortTableFilter {
     override val value: String = "AmendmentWrittenToSalesforce"
   }
@@ -43,6 +41,8 @@ object CohortTableFilter {
   case object NotificationSendProcessingOrError extends CohortTableFilter {
     override val value: String = "NotificationSendProcessingOrError"
   }
+
+  case object AmendmentFailed extends CohortTableFilter { override val value: String = "AmendmentFailed" }
 
   val all = Set(
     AmendmentComplete,

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -24,6 +24,8 @@ object CohortTableFilter {
 
   case object AmendmentComplete extends CohortTableFilter { override val value: String = "AmendmentComplete" }
 
+  case object AmendmentFailed extends CohortTableFilter { override val value: String = "AmendmentFailed" }
+
   case object AmendmentWrittenToSalesforce extends CohortTableFilter {
     override val value: String = "AmendmentWrittenToSalesforce"
   }
@@ -43,15 +45,16 @@ object CohortTableFilter {
   }
 
   val all = Set(
-    ReadyForEstimation,
-    EstimationFailed,
-    EstimationComplete,
-    SalesforcePriceRiceCreationComplete,
     AmendmentComplete,
+    AmendmentFailed,
+    AmendmentWrittenToSalesforce,
     Cancelled,
-    NotificationSendProcessingOrError,
+    EstimationComplete,
+    EstimationFailed,
     NotificationSendComplete,
     NotificationSendDateWrittenToSalesforce,
-    AmendmentWrittenToSalesforce
+    NotificationSendProcessingOrError,
+    ReadyForEstimation,
+    SalesforcePriceRiceCreationComplete,
   )
 }


### PR DESCRIPTION
Adding a 'missing' cohort table filter 'AmendmentFailed' and ensured the CohortFilter.all field is up to date.