### PR TITLE
Downgrade AWS SDK to v 2.16

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   private val zioVersion = "1.0.11"
-  private val awsSdkVersion = "2.17.34"
+  private val awsSdkVersion = "2.16.104"
 
   lazy val awsDynamoDb = "software.amazon.awssdk" % "dynamodb" % awsSdkVersion
   lazy val awsS3 = "software.amazon.awssdk" % "s3" % awsSdkVersion


### PR DESCRIPTION
This is a temporary rollback until reason for new bug discovered.

The new bug is in the `ExportingCohortTableToDatalake` step:
```
CohortTableDatalakeExportFailure(
Failed to write CohortItems to s3: 
Failed to write s3 object S3Location(ophan-clean-price-migration-engine-cohort-items,data/Vouchers 2020.csv): 
The request signature we calculated does not match the signature you provided. Check your key and signing method.
)
```
