### PR TITLE
Revert "Update upickle to 1.4.1"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   lazy val zioStreams = "dev.zio" %% "zio-streams" % zioVersion
   lazy val zioTest = "dev.zio" %% "zio-test" % zioVersion
   lazy val zioTestSbt = "dev.zio" %% "zio-test-sbt" % zioVersion
-  lazy val upickle = "com.lihaoyi" %% "upickle" % "1.4.1"
+  lazy val upickle = "com.lihaoyi" %% "upickle" % "1.4.0"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"
   lazy val munit = "org.scalameta" %% "munit" % "0.7.29"


### PR DESCRIPTION
Reverts guardian/price-migration-engine#333