### PR TITLE
Fix case where subscriber's billing address has no street

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 2.7.0
+version = 2.7.2
 
 maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -34,9 +34,12 @@ lazy val lambda = (project in file("lambda"))
       awsStateMachine,
       http,
       commonsCsv,
-      munit % Test
+      munit % Test,
+      zioTest % Test,
+      zioTestSbt % Test
     ),
     testFrameworks += new TestFramework("munit.Framework"),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     description := "Lambda jar for the Price Migration Engine",
     assemblyJarName := "price-migration-engine-lambda.jar",
     riffRaffPackageType := assembly.value,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerSpec.scala
@@ -1,0 +1,57 @@
+package pricemigrationengine.handlers
+
+import pricemigrationengine.model.{SalesforceAddress, SalesforceContact}
+import zio.test.Assertion.equalTo
+import zio.test._
+
+object NotificationHandlerSpec extends DefaultRunnableSpec {
+
+  private val billingAddress = SalesforceAddress(
+    street = Some("21 High Street"),
+    city = Some("London"),
+    state = None,
+    postalCode = Some("N2 9GZ"),
+    country = Some("United Kingdom")
+  )
+
+  private val mailingAddress = SalesforceAddress(
+    street = Some("1 High Street"),
+    city = Some("London"),
+    state = None,
+    postalCode = Some("N1 9GU"),
+    country = Some("United Kingdom")
+  )
+
+  def spec: ZSpec[Environment, Failure] = suite("targetAddress")(
+    testM("should use mailing address if billing address has no street") {
+      val contact = SalesforceContact(
+        Id = "id",
+        IdentityID__c = None,
+        Email = None,
+        Salutation = None,
+        FirstName = None,
+        LastName = None,
+        OtherAddress = Some(billingAddress.copy(street = None)),
+        MailingAddress = Some(mailingAddress)
+      )
+      NotificationHandler.targetAddress(contact) map { address =>
+        assert(address)(equalTo(mailingAddress))
+      }
+    },
+    testM("should use mailing address if billing address has no city") {
+      val contact = SalesforceContact(
+        Id = "id",
+        IdentityID__c = None,
+        Email = None,
+        Salutation = None,
+        FirstName = None,
+        LastName = None,
+        OtherAddress = Some(billingAddress.copy(city = None)),
+        MailingAddress = Some(mailingAddress)
+      )
+      NotificationHandler.targetAddress(contact) map { address =>
+        assert(address)(equalTo(mailingAddress))
+      }
+    }
+  )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   private val zioVersion = "1.0.1"
-  private val awsSdkVersion = "1.11.855"
+  private val awsSdkVersion = "1.11.869"
 
   lazy val awsDynamoDb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
   lazy val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion
@@ -10,6 +10,8 @@ object Dependencies {
   lazy val awsStateMachine = "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsSdkVersion
   lazy val zio = "dev.zio" %% "zio" % zioVersion
   lazy val zioStreams = "dev.zio" %% "zio-streams" % zioVersion
+  lazy val zioTest = "dev.zio" %% "zio-test" % zioVersion
+  lazy val zioTestSbt = "dev.zio" %% "zio-test-sbt" % zioVersion
   lazy val upickle = "com.lihaoyi" %% "upickle" % "1.2.0"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"


### PR DESCRIPTION
Part of the price migration process is notifying subscribers by direct mail that a price migration is coming up.  There are a few cases where a missing street in the subscriber's billing address stops notifications being sent.  We have a business rule that if the billing address isn't complete, the mailing address is used instead.

This change modifies the logic of choosing an address so that a missing street in the billing address indicates that the billing address is incomplete.  So in that case the mailing address should be used instead.
