### PR TITLE
Remove redundant tmpTableName field from cohort spec

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -22,20 +22,16 @@ import java.util
   *   its billing dates.
   * @param migrationCompleteDate
   *   Date on which the final step in the price migration was complete for every sub in the cohort.
-  *
-  * @param tmpTableName
-  *   A temporary value for the special case where the table name can't be derived from the cohort name.
   */
 case class CohortSpec(
     cohortName: String,
     brazeCampaignName: String,
     importStartDate: LocalDate,
     earliestPriceMigrationStartDate: LocalDate,
-    migrationCompleteDate: Option[LocalDate] = None,
-    tmpTableName: Option[String] = None // TODO: remove when price migration 2020 complete
+    migrationCompleteDate: Option[LocalDate] = None
 ) {
   val normalisedCohortName: String = cohortName.replaceAll(" ", "")
-  def tableName(stage: String): String = tmpTableName getOrElse s"PriceMigration-$stage-$normalisedCohortName"
+  def tableName(stage: String): String = s"PriceMigration-$stage-$normalisedCohortName"
 }
 
 object CohortSpec {
@@ -49,7 +45,6 @@ object CohortSpec {
     def isValidStringValue(s: String) = s.trim == s && s.nonEmpty && s.matches("[A-Za-z0-9-_ ]+")
     isValidStringValue(spec.cohortName) &&
     isValidStringValue(spec.brazeCampaignName) &&
-    spec.tmpTableName.forall(isValidStringValue) &&
     spec.earliestPriceMigrationStartDate.isAfter(spec.importStartDate)
   }
 
@@ -60,13 +55,11 @@ object CohortSpec {
       importStartDate <- getDateFromResults(values, "importStartDate")
       earliestPriceMigrationStartDate <- getDateFromResults(values, "earliestPriceMigrationStartDate")
       migrationCompleteDate <- getOptionalDateFromResults(values, "migrationCompleteDate")
-      tmpTableName <- getOptionalStringFromResults(values, "tmpTableName")
     } yield CohortSpec(
       cohortName,
       brazeCampaignName,
       importStartDate,
       earliestPriceMigrationStartDate,
-      migrationCompleteDate,
-      tmpTableName
+      migrationCompleteDate
     )).left.map(e => CohortSpecFetchFailure(e))
 }

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -16,8 +16,7 @@ class CohortSpecTest extends munit.FunSuite {
     brazeCampaignName = "cmp123",
     importStartDate = LocalDate.of(2020, 1, 1),
     earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 2),
-    migrationCompleteDate = None,
-    tmpTableName = None
+    migrationCompleteDate = None
   )
 
   private def assertTrue(obtained: Boolean): Unit = assertEquals(obtained, true)
@@ -58,14 +57,7 @@ class CohortSpecTest extends munit.FunSuite {
     assertTrue(isActive(importStartDate.plusDays(3), migrationComplete = None))
   }
 
-  test("tableName: should be tmpTableName field value when present") {
-    assertEquals(
-      cohortSpec.copy(tmpTableName = Some("givenName")).tableName(stage = "DEV"),
-      "givenName"
-    )
-  }
-
-  test("tableName: should be transformed cohort name when tmpTableName field value not present") {
+  test("tableName: should be transformed cohort name") {
     assertEquals(
       cohortSpec.tableName(stage = "PROD"),
       "PriceMigration-PROD-HomeDelivery2018"
@@ -77,12 +69,11 @@ class CohortSpecTest extends munit.FunSuite {
       "cohortName" -> AttributeValue.builder.s("Home Delivery 2018").build(),
       "brazeCampaignName" -> AttributeValue.builder.s("cmp123").build(),
       "importStartDate" -> AttributeValue.builder.s("2020-01-01").build(),
-      "earliestPriceMigrationStartDate" -> AttributeValue.builder.s("2020-01-02").build(),
-      "tmpTableName" -> AttributeValue.builder.s("tmpName").build()
+      "earliestPriceMigrationStartDate" -> AttributeValue.builder.s("2020-01-02").build()
     ).asJava
     assertEquals(
       CohortSpec.fromDynamoDbItem(item),
-      Right(cohortSpec.copy(tmpTableName = Some("tmpName")))
+      Right(cohortSpec)
     )
   }
 


### PR DESCRIPTION
The first cohort had a hardcoded table name, which is no longer required.  Now we generate the table name from the cohort name.