### PR TITLE
Add product type to fields for Braze

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -113,7 +113,8 @@ object NotificationHandler extends CohortHandler {
                 payment_amount = estimatedNewPrice,
                 next_payment_date = startDate,
                 payment_frequency = paymentFrequency,
-                subscription_id = cohortItem.subscriptionName
+                subscription_id = cohortItem.subscriptionName,
+                product_type = sfSubscription.Product_Type__c.getOrElse("")
               )
             )
           ),

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforceSubscription.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforceSubscription.scala
@@ -1,3 +1,9 @@
 package pricemigrationengine.model
 
-case class SalesforceSubscription(Id: String, Name: String, Buyer__c: String, Status__c: String)
+case class SalesforceSubscription(
+    Id: String,
+    Name: String,
+    Buyer__c: String,
+    Status__c: String,
+    Product_Type__c: Option[String] // This ought to always have a value but there appear to be some nulls in the data.
+)

--- a/lambda/src/main/scala/pricemigrationengine/model/membershipworkflow/EmailMessage.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/membershipworkflow/EmailMessage.scala
@@ -17,7 +17,8 @@ case class EmailPayloadSubscriberAttributes(
     payment_amount: String,
     next_payment_date: String,
     payment_frequency: String,
-    subscription_id: String
+    subscription_id: String,
+    product_type: String
 )
 
 object EmailPayloadSubscriberAttributes {

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -37,6 +37,7 @@ class NotificationHandlerTest extends munit.FunSuite {
   val expectedDataExtensionName = "SV_VO_Pricerise_Q22020"
   val expectedSalutation = "Ms"
   val expectedSfStatus = "Active"
+  val expectedProductType = "Newspaper - Digital Voucher"
 
   val mailingAddressStreet = "buyer1MailStreet"
   val mailingAddressCity = "buyer1MailCity"
@@ -136,7 +137,8 @@ class NotificationHandlerTest extends munit.FunSuite {
       expectedSFSubscriptionId,
       expectedSubscriptionName,
       expectedBuyerId,
-      expectedSfStatus
+      expectedSfStatus,
+      Some(expectedProductType)
     )
 
   private val salesforceContact: SalesforceContact =

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -62,7 +62,8 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
               s"SubscritionId-$subscriptionName",
               subscriptionName,
               s"Buyer-$subscriptionName",
-              "Active"
+              "Active",
+              Some("Newspaper - Digital Voucher")
             )
           ).orElseFail(SalesforceClientFailure(""))
         }

--- a/lambda/src/test/scala/pricemigrationengine/service/EmailSenderLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/EmailSenderLiveTest.scala
@@ -29,7 +29,8 @@ class EmailSenderLiveTest extends munit.FunSuite {
                 "1.23",
                 "2020-01-01",
                 "Monthly",
-                "Subscription-001"
+                "Subscription-001",
+                "Newspaper - Digital Voucher"
               )
             )
           ),
@@ -55,7 +56,8 @@ class EmailSenderLiveTest extends munit.FunSuite {
         |        "payment_amount": "1.23",
         |        "next_payment_date": "2020-01-01",
         |        "payment_frequency": "Monthly",
-        |        "subscription_id": "Subscription-001"
+        |        "subscription_id": "Subscription-001",
+        |        "product_type": "Newspaper - Digital Voucher"
         |      }
         |    }
         |  },
@@ -86,7 +88,8 @@ class EmailSenderLiveTest extends munit.FunSuite {
                 "1.23",
                 "2020-01-01",
                 "Monthly",
-                "Subscription-001"
+                "Subscription-001",
+                "Newspaper - Digital Voucher"
               )
             )
           ),
@@ -112,7 +115,8 @@ class EmailSenderLiveTest extends munit.FunSuite {
         |        "payment_amount": "1.23",
         |        "next_payment_date": "2020-01-01",
         |        "payment_frequency": "Monthly",
-        |        "subscription_id": "Subscription-001"
+        |        "subscription_id": "Subscription-001",
+        |        "product_type": "Newspaper - Digital Voucher"
         |      }
         |    }
         |  },


### PR DESCRIPTION
This will allow the Braze template to include conditional logic that will send the correct letter code out according to the type of product.

This has been tested in Code and the messages are successfully arriving at membership-workflow with the new field included.  It should arrive at Braze when the campaign mapping has been added to membership-workflow config.
