### PR TITLE
Run Snyk as a GitHub Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,31 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  push:
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    env:
+      SNYK_COMMAND: test
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set command to monitor
+        if: github.ref == 'refs/heads/main'
+        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=the-guardian-cuu --project-name=${{ github.repository }}
+          command: ${{ env.SNYK_COMMAND }}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.0


### PR DESCRIPTION
This PR configures a GitHub Action to run Snyk. This action runs every day at 6 AM and on every push. If the branch it's running on is main then it will run `snyk monitor` (reports vulnerabilities to snyk.io), otherwise it will run `snyk test`. 
It also upgrades sbt to v1.4.0 so we can use `dependencyTree`.

Note: Because `dependencyTree` was missing, Snyk was unable to run correctly. For that reason I did not until this PR is merged to remove the Snyk config from TeamCity and GitHub.