### PR TITLE
Rollback to Java 8 for failing lambda

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -694,7 +694,7 @@ Resources:
           - PriceMigrationEngineCohortTableDatalakeExportLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java8
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineCohortTableDatalakeExportLambdaRole


### PR DESCRIPTION
This is to isolate the problem.

