### PR TITLE
Throttle send email

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -16,6 +16,7 @@ import pricemigrationengine.model.membershipworkflow.{
 import pricemigrationengine.services._
 import zio.clock.Clock
 import zio.{ZEnv, ZIO, ZLayer}
+import zio.duration._
 
 object NotificationHandler extends CohortHandler {
 
@@ -37,6 +38,8 @@ object NotificationHandler extends CohortHandler {
       )
       count <-
         subscriptions
+          .chunkN(1)
+          .throttleShape(1, 250.milliseconds)(costFn = _ => 1)
           .mapM(sendNotification(brazeCampaignName))
           .fold(0) { (sum, count) => sum + count }
       _ <- Logging.info(s"Successfully sent $count price rise notifications")

--- a/lambda/src/test/scala/pricemigrationengine/StubClock.scala
+++ b/lambda/src/test/scala/pricemigrationengine/StubClock.scala
@@ -14,7 +14,7 @@ object StubClock {
       override def currentTime(unit: TimeUnit): UIO[Long] = ???
       override def currentDateTime: IO[DateTimeException, OffsetDateTime] =
         IO.succeed(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
-      override def nanoTime: UIO[Long] = ???
+      override def nanoTime: UIO[Long] = UIO.succeed(1L)
       override def sleep(duration: Duration): UIO[Unit] = ???
     }
   )


### PR DESCRIPTION
Try to stay under 1000 Latcham webhook triggers per minute. Paul's performance testing demonstrated 500 response on above 1000 per minute, which means Braze would retry the webhook, which might be the cause of duplicate records in Latcham (TBC).

- [Braze retry logic](https://www.braze.com/docs/user_guide/message_building_by_channel/webhooks/creating_a_webhook/#errors-retry-logic-and-timeouts)
- [Latcham Direct - API test cases](https://docs.google.com/spreadsheets/d/1d_UpFB9JzkfRXfG_Rel2jUq3ORvYO3us6ru9i59vn0w/edit#gid=5475790)
- [Rates of webhook trigger on 2020-08-22](https://docs.google.com/spreadsheets/d/18WWCApCKn-MsUDOcYmtXx4wJyUcgHyaOSbmVnGOqU2c/edit?ts=5f47edbc#gid=989130158)