### PR TITLE
Upgrade ZIO v2 to RC3

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/services/S3.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/S3.scala
@@ -2,7 +2,7 @@ package pricemigrationengine.services
 
 import pricemigrationengine.model.S3Failure
 import software.amazon.awssdk.services.s3.model.{ObjectCannedACL, PutObjectResponse}
-import zio.{IO, ZIO, ZManaged}
+import zio.{IO, Scope, ZIO}
 
 import java.io.{File, InputStream}
 
@@ -10,7 +10,7 @@ case class S3Location(bucket: String, key: String)
 
 object S3 {
   trait Service {
-    def getObject(s3Location: S3Location): ZManaged[Any, S3Failure, InputStream]
+    def getObject(s3Location: S3Location): ZIO[Scope, S3Failure, InputStream]
     def putObject(
         s3Location: S3Location,
         localFile: File,
@@ -19,7 +19,7 @@ object S3 {
     def deleteObject(s3Location: S3Location): IO[S3Failure, Unit]
   }
 
-  def getObject(s3Location: S3Location): ZIO[S3, S3Failure, ZManaged[Any, S3Failure, InputStream]] =
+  def getObject(s3Location: S3Location): ZIO[S3, S3Failure, ZIO[Scope, S3Failure, InputStream]] =
     ZIO.environmentWith(_.get.getObject(s3Location))
 
   def putObject(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  private val zioVersion = "2.0.0-RC2"
+  private val zioVersion = "2.0.0-RC3"
   private val awsSdkVersion = "2.17.182"
 
   lazy val awsDynamoDb = "software.amazon.awssdk" % "dynamodb" % awsSdkVersion


### PR DESCRIPTION
The main change here is that `ZManaged` has been replaced by `Scope`.
This is a more straightforward way of managing opening and closing of resources.
Just have to be aware that the lifecycle of the use of a resource has to be inside a `ZIO.scoped` block.

See:

* https://github.com/zio/zio/releases/tag/v2.0.0-RC3
* https://zio.dev/next/howto/migrate/zio-2.x-migration-guide/#migration-from-zmanaged-to-scope
