### PR TITLE
Retry Zuora calls on failure

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 2.6.4
+version = 2.7.0
 
 maxColumn = 120

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -3,9 +3,7 @@ package pricemigrationengine.handlers
 import pricemigrationengine.model.CohortTableFilter.NotificationSendDateWrittenToSalesforce
 import pricemigrationengine.model._
 import pricemigrationengine.services._
-import zio.Schedule.{exponential, recurs}
 import zio.clock.Clock
-import zio.duration._
 import zio.{ZEnv, ZIO, ZLayer}
 
 /**
@@ -72,9 +70,7 @@ object AmendmentHandler extends CohortHandler {
       newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
       subscriptionAfterUpdate <- fetchSubscription(item)
       invoicePreviewAfterUpdate <-
-        Zuora
-          .fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)
-          .retry(exponential(1.second) && recurs(5)) // to work around StaleObjectStateException in Zuora response
+        Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)
       newPrice <-
         ZIO.fromEither(AmendmentData.totalChargeAmount(subscriptionAfterUpdate, invoicePreviewAfterUpdate, startDate))
       whenDone <- Time.thisInstant

--- a/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
@@ -28,7 +28,7 @@ object LiveLayer {
     Blocking.live and logging and EnvConfiguration.cohortStateMachineImpl to CohortStateMachineLive.impl
 
   val zuora: ZLayer[Logging, ConfigurationFailure, Zuora] =
-    EnvConfiguration.zuoraImpl and logging to ZuoraLive.impl
+    EnvConfiguration.zuoraImpl and Clock.live and logging to ZuoraLive.impl
 
   val salesforce: ZLayer[Logging, SalesforceClientFailure, SalesforceClient] =
     EnvConfiguration.salesforceImp and logging to SalesforceClientLive.impl

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -21,6 +21,7 @@ case class CohortCreateFailure(reason: String) extends Failure
 case class CohortItemAlreadyPresentFailure(reason: String) extends Failure
 case class CohortUpdateFailure(reason: String) extends Failure
 
+case class ZuoraFailure(reason: String) extends Failure
 case class ZuoraFetchFailure(reason: String) extends Failure
 case class ZuoraUpdateFailure(reason: String) extends Failure
 

--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -4,26 +4,28 @@ import java.time.LocalDate
 
 import pricemigrationengine.model._
 import scalaj.http.{Http, HttpOptions, HttpRequest, HttpResponse}
-import upickle.default._
+import upickle.default.{ReadWriter, Reader, macroRW, read, write}
+import zio.Schedule.{exponential, recurs}
+import zio.clock.Clock
+import zio.duration._
 import zio.{ZIO, ZLayer}
 
-import scala.concurrent.duration._
-
 object ZuoraLive {
-  val impl: ZLayer[ZuoraConfiguration with Logging, ConfigurationFailure, Zuora] = ZLayer
+  val impl: ZLayer[ZuoraConfiguration with Clock with Logging, ConfigurationFailure, Zuora] = ZLayer
     .fromServicesM[
       ZuoraConfiguration.Service,
+      Clock.Service,
       Logging.Service,
-      ZuoraConfiguration with Logging,
+      ZuoraConfiguration with Clock with Logging,
       ConfigurationFailure,
       Zuora.Service
-    ] { (configuration, logging) =>
+    ] { (configuration, clock, logging) =>
       configuration.config map { config =>
         new Zuora.Service {
 
           private val apiVersion = "v1"
 
-          private val timeout = Duration(30, SECONDS).toMillis.toInt
+          private val timeout = 30.seconds.toMillis.toInt
           private val connTimeout = HttpOptions.connTimeout(timeout)
           private val readTimeout = HttpOptions.readTimeout(timeout)
 
@@ -65,55 +67,62 @@ object ZuoraLive {
               Left(ZuoraFetchFailure(failureMessage(request, response)))
           }
 
-          private def get[A: Reader](path: String, params: Map[String, String] = Map.empty): ZIO[Any, Failure, A] =
+          private def get[A: Reader](
+              path: String,
+              params: Map[String, String] = Map.empty
+          ): ZIO[Any, ZuoraFetchFailure, A] =
             for {
               accessToken <- ZIO.fromEither(fetchedAccessToken)
               a <- handleRequest[A](
                 Http(s"${config.apiHost}/$apiVersion/$path")
                   .params(params)
                   .header("Authorization", s"Bearer $accessToken")
-              )
+              ).mapError(e => ZuoraFetchFailure(e.reason))
             } yield a
 
-          private def post[A: Reader](path: String, body: String): ZIO[Any, Failure, A] =
+          private def post[A: Reader](path: String, body: String): ZIO[Any, ZuoraUpdateFailure, A] =
             for {
-              accessToken <- ZIO.fromEither(fetchedAccessToken)
+              accessToken <- ZIO.fromEither(fetchedAccessToken).mapError(e => ZuoraUpdateFailure(e.reason))
               a <- handleRequest[A](
                 Http(s"${config.apiHost}/$apiVersion/$path")
                   .header("Authorization", s"Bearer $accessToken")
                   .header("Content-Type", "application/json")
                   .postData(body)
-              )
+              ).mapError(e => ZuoraUpdateFailure(e.reason))
             } yield a
 
-          private def put[A: Reader](path: String, body: String): ZIO[Any, Failure, A] =
+          private def put[A: Reader](path: String, body: String): ZIO[Any, ZuoraUpdateFailure, A] =
             for {
-              accessToken <- ZIO.fromEither(fetchedAccessToken)
+              accessToken <- ZIO.fromEither(fetchedAccessToken).mapError(e => ZuoraUpdateFailure(e.reason))
               a <- handleRequest[A](
                 Http(s"${config.apiHost}/$apiVersion/$path")
                   .header("Authorization", s"Bearer $accessToken")
                   .header("Content-Type", "application/json")
                   .put(body)
-              )
+              ).mapError(e => ZuoraUpdateFailure(e.reason))
             } yield a
 
-          private def handleRequest[A: Reader](request: HttpRequest): ZIO[Any, Failure, A] = {
-            val response = request
-              .option(connTimeout)
-              .option(readTimeout)
-              .asString
-            val body = response.body
-            if (response.code == 200)
-              ZIO
-                .effect(read[A](body))
-                .orElse(ZIO.fail(ZuoraFetchFailure(failureMessage(request, response))))
-            else
-              ZIO.fail(ZuoraFetchFailure(failureMessage(request, response)))
-          }
+          private def handleRequest[A: Reader](request: HttpRequest): ZIO[Any, ZuoraFailure, A] =
+            for {
+              response <-
+                ZIO
+                  .effect(request.option(connTimeout).option(readTimeout).asString)
+                  .retry(exponential(1.second) && recurs(5))
+                  .provideLayer(ZLayer.succeed(clock))
+                  .mapError(e => ZuoraFailure(failureMessage(request, e)))
+                  .filterOrElse(_.code == 200)(response => ZIO.fail(ZuoraFailure(failureMessage(request, response))))
+              a <-
+                ZIO
+                  .effect(read[A](response.body))
+                  .orElse(ZIO.fail(ZuoraFailure(failureMessage(request, response))))
+            } yield a
 
           private def failureMessage(request: HttpRequest, response: HttpResponse[String]) = {
             s"Request for ${request.method} ${request.url} returned status ${response.code} with body:${response.body}"
           }
+
+          private def failureMessage(request: HttpRequest, t: Throwable) =
+            s"Request for ${request.method} ${request.url} returned error ${t.toString}"
 
           def fetchSubscription(subscriptionNumber: String): ZIO[Any, ZuoraFetchFailure, ZuoraSubscription] =
             get[ZuoraSubscription](s"subscriptions/$subscriptionNumber")
@@ -166,9 +175,10 @@ object ZuoraLive {
               for {
                 curr <- fetchPage(pageIdx)
                 soFar = combine(acc, curr)
-                catalogue <- if (hasNextPage(curr)) {
-                  fetchCatalogue(soFar, pageIdx + 1)
-                } else ZIO.succeed(soFar)
+                catalogue <-
+                  if (hasNextPage(curr)) {
+                    fetchCatalogue(soFar, pageIdx + 1)
+                  } else ZIO.succeed(soFar)
               } yield catalogue
 
             fetchCatalogue(ZuoraProductCatalogue.empty, pageIdx = 1)
@@ -182,13 +192,12 @@ object ZuoraLive {
               path = s"subscriptions/${subscription.subscriptionNumber}",
               body = write(update)
             ).bimap(
-                e =>
-                  ZuoraUpdateFailure(
-                    s"Subscription ${subscription.subscriptionNumber} and update $update: ${e.reason}"
+              e =>
+                ZuoraUpdateFailure(
+                  s"Subscription ${subscription.subscriptionNumber} and update $update: ${e.reason}"
                 ),
-                response => response.subscriptionId
-              )
-              .tap(_ => logging.info(s"Updated subscription ${subscription.subscriptionNumber} with: $update"))
+              response => response.subscriptionId
+            ).tap(_ => logging.info(s"Updated subscription ${subscription.subscriptionNumber} with: $update"))
         }
       }
     }


### PR DESCRIPTION
Previously only the call to [fetch invoice preview after updating a subscription](https://github.com/guardian/price-migration-engine/compare/kc-zuora-retry?expand=1#diff-7e7faab75b94ac20b1e6efd5d0f2b264L77-L79) had a retry attached to it.
Now [all Zuora calls are retried](https://github.com/guardian/price-migration-engine/compare/kc-zuora-retry?expand=1#diff-04e584920e7bd8528c5096efbec9ce3cR105-R118) if they fail.

The [retry](https://github.com/guardian/price-migration-engine/compare/kc-zuora-retry?expand=1#diff-04e584920e7bd8528c5096efbec9ce3cR110) uses an exponential backoff policy - retrying up to 5 times at extending intervals starting at 1 second.
 