### PR TITLE
Set a unique build number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,11 @@ jobs:
 
       - name: Upload artefacts to Riffraff
         if: env.isPrFromForkedRepo == 'false'
+        env:
+          lastTeamCityBuild: 884
         run: >
+          export BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $lastTeamCityBuild ))
+
           sbt
           scalafmtCheckAll
           scalafmtSbtCheck


### PR DESCRIPTION
Now that GHA is generating builds, the numbering has restarted from 1.  This means that build numbers are duplicating TeamCity build numbers.

We can ensure build numbers are unique by starting build numbers where the TeamCity ones ended.


