### PR TITLE
Upgrade AWS SDK to v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .idea
+.bsp

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,20 @@ lazy val lambda = (project in file("lambda"))
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffManifestProjectName := "MemSub::Subscriptions::Lambda::PriceMigrationEngine",
-    riffRaffArtifactResources += ((project.base / "cfn.yaml", "cfn/cfn.yaml"))
+    riffRaffArtifactResources += ((project.base / "cfn.yaml", "cfn/cfn.yaml")),
+    assembly / assemblyMergeStrategy := {
+      /*
+       * AWS SDK v2 includes a codegen-resources directory in each jar, with conflicting names.
+       * This appears to be for generating clients from HTTP services.
+       * So it's redundant in a binary artefact.
+       */
+      case PathList("codegen-resources", _*)                    => MergeStrategy.discard
+      case PathList("module-info.class")                        => MergeStrategy.discard
+      case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.discard
+      case x =>
+        val oldStrategy = (assembly / assemblyMergeStrategy).value
+        oldStrategy(x)
+    }
   )
 
 lazy val stateMachine = (project in file("stateMachine"))

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -1,16 +1,15 @@
 package pricemigrationengine.handlers
 
-import java.io.{File, OutputStream, OutputStreamWriter}
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
-
-import com.amazonaws.services.s3.model.CannedAccessControlList
 import org.apache.commons.csv.{CSVFormat, CSVPrinter, QuoteMode}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import zio._
 import zio.stream.ZStream
 
+import java.io.{File, OutputStream, OutputStreamWriter}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
 import scala.util.Try
 
 object CohortTableDatalakeExportHandler extends CohortHandler {
@@ -42,7 +41,7 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
         }
 
         putResult <-
-          S3.putObject(s3Location, filePath.toFile, Some(CannedAccessControlList.BucketOwnerRead))
+          S3.putObject(s3Location, filePath.toFile, Some(ObjectCannedACL.BUCKET_OWNER_READ))
             .mapError { failure =>
               CohortTableDatalakeExportFailure(s"Failed to write CohortItems to s3: ${failure.reason}")
             }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
@@ -11,7 +11,7 @@ object LiveLayer {
   val logging: URLayer[Logging, Logging] = ZLayer.identity[Logging]
 
   private val dynamoDbClient: ZLayer[Logging, ConfigurationFailure, DynamoDBClient] =
-    EnvConfiguration.dynamoDbImpl and logging to DynamoDBClientLive.impl
+    logging to DynamoDBClientLive.impl
 
   def cohortTable(cohortSpec: CohortSpec): ZLayer[Logging, ConfigurationFailure, CohortTable] =
     dynamoDbClient and logging andTo

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentConfig.scala
@@ -6,10 +6,6 @@ case class ZuoraConfig(
     clientSecret: String
 )
 
-case class DynamoDBConfig(endpoint: Option[DynamoDBEndpointConfig])
-
-case class DynamoDBEndpointConfig(serviceEndpoint: String, signingRegion: String)
-
 case class CohortTableConfig(batchSize: Int = 100)
 
 case class StageConfig(stage: String)

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -1,11 +1,11 @@
 package pricemigrationengine.model
 
+import pricemigrationengine.model.dynamodb.Conversions._
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import upickle.default.{ReadWriter, macroRW}
+
 import java.time.LocalDate
 import java.util
-
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
-import pricemigrationengine.model.dynamodb.Conversions._
-import upickle.default.{ReadWriter, macroRW}
 
 /** Specification of a cohort.
   *

--- a/lambda/src/main/scala/pricemigrationengine/services/AwsClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/AwsClient.scala
@@ -1,0 +1,30 @@
+package pricemigrationengine.services
+
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
+import software.amazon.awssdk.regions.Region.EU_WEST_1
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.sfn.SfnClient
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+
+object AwsClient {
+
+  private val region = EU_WEST_1
+
+  /** By explicitly specifying which HTTP client to use, we save an expensive operation
+    * looking for a suitable HTTP client on the classpath.
+    */
+  private def httpSyncClientBuilder() = ApacheHttpClient.builder()
+  private def httpAsyncClientBuilder() = NettyNioAsyncHttpClient.builder()
+
+  lazy val sfn: SfnClient = SfnClient.builder.httpClientBuilder(httpSyncClientBuilder()).region(region).build()
+
+  lazy val s3: S3Client = S3Client.builder.httpClientBuilder(httpSyncClientBuilder()).region(region).build()
+
+  lazy val dynamoDb: DynamoDbClient =
+    DynamoDbClient.builder.httpClientBuilder(httpSyncClientBuilder()).region(region).build()
+
+  lazy val sqsAsync: SqsAsyncClient =
+    SqsAsyncClient.builder.httpClientBuilder(httpAsyncClientBuilder()).region(region).build()
+}

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachine.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachine.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.services
 
