### PR TITLE
Fetch all from correct cohort table

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -178,7 +178,7 @@ object CohortTableLive {
           ZIO
             .from {
               val queryRequest = ScanRequest.builder
-                .tableName(s"PriceMigrationEngine${config.stage}")
+                .tableName(tableName)
                 .limit(cohortTableConfig.batchSize)
                 .build()
               for {


### PR DESCRIPTION
This call is only used by the datalake export job, which is why it was failing.  It was previously overwriting the cohort data with the `Vouchers 2020` data because the cohort table name was hardcoded.
