### PR TITLE
Include subscription number in notification error

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -60,7 +60,9 @@ object NotificationHandler extends CohortHandler {
 
     result.catchAll { failure =>
       for {
-        _ <- Logging.error(s"Failed to send price rise notification: $failure")
+        _ <- Logging.error(
+          s"Subscription ${cohortItem.subscriptionName}: Failed to send price rise notification: $failure"
+        )
       } yield Unsuccessful
     }
   }


### PR DESCRIPTION
To make it easier to search for errors.
