### PR TITLE
Update Snyk workflow to monitor only

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,31 +1,37 @@
-# This action runs every day at 6 AM and on every push
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
+# This workflow runs Snyk Monitor on every push to main.
 name: Snyk
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
   security:
     runs-on: ubuntu-latest
-    env:
-      SNYK_COMMAND: test
+
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
 
-      - name: Set command to monitor
-        if: github.ref == 'refs/heads/main'
-        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
-
-      - name: Run Snyk to check for vulnerabilities
+      - name: Update Snyk UI with current vulnerabilities
         uses: snyk/actions/scala@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
+          command: monitor
           args: --org=the-guardian-cuu --project-name=${{ github.repository }}
-          command: ${{ env.SNYK_COMMAND }}
+
+      - name: Update Github Code Scanning file with current vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        continue-on-error: true # To make sure that SARIF upload gets called
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk.sarif
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif


### PR DESCRIPTION
There's little value in failing builds because of vulnerabilities for which there's no remediation available.
Better to monitor and update Snyk and the Security tab of the repo.