### PR TITLE
Retry if amendment step times out

### DIFF
--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -337,7 +337,8 @@ Resources:
                     "ErrorEquals": [
                         "Lambda.ServiceException",
                         "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException"
+                        "Lambda.SdkClientException",
+                        "Lambda.Unknown"
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 6,


### PR DESCRIPTION
AWS considers lambda timeouts to be unknown exceptions.
See https://docs.aws.amazon.com/step-functions/latest/dg/bp-lambda-serviceexception.html

So I've included unknown exceptions in the list to retry for the amendment step.
The worst that could happen is that we would needlessly retry the step 5 times.
