### PR TITLE
Expect new price to be greater than old price

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -33,6 +33,6 @@ object EstimationResult {
     }
 }
 
-case class FailedEstimationResult(subscriptionNumber: String) extends EstimationResult
+case class FailedEstimationResult(subscriptionNumber: String, reason: String) extends EstimationResult
 
 case class CancelledEstimationResult(subscriptionNumber: String) extends EstimationResult


### PR DESCRIPTION
If the new price is the same as, or lower than, the old price this suggests that something has gone wrong.
Either the estimate is wrong or the subscription is in a bad state or the amendment has already been applied and is now being applied again.

This change will set the state of such a sub to 'EstimationFailed' and log the reason for failure:
`FailedEstimationResult(A-S12345678,No increase in price)`
