### PR TITLE
Temporarily disable lambda that kicks off state machines

### DIFF
--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -139,9 +139,9 @@ Resources:
       - PriceMigrationLambda
     Condition: IsProd
     Properties:
-      Description: Trigger daily 7 am kick-off of state machines for active cohorts.
+      Description: Trigger daily 7 am (UTC) kick-off of state machines for active cohorts.
       ScheduleExpression: "cron(0 7 ? * * *)"
-      State: ENABLED
+      State: DISABLED
       Targets:
         - Arn: !GetAtt PriceMigrationLambda.Arn
           Id: !Ref PriceMigrationLambda


### PR DESCRIPTION
This is to stop state machines running while business issues are sorted out.
