### PR TITLE
Bump ZIO to v1.0.2

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
@@ -16,9 +16,9 @@ object MigrationHandler extends zio.App with RequestHandler[Unit, Unit] {
       cohortSpecs <- CohortSpecTable.fetchAll
       activeSpecs <-
         ZIO
-          .filter(cohortSpecs.toList)(cohort => ZIO.succeed(CohortSpec.isActive(cohort)(today)))
+          .filter(cohortSpecs)(cohort => ZIO.succeed(CohortSpec.isActive(cohort)(today)))
           .tap(specs => Logging.info(s"Currently ${specs.size} active cohorts"))
-      _ <- ZIO.foreach(activeSpecs)(CohortStateMachine.startExecution)
+      _ <- ZIO.foreach_(activeSpecs)(CohortStateMachine.startExecution)
     } yield ()).tapError(e => Logging.error(s"Migration run failed: $e"))
 
   private val env: ZLayer[Logging, ConfigurationFailure, CohortSpecTable with CohortStateMachine with Logging] =

--- a/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
@@ -46,7 +46,7 @@ object S3Live {
       override def deleteObject(s3Location: S3Location): IO[S3Failure, Unit] =
         (for {
           listing <- IO.effect(s3.listObjects(s3Location.bucket, s3Location.key))
-          _ <- IO.foreach(listing.getObjectSummaries.asScala.toList)(summary =>
+          _ <- IO.foreach_(listing.getObjectSummaries.asScala)(summary =>
             IO.effect(s3.deleteObject(summary.getBucketName, summary.getKey))
               .tap(_ => logging.info(s"Deleted $summary"))
           )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  private val zioVersion = "1.0.1"
+  private val zioVersion = "1.0.2"
   private val awsSdkVersion = "1.11.869"
 
   lazy val awsDynamoDb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion


### PR DESCRIPTION
This update brings in https://github.com/zio/zio/pull/4188, which means we no longer need to convert sets to lists to filter them. 
It also changes some `foreach` to `foreach_`, which is more efficient as it doesn't bother to build up results.