### PR TITLE
Use no-op implementation of SLF4J at runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val lambda = (project in file("lambda"))
       awsStateMachine,
       http,
       commonsCsv,
+      slf4jNop % Runtime,
       munit % Test,
       zioTest % Test,
       zioTestSbt % Test

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val lambda = (project in file("lambda"))
        * So it's redundant in a binary artefact.
        */
       case PathList("codegen-resources", _*)                    => MergeStrategy.discard
-      case PathList("module-info.class")                        => MergeStrategy.discard
+      case PathList(ps @ _*) if ps.last == "module-info.class"  => MergeStrategy.discard
       case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.discard
       case x =>
         val oldStrategy = (assembly / assemblyMergeStrategy).value

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,4 +17,5 @@ object Dependencies {
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"
   lazy val munit = "org.scalameta" %% "munit" % "0.7.25"
   lazy val commonsCsv = "org.apache.commons" % "commons-csv" % "1.8"
+  lazy val slf4jNop = "org.slf4j" % "slf4j-nop" % "2.0.0-alpha1"
 }


### PR DESCRIPTION
We're not actually using SLF4J but it's imported with the AWS SDK.
By using a no-op implementation at runtime we get rid of the warning:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
