### PR TITLE
Warn for deprecations and fail on warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,11 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / scalaVersion := "2.13.8"
 
+ThisBuild / scalacOptions ++= Seq(
+  "-deprecation",
+  "-Xfatal-warnings"
+)
+
 lazy val root = (project in file("."))
   .aggregate(dynamoDb, lambda, stateMachine)
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
@@ -33,7 +33,7 @@ trait CohortHandler extends zio.App with RequestStreamHandler {
       cohortSpec <-
         ZIO
           .effect(read[CohortSpec](input))
-          .bimap(e => InputFailure(s"Failed to parse json: $e"), Option(_))
+          .mapBoth(e => InputFailure(s"Failed to parse json: $e"), Option(_))
           .filterOrElse(_.exists(CohortSpec.isValid))(spec => ZIO.fail(InputFailure(s"Invalid cohort spec: $spec")))
       validSpec <- ZIO.fromOption(cohortSpec).orElseFail(InputFailure("No input"))
     } yield validSpec).tapBoth(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -1,6 +1,7 @@
 package pricemigrationengine.handlers
 
-import org.apache.commons.csv.{CSVFormat, CSVPrinter, QuoteMode}
+import org.apache.commons.csv.QuoteMode.ALL
+import org.apache.commons.csv.{CSVFormat, CSVPrinter}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
@@ -13,7 +14,8 @@ import java.nio.file.{Files, Path}
 import scala.util.Try
 
 object CohortTableDatalakeExportHandler extends CohortHandler {
-  private val csvFormat = CSVFormat.DEFAULT.withHeader("").withQuoteMode(QuoteMode.ALL)
+
+  private val csvFormat = CSVFormat.Builder.create().setHeader("").setQuoteMode(ALL).build()
   private val TempFileDirectory = "/tmp/"
 
   def main(
@@ -136,7 +138,7 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
       .makeEffect(
         new CSVPrinter(
           new OutputStreamWriter(outputStream, StandardCharsets.UTF_8.name()),
-          csvFormat.withHeader(headers: _*)
+          CSVFormat.Builder.create(csvFormat).setHeader(headers: _*).build()
         )
       )(printer => printer.close(true))
       .mapError { ex =>

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIOLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBZIOLive.scala
@@ -94,7 +94,7 @@ object DynamoDBZIOLive {
                 .attributeUpdates(valueSerializer.serialise(value))
                 .build()
             )
-            .bimap(
+            .mapBoth(
               ex => DynamoDBZIOError(s"Failed to write value '$value' to '$table': $ex"),
               _ => ()
             )


### PR DESCRIPTION
This is particularly to ensure that any deprecations from  dependency updates aren't missed.  But also in general to avoid missing warnings.  