### PR TITLE
Add missing lambdas to deployment

### DIFF
--- a/lambda/riff-raff.yaml
+++ b/lambda/riff-raff.yaml
@@ -17,6 +17,8 @@ deployments:
       bucket: membership-dist
       prefixStack: false
       functionNames:
+      - price-migration-lambda-
+      - price-migration-engine-table-create-lambda-
       - price-migration-engine-estimation-lambda-
       - price-migration-engine-salesforce-price-rise-lambda-
       - price-migration-engine-amendment-lambda-


### PR DESCRIPTION
There were a couple of lambdas missing from the Riffraff deployment config, which was causing some problems as the deployed code was out-of-date on Code.

Tested on Code.