-import com.amazonaws.services.stepfunctions.model.StartExecutionResult
 import pricemigrationengine.model.{CohortSpec, CohortStateMachineFailure}
+import software.amazon.awssdk.services.sfn.model.StartExecutionResponse
 import zio.ZIO
 import zio.clock.Clock
 
@@ -12,11 +12,11 @@ import zio.clock.Clock
 object CohortStateMachine {
 
   trait Service {
-    def startExecution(spec: CohortSpec): ZIO[Clock, CohortStateMachineFailure, StartExecutionResult]
+    def startExecution(spec: CohortSpec): ZIO[Clock, CohortStateMachineFailure, StartExecutionResponse]
   }
 
   def startExecution(
       spec: CohortSpec
-  ): ZIO[CohortStateMachine with Clock, CohortStateMachineFailure, StartExecutionResult] =
+  ): ZIO[CohortStateMachine with Clock, CohortStateMachineFailure, StartExecutionResponse] =
     ZIO.accessM(_.get.startExecution(spec))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
@@ -2,8 +2,6 @@ package pricemigrationengine.services
 
 import pricemigrationengine.handlers.Time
 import pricemigrationengine.model._
-import software.amazon.awssdk.regions.Region.EU_WEST_1
-import software.amazon.awssdk.services.sfn.SfnClient
 import software.amazon.awssdk.services.sfn.model.{StartExecutionRequest, StartExecutionResponse}
 import upickle.default.{ReadWriter, macroRW, write}
 import zio.blocking.Blocking
