### PR TITLE
Generalise cohort query for any cohort

### DIFF
--- a/dynamoDb/scripts/cohortStateQuery.bash
+++ b/dynamoDb/scripts/cohortStateQuery.bash
@@ -5,22 +5,24 @@
 # that are in a given processing stage
 # and have a start date up to and including a given threshold.
 #
-# Arg 1: Deployment stage: DEV, CODE or PROD
-# Arg 2: processingStage, eg. EstimationComplete
-# Arg 3: Inclusive maximum date
+# Arg 1: Cohort name
+# Arg 2: Deployment stage: DEV, CODE or PROD
+# Arg 3: processingStage, eg. EstimationComplete
+# Arg 4: Inclusive maximum date (yyyy-mm-dd)
 # =====================================================================
 
-# Arg 1: Deployment stage: DEV, CODE or PROD
-# Arg 2: processingStage
-# Arg 3: Inclusive maximum date
+# Arg 1: Cohort name
+# Arg 2: Deployment stage: DEV, CODE or PROD
+# Arg 3: processingStage
+# Arg 4: Inclusive maximum date (yyyy-mm-dd)
 function query() {
   aws dynamodb query --region eu-west-1 --profile membership \
-    --table-name "PriceMigrationEngine$1" \
-    --index-name "ProcessingStageIndexV3" \
+    --table-name "PriceMigration-$2-$1" \
+    --index-name "ProcessingStageStartDateIndexV1" \
     --projection-expression "subscriptionNumber" \
     --key-condition-expression "processingStage = :s AND startDate <= :d " \
-    --expression-attribute-values "{\":s\": {\"S\": \"$2\"}, \":d\": {\"S\": \"$3\"}}" \
+    --expression-attribute-values "{\":s\": {\"S\": \"$3\"}, \":d\": {\"S\": \"$4\"}}" \
     --max-items "100000"
 }
 
-query "$1" "$2" "$3" | jq --raw-output '.Items[] | .subscriptionNumber | .S'
+query "$1" "$2" "$3" "$4" | jq --raw-output '.Items[] | .subscriptionNumber | .S'

--- a/dynamoDb/scripts/cohortStateQuery.bash
+++ b/dynamoDb/scripts/cohortStateQuery.bash
@@ -5,6 +5,9 @@
 # that are in a given processing stage
 # and have a start date up to and including a given threshold.
 #
+# Example usage:
+#   cohortStateQuery.bash Cohort1 DEV SalesforcePriceRiseCreationComplete 2022-05-26
+#
 # Arg 1: Cohort name
 # Arg 2: Deployment stage: DEV, CODE or PROD
 # Arg 3: processingStage, eg. EstimationComplete


### PR DESCRIPTION
The cohort query was specifically for interrogating the first cohort from 2020.  This change updates the query so that it can interrogate any cohort.
There's also a correction to the name of the index being queried.