@@ -22,7 +20,7 @@ object CohortStateMachineLive {
   val impl
       : ZLayer[CohortStateMachineConfiguration with Logging with Blocking, ConfigurationFailure, CohortStateMachine] = {
 
-    val stateMachine = SfnClient.builder.region(EU_WEST_1).build()
+    val stateMachine = AwsClient.sfn
 
     ZLayer.fromServicesM[
       CohortStateMachineConfiguration.Service,

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
@@ -1,17 +1,17 @@
 package pricemigrationengine.services
 
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-
-import com.amazonaws.regions.Regions.EU_WEST_1
-import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder
-import com.amazonaws.services.stepfunctions.model.{StartExecutionRequest, StartExecutionResult}
 import pricemigrationengine.handlers.Time
 import pricemigrationengine.model._
+import software.amazon.awssdk.regions.Region.EU_WEST_1
+import software.amazon.awssdk.services.sfn.SfnClient
+import software.amazon.awssdk.services.sfn.model.{StartExecutionRequest, StartExecutionResponse}
 import upickle.default.{ReadWriter, macroRW, write}
 import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.{ZIO, ZLayer}
+
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 object CohortStateMachineLive {
 
@@ -22,7 +22,7 @@ object CohortStateMachineLive {
   val impl
       : ZLayer[CohortStateMachineConfiguration with Logging with Blocking, ConfigurationFailure, CohortStateMachine] = {
 
-    val stateMachine = AWSStepFunctionsClientBuilder.standard.withRegion(EU_WEST_1).build
+    val stateMachine = SfnClient.builder.region(EU_WEST_1).build()
 
     ZLayer.fromServicesM[
       CohortStateMachineConfiguration.Service,
@@ -36,7 +36,7 @@ object CohortStateMachineLive {
         //noinspection ConvertExpressionToSAM
         new CohortStateMachine.Service {
 
-          def startExecution(spec: CohortSpec): ZIO[Clock, CohortStateMachineFailure, StartExecutionResult] =
+          def startExecution(spec: CohortSpec): ZIO[Clock, CohortStateMachineFailure, StartExecutionResponse] =
             for {
               _ <- logging.info(s"Starting execution with input: ${spec.toString} ...")
               time <- Time.thisInstant.mapError(e => CohortStateMachineFailure(e.toString))
@@ -48,10 +48,11 @@ object CohortStateMachineLive {
                 blocking
                   .effectBlocking(
                     stateMachine.startExecution(
-                      new StartExecutionRequest()
-                        .withStateMachineArn(config.stateMachineArn)
-                        .withName(s"${spec.normalisedCohortName}-$timeStr")
-                        .withInput(write(StateMachineInput(spec)))
+                      StartExecutionRequest.builder
+                        .stateMachineArn(config.stateMachineArn)
+                        .name(s"${spec.normalisedCohortName}-$timeStr")
+                        .input(write(StateMachineInput(spec)))
+                        .build()
                     )
                   )
                   .mapError(e => CohortStateMachineFailure(s"Failed to start execution: $e"))

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdl.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdl.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.services
 
-import com.amazonaws.services.dynamodbv2.model.CreateTableResult
 import pricemigrationengine.model.{CohortSpec, CohortTableCreateFailure}
+import software.amazon.awssdk.services.dynamodb.model.CreateTableResponse
 import zio.{IO, ZIO}
 
 object CohortTableDdl {
@@ -14,9 +14,9 @@ object CohortTableDdl {
     /** Create a table for the given CohortSpec if it doesn't already exist.
       * Otherwise do nothing.
       */
-    def createTable(cohortSpec: CohortSpec): IO[CohortTableCreateFailure, Option[CreateTableResult]]
+    def createTable(cohortSpec: CohortSpec): IO[CohortTableCreateFailure, Option[CreateTableResponse]]
   }
 
-  def createTable(cohortSpec: CohortSpec): ZIO[CohortTableDdl, CohortTableCreateFailure, Option[CreateTableResult]] =
+  def createTable(cohortSpec: CohortSpec): ZIO[CohortTableDdl, CohortTableCreateFailure, Option[CreateTableResponse]] =
     ZIO.accessM(_.get.createTable(cohortSpec))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Configuration.scala
@@ -12,15 +12,6 @@ object ZuoraConfiguration {
     ZIO.accessM(_.get.config)
 }
 
-object DynamoDBConfiguration {
-  trait Service {
-    val config: IO[ConfigurationFailure, DynamoDBConfig]
-  }
-
-  val dynamoDBConfig: ZIO[DynamoDBConfiguration, ConfigurationFailure, DynamoDBConfig] =
-    ZIO.accessM(_.get.config)
-}
-
 object CohortTableConfiguration {
   trait Service {
     val config: IO[ConfigurationFailure, CohortTableConfig]

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClient.scala
@@ -1,36 +1,50 @@
 package pricemigrationengine.services
 
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model.{
+  CreateTableRequest,
+  CreateTableResponse,
+  DescribeTableResponse,
+  PutItemRequest,
+  PutItemResponse,
+  QueryRequest,
+  QueryResponse,
+  ScanRequest,
+  ScanResponse,
+  UpdateContinuousBackupsRequest,
+  UpdateContinuousBackupsResponse,
+  UpdateItemRequest,
+  UpdateItemResponse
+}
 import zio.{RIO, Task}
 
 object DynamoDBClient {
   trait Service {
-    def query(queryRequest: QueryRequest): Task[QueryResult]
-    def scan(scanRequest: ScanRequest): Task[ScanResult]
-    def updateItem(updateRequest: UpdateItemRequest): Task[UpdateItemResult]
-    def createItem(createRequest: PutItemRequest, keyName: String): Task[PutItemResult]
-    def describeTable(tableName: String): Task[DescribeTableResult]
-    def createTable(request: CreateTableRequest): Task[CreateTableResult]
-    def updateContinuousBackups(request: UpdateContinuousBackupsRequest): Task[UpdateContinuousBackupsResult]
+    def query(queryRequest: QueryRequest): Task[QueryResponse]
+    def scan(scanRequest: ScanRequest): Task[ScanResponse]
+    def updateItem(updateRequest: UpdateItemRequest): Task[UpdateItemResponse]
+    def createItem(createRequest: PutItemRequest, keyName: String): Task[PutItemResponse]
+    def describeTable(tableName: String): Task[DescribeTableResponse]
+    def createTable(request: CreateTableRequest): Task[CreateTableResponse]
+    def updateContinuousBackups(request: UpdateContinuousBackupsRequest): Task[UpdateContinuousBackupsResponse]
   }
 
-  def query(queryRequest: QueryRequest): RIO[DynamoDBClient, QueryResult] = RIO.accessM(_.get.query(queryRequest))
+  def query(queryRequest: QueryRequest): RIO[DynamoDBClient, QueryResponse] = RIO.accessM(_.get.query(queryRequest))
 
-  def scan(scanRequest: ScanRequest): RIO[DynamoDBClient, ScanResult] = RIO.accessM(_.get.scan(scanRequest))
+  def scan(scanRequest: ScanRequest): RIO[DynamoDBClient, ScanResponse] = RIO.accessM(_.get.scan(scanRequest))
 
-  def updateItem(updateRequest: UpdateItemRequest): RIO[DynamoDBClient, UpdateItemResult] =
+  def updateItem(updateRequest: UpdateItemRequest): RIO[DynamoDBClient, UpdateItemResponse] =
     RIO.accessM(_.get.updateItem(updateRequest))
 
-  def createItem(createRequest: PutItemRequest, keyName: String): RIO[DynamoDBClient, PutItemResult] =
+  def createItem(createRequest: PutItemRequest, keyName: String): RIO[DynamoDBClient, PutItemResponse] =
     RIO.accessM(_.get.createItem(createRequest, keyName))
 
-  def describeTable(tableName: String): RIO[DynamoDBClient, DescribeTableResult] =
+  def describeTable(tableName: String): RIO[DynamoDBClient, DescribeTableResponse] =
     RIO.accessM(_.get.describeTable(tableName))
 
-  def createTable(request: CreateTableRequest): RIO[DynamoDBClient, CreateTableResult] =
+  def createTable(request: CreateTableRequest): RIO[DynamoDBClient, CreateTableResponse] =
     RIO.accessM(_.get.createTable(request))
 
   def updateContinuousBackups(
       request: UpdateContinuousBackupsRequest
-  ): RIO[DynamoDBClient, UpdateContinuousBackupsResult] = RIO.accessM(_.get.updateContinuousBackups(request))
+  ): RIO[DynamoDBClient, UpdateContinuousBackupsResponse] = RIO.accessM(_.get.updateContinuousBackups(request))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClientLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClientLive.scala
@@ -1,57 +1,47 @@
 package pricemigrationengine.services
 
-import com.amazonaws.client.builder.AwsClientBuilder
-import com.amazonaws.services.dynamodbv2.model._
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClient}
 import pricemigrationengine.model.ConfigurationFailure
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model._
 import zio._
 
 object DynamoDBClientLive {
-  val impl: ZLayer[DynamoDBConfiguration with Logging, ConfigurationFailure, DynamoDBClient] = {
+  val impl: ZLayer[Logging, ConfigurationFailure, DynamoDBClient] = {
 
-    def acquireDynamoDb: ZIO[DynamoDBConfiguration with Logging, ConfigurationFailure, AmazonDynamoDB] =
-      for {
-        config <- DynamoDBConfiguration.dynamoDBConfig
-        client <-
-          ZIO
-            .effect(
-              config.endpoint
-                .foldLeft(AmazonDynamoDBClient.builder())((builder, endpoint) =>
-                  builder.withEndpointConfiguration(
-                    new AwsClientBuilder.EndpointConfiguration(endpoint.serviceEndpoint, endpoint.signingRegion)
-                  )
-                )
-                .build()
-            )
-            .mapError(ex => ConfigurationFailure(s"Failed to create the dynamoDb client: $ex"))
-      } yield client
-
-    def releaseDynamoDb(dynamoDb: AmazonDynamoDB): URIO[Logging, Unit] =
+    def acquireDynamoDb: ZIO[Logging, ConfigurationFailure, DynamoDbClient] =
       ZIO
-        .effect(dynamoDb.shutdown())
+        .effect(DynamoDbClient.create())
+        .mapError(ex => ConfigurationFailure(s"Failed to create the dynamoDb client: $ex"))
+
+    def releaseDynamoDb(dynamoDb: DynamoDbClient): URIO[Logging, Unit] =
+      ZIO
+        .effect(dynamoDb.close())
         .catchAll(ex => Logging.error(s"Failed to close dynamo db connection: $ex"))
 
-    val dynamoDbLayer: ZLayer[DynamoDBConfiguration with Logging, ConfigurationFailure, Has[AmazonDynamoDB]] =
+    val dynamoDbLayer: ZLayer[Logging, ConfigurationFailure, Has[DynamoDbClient]] =
       ZLayer.fromAcquireRelease(acquireDynamoDb)(releaseDynamoDb)
 
-    val serviceLayer: ZLayer[Has[AmazonDynamoDB], Nothing, DynamoDBClient] = ZLayer.fromService { dynamoDb =>
+    val serviceLayer: ZLayer[Has[DynamoDbClient], Nothing, DynamoDBClient] = ZLayer.fromService { dynamoDb =>
       new DynamoDBClient.Service {
-        def query(queryRequest: QueryRequest): Task[QueryResult] = Task.effect(dynamoDb.query(queryRequest))
+        def query(queryRequest: QueryRequest): Task[QueryResponse] = Task.effect(dynamoDb.query(queryRequest))
 
-        def scan(scanRequest: ScanRequest): Task[ScanResult] = Task.effect(dynamoDb.scan(scanRequest))
+        def scan(scanRequest: ScanRequest): Task[ScanResponse] = Task.effect(dynamoDb.scan(scanRequest))
 
-        def updateItem(updateRequest: UpdateItemRequest): Task[UpdateItemResult] =
+        def updateItem(updateRequest: UpdateItemRequest): Task[UpdateItemResponse] =
           Task.effect(dynamoDb.updateItem(updateRequest))
 
-        def createItem(createRequest: PutItemRequest, keyName: String): Task[PutItemResult] =
-          Task.effect(dynamoDb.putItem(createRequest.withConditionExpression(s"attribute_not_exists($keyName)")))
+        def createItem(createRequest: PutItemRequest, keyName: String): Task[PutItemResponse] =
+          Task.effect(
+            dynamoDb.putItem(createRequest.copy(x => x.conditionExpression(s"attribute_not_exists($keyName)")))
+          )
 
-        def describeTable(tableName: String): Task[DescribeTableResult] = Task.effect(dynamoDb.describeTable(tableName))
+        def describeTable(tableName: String): Task[DescribeTableResponse] =
+          Task.effect(dynamoDb.describeTable(DescribeTableRequest.builder.tableName(tableName).build()))
 
-        def createTable(request: CreateTableRequest): Task[CreateTableResult] =
+        def createTable(request: CreateTableRequest): Task[CreateTableResponse] =
           Task.effect(dynamoDb.createTable(request))
 
-        def updateContinuousBackups(request: UpdateContinuousBackupsRequest): Task[UpdateContinuousBackupsResult] =
+        def updateContinuousBackups(request: UpdateContinuousBackupsRequest): Task[UpdateContinuousBackupsResponse] =
           Task.effect(dynamoDb.updateContinuousBackups(request))
       }
     }

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClientLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClientLive.scala
@@ -10,7 +10,7 @@ object DynamoDBClientLive {
 
     def acquireDynamoDb: ZIO[Logging, ConfigurationFailure, DynamoDbClient] =
       ZIO
-        .effect(DynamoDbClient.create())
+        .effect(AwsClient.dynamoDb)
         .mapError(ex => ConfigurationFailure(s"Failed to create the dynamoDb client: $ex"))
 
     def releaseDynamoDb(dynamoDb: DynamoDbClient): URIO[Logging, Unit] =

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIO.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIO.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.services
 
-import com.amazonaws.services.dynamodbv2.model.{AttributeValue, AttributeValueUpdate, QueryRequest, ScanRequest}
+import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, AttributeValueUpdate, QueryRequest, ScanRequest}
 import zio.stream.ZStream
 import zio.{IO, URIO, ZIO}
 

--- a/lambda/src/main/scala/pricemigrationengine/services/EmailSenderLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/EmailSenderLive.scala
@@ -28,7 +28,7 @@ object EmailSenderLive {
             }
           sqsClient <- ZIO
             .effect {
-              SqsAsyncClient.create()
+              AwsClient.sqsAsync
             }
             .mapError { ex =>
               EmailSenderFailure(s"Failed to create sqs client: ${ex.getMessage}")

--- a/lambda/src/main/scala/pricemigrationengine/services/EmailSenderLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/EmailSenderLive.scala
@@ -1,9 +1,9 @@
 package pricemigrationengine.services
 
-import com.amazonaws.services.sqs.model.SendMessageRequest
-import com.amazonaws.services.sqs.{AmazonSQSAsync, AmazonSQSAsyncClientBuilder}
 import pricemigrationengine.model.EmailSenderFailure
 import pricemigrationengine.model.membershipworkflow.EmailMessage
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.{GetQueueUrlRequest, SendMessageRequest}
 import upickle.default.write
 import zio.{ZIO, ZLayer}
 
@@ -28,34 +28,33 @@ object EmailSenderLive {
             }
           sqsClient <- ZIO
             .effect {
-              AmazonSQSAsyncClientBuilder.standard().build()
+              SqsAsyncClient.create()
             }
             .mapError { ex =>
               EmailSenderFailure(s"Failed to create sqs client: ${ex.getMessage}")
             }
-          queueUrl <- ZIO
-            .effect {
-              sqsClient.getQueueUrl(config.sqsEmailQueueName).getQueueUrl
+          queueUrlResponse <- ZIO
+            .fromCompletableFuture {
+              sqsClient.getQueueUrl(GetQueueUrlRequest.builder.queueName(config.sqsEmailQueueName).build())
             }
-            .mapError { ex =>
-              EmailSenderFailure(s"Failed to get sqs queue url: ${ex.getMessage}")
-            }
+            .mapError { ex => EmailSenderFailure(s"Failed to get sqs queue url: ${ex.getMessage}") }
         } yield new EmailSender.Service {
           override def sendEmail(message: EmailMessage): ZIO[Any, EmailSenderFailure, Unit] = {
-            sendMessage(sqsClient, queueUrl, message)
+            sendMessage(sqsClient, queueUrlResponse.queueUrl, message)
           }.provide(dependencies)
         }
       ).provide(dependencies)
   }
 
-  private def sendMessage(sqsClient: AmazonSQSAsync, queueUrl: String, message: EmailMessage) = {
+  private def sendMessage(sqsClient: SqsAsyncClient, queueUrl: String, message: EmailMessage) = {
     for {
       result <- ZIO
-        .effect {
+        .fromCompletableFuture {
           sqsClient.sendMessage(
-            new SendMessageRequest()
-              .withQueueUrl(queueUrl)
-              .withMessageBody(serialiseMessage(message))
+            SendMessageRequest.builder
+              .queueUrl(queueUrl)
+              .messageBody(serialiseMessage(message))
+              .build()
           )
         }
         .mapError { ex =>
@@ -64,7 +63,7 @@ object EmailSenderLive {
           )
         }
       _ <- Logging.info(
-        s"Successfully sent email for sfContactId ${message.SfContactId} message id: ${result.getMessageId}"
+        s"Successfully sent email for sfContactId ${message.SfContactId} message id: ${result.messageId}"
       )
     } yield ()
   }

--- a/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/EnvConfiguration.scala
@@ -31,20 +31,6 @@ object EnvConfiguration {
     }
   }
 
-  val dynamoDbImpl: ZLayer[Any, Nothing, DynamoDBConfiguration] = ZLayer.succeed {
-    new DynamoDBConfiguration.Service {
-      val config: IO[ConfigurationFailure, DynamoDBConfig] = for {
-        dynamoDBServiceEndpointOption <- optionalEnv("dynamodb.serviceEndpoint")
-        dynamoDBSigningRegionOption <- optionalEnv("dynamodb.signingRegion")
-        dynamoDBEndpoint =
-          dynamoDBServiceEndpointOption
-            .flatMap(endpoint => dynamoDBSigningRegionOption.map(region => DynamoDBEndpointConfig(endpoint, region)))
-      } yield DynamoDBConfig(
-        dynamoDBEndpoint
-      )
-    }
-  }
-
   val cohortTableImp: ZLayer[Any, Nothing, CohortTableConfiguration] = ZLayer.succeed {
     new CohortTableConfiguration.Service {
       val config: IO[ConfigurationFailure, CohortTableConfig] = for {

--- a/lambda/src/main/scala/pricemigrationengine/services/S3.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/S3.scala
@@ -1,10 +1,11 @@
 package pricemigrationengine.services
 
+import pricemigrationengine.model.S3Failure
+import software.amazon.awssdk.services.s3.model.{ObjectCannedACL, PutObjectResponse}
+import zio.{IO, ZIO, ZManaged}
+
 import java.io.{File, InputStream}
 
-import com.amazonaws.services.s3.model.{CannedAccessControlList, PutObjectResult}
-import pricemigrationengine.model.S3Failure
-import zio.{IO, ZIO, ZManaged}
 case class S3Location(bucket: String, key: String)
 
 object S3 {
@@ -13,8 +14,8 @@ object S3 {
     def putObject(
         s3Location: S3Location,
         localFile: File,
-        cannedAcl: Option[CannedAccessControlList]
-    ): IO[S3Failure, PutObjectResult]
+        cannedAcl: Option[ObjectCannedACL]
+    ): IO[S3Failure, PutObjectResponse]
     def deleteObject(s3Location: S3Location): IO[S3Failure, Unit]
   }
 
@@ -24,9 +25,9 @@ object S3 {
   def putObject(
       s3Location: S3Location,
       localFile: File,
-      cannedAcl: Option[CannedAccessControlList]
-  ): ZIO[S3, S3Failure, PutObjectResult] =
-    ZIO.accessM(_.get.putObject(s3Location, localFile, cannedAcl: Option[CannedAccessControlList]))
+      cannedAcl: Option[ObjectCannedACL]
+  ): ZIO[S3, S3Failure, PutObjectResponse] =
+    ZIO.accessM(_.get.putObject(s3Location, localFile, cannedAcl: Option[ObjectCannedACL]))
 
   def deleteObject(s3Location: S3Location): ZIO[S3, S3Failure, Unit] =
     ZIO.accessM(_.get.deleteObject(s3Location))

--- a/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
@@ -20,7 +20,7 @@ import scala.jdk.CollectionConverters._
 
 object S3Live {
   val impl: ZLayer[Logging, Nothing, S3] = ZLayer.fromService { logging =>
-    val s3 = S3Client.builder.region(EU_WEST_1).build()
+    val s3 = AwsClient.s3
 
     new S3.Service {
       override def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream] = {

--- a/lambda/src/main/scala/pricemigrationengine/services/package.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/package.scala
@@ -5,7 +5,6 @@ import zio.Has
 package object services {
 
   type ZuoraConfiguration = Has[ZuoraConfiguration.Service]
-  type DynamoDBConfiguration = Has[DynamoDBConfiguration.Service]
   type CohortTableConfiguration = Has[CohortTableConfiguration.Service]
   type SalesforceConfiguration = Has[SalesforceConfiguration.Service]
   type StageConfiguration = Has[StageConfiguration.Service]

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -1,18 +1,17 @@
 package pricemigrationengine.handlers
 
-import java.io.{File, InputStream}
-import java.time._
-
-import com.amazonaws.services.s3.model.{CannedAccessControlList, PutObjectResult}
+import pricemigrationengine.TestLogging
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.services._
-import pricemigrationengine.{StubClock, TestLogging}
+import software.amazon.awssdk.services.s3.model.{ObjectCannedACL, PutObjectResponse}
 import zio.Exit.Success
 import zio.Runtime.default
 import zio._
 import zio.stream.ZStream
 
+import java.io.{File, InputStream}
+import java.time._
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
 
@@ -45,12 +44,12 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
         override def putObject(
             s3Location: S3Location,
             file: File,
-            cannedAccessControlList: Option[CannedAccessControlList]
-        ): IO[S3Failure, PutObjectResult] =
+            cannedAccessControlList: Option[ObjectCannedACL]
+        ): IO[S3Failure, PutObjectResponse] =
           for {
             fileContents <- ZIO.effectTotal(Source.fromFile(file, "UTF-8").getLines().mkString("\n"))
             _ <- ZIO.effectTotal(filesWrittenToS3.addOne((s3Location, fileContents)))
-          } yield new PutObjectResult()
+          } yield PutObjectResponse.builder.build()
 
         def deleteObject(s3Location: S3Location): IO[S3Failure, Unit] = ???
       }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -1,17 +1,16 @@
 package pricemigrationengine.handlers
 
-import java.io.{File, InputStream}
-import java.time.LocalDate
-
-import com.amazonaws.services.s3.model.{CannedAccessControlList, PutObjectResult}
-import pricemigrationengine.{StubClock, TestLogging}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
+import pricemigrationengine.{StubClock, TestLogging}
+import software.amazon.awssdk.services.s3.model.{ObjectCannedACL, PutObjectResponse}
 import zio.Exit.Success
 import zio.Runtime.default
 import zio._
 import zio.stream.ZStream
 
+import java.io.{File, InputStream}
+import java.time.LocalDate
 import scala.collection.mutable.ArrayBuffer
 
 class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
@@ -62,8 +61,8 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
         override def putObject(
             s3Location: S3Location,
             file: File,
-            cannedAccessControlList: Option[CannedAccessControlList]
-        ): IO[S3Failure, PutObjectResult] = ???
+            cannedAccessControlList: Option[ObjectCannedACL]
+        ): IO[S3Failure, PutObjectResponse] = ???
 
         override def deleteObject(s3Location: S3Location): IO[S3Failure, Unit] = ZIO.succeed(())
       }

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -1,10 +1,9 @@
 package pricemigrationengine.model
 
-import java.time.LocalDate
-
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import pricemigrationengine.model.CohortSpec.isValid
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
+import java.time.LocalDate
 import scala.jdk.CollectionConverters._
 
 class CohortSpecTest extends munit.FunSuite {
@@ -75,11 +74,11 @@ class CohortSpecTest extends munit.FunSuite {
 
   test("fromDynamoDbItem: should include all fields") {
     val item = Map(
-      "cohortName" -> new AttributeValue().withS("Home Delivery 2018"),
-      "brazeCampaignName" -> new AttributeValue().withS("cmp123"),
-      "importStartDate" -> new AttributeValue().withS("2020-01-01"),
-      "earliestPriceMigrationStartDate" -> new AttributeValue().withS("2020-01-02"),
-      "tmpTableName" -> new AttributeValue().withS("tmpName")
+      "cohortName" -> AttributeValue.builder.s("Home Delivery 2018").build(),
+      "brazeCampaignName" -> AttributeValue.builder.s("cmp123").build(),
+      "importStartDate" -> AttributeValue.builder.s("2020-01-01").build(),
+      "earliestPriceMigrationStartDate" -> AttributeValue.builder.s("2020-01-02").build(),
+      "tmpTableName" -> AttributeValue.builder.s("tmpName").build()
     ).asJava
     assertEquals(
       CohortSpec.fromDynamoDbItem(item),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,12 +2,12 @@ import sbt._
 
 object Dependencies {
   private val zioVersion = "1.0.7"
-  private val awsSdkVersion = "1.11.979"
+  private val awsSdkVersion = "2.16.58"
 
-  lazy val awsDynamoDb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
-  lazy val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion
-  lazy val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion
-  lazy val awsStateMachine = "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsSdkVersion
+  lazy val awsDynamoDb = "software.amazon.awssdk" % "dynamodb" % awsSdkVersion
+  lazy val awsS3 = "software.amazon.awssdk" % "s3" % awsSdkVersion
+  lazy val awsSQS = "software.amazon.awssdk" % "sqs" % awsSdkVersion
+  lazy val awsStateMachine = "software.amazon.awssdk" % "sfn" % awsSdkVersion
   lazy val zio = "dev.zio" %% "zio" % zioVersion
   lazy val zioStreams = "dev.zio" %% "zio-streams" % zioVersion
   lazy val zioTest = "dev.zio" %% "zio-test" % zioVersion


### PR DESCRIPTION
This upgrades all the AWS services from v1 to v2.
These are the main references:
* https://docs.aws.amazon.com/sdk-for-java/latest/migration-guide/whats-different.html
* https://docs.aws.amazon.com/sdk-for-java/latest/migration-guide/aws-sdk-java-mg.pdf
* https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md

Doing this should remove some of the vulnerable transitive dependencies that v1 had, which will keep Snyk happy.

It has been tested on the Dev stage.

Along the way:
* Removal of some [redundant config](https://github.com/guardian/price-migration-engine/compare/kc-aws-v2?expand=1#diff-f6015ed051d21ff9066e0e0c7fdb8f559d3bc34421daf6dc57092341266c7fb2L9-L12)
* Updated [gitignore](https://github.com/guardian/price-migration-engine/compare/kc-aws-v2?expand=1#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947R3)
