### PR TITLE
Upgrade ZIO v2 to RC4

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableCreationHandler.scala
@@ -24,6 +24,6 @@ object CohortTableCreationHandler extends CohortHandler {
     (LiveLayer.cohortTableDdl and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
-  def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =
-    main(input).provideSomeLayer[ZEnv with Logging](env)
+  def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
+    main(input).provideSomeLayer[Logging](env)
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -154,6 +154,6 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
     (LiveLayer.cohortTable(cohortSpec) and LiveLayer.s3 and LiveLayer.logging and LiveLayer.exportConfig)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
-  def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =
-    main(input).provideSomeLayer[ZEnv with Logging](env(input))
+  def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
+    main(input).provideSomeLayer[Logging](env(input))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
@@ -19,16 +19,16 @@ object LiveLayer {
       CohortTableLive.impl(cohortSpec)
 
   val cohortTableDdl: ZLayer[Logging, ConfigurationFailure, CohortTableDdl] =
-    Clock.live and dynamoDbClient and EnvConfiguration.stageImp and logging to CohortTableDdlLive.impl
+    dynamoDbClient and EnvConfiguration.stageImp and logging to CohortTableDdlLive.impl
 
   val cohortSpecTable: ZLayer[Logging, ConfigurationFailure, CohortSpecTable] =
     dynamoDbClient and EnvConfiguration.stageImp and logging to CohortSpecTableLive.impl
 
   val cohortStateMachine: ZLayer[Logging, ConfigurationFailure, CohortStateMachine] =
-    logging and Clock.live and EnvConfiguration.cohortStateMachineImpl to CohortStateMachineLive.impl
+    logging and EnvConfiguration.cohortStateMachineImpl to CohortStateMachineLive.impl
 
   val zuora: ZLayer[Logging, ConfigurationFailure, Zuora] =
-    EnvConfiguration.zuoraImpl and Clock.live and logging to ZuoraLive.impl
+    EnvConfiguration.zuoraImpl and logging to ZuoraLive.impl
 
   val salesforce: ZLayer[Logging, SalesforceClientFailure, SalesforceClient] =
     EnvConfiguration.salesforceImp and logging to SalesforceClientLive.impl

--- a/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.handlers
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import pricemigrationengine.model.{CohortSpec, ConfigurationFailure}
 import pricemigrationengine.services._
-import zio.{Runtime, ZEnv, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer}
+import zio.{Runtime, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer}
 
 /** Executes price migration for active cohorts.
   */
@@ -24,14 +24,14 @@ object MigrationHandler extends ZIOAppDefault with RequestHandler[Unit, Unit] {
     (LiveLayer.cohortSpecTable and LiveLayer.cohortStateMachine and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
-  override def run: ZIO[ZEnv with ZIOAppArgs, Any, Any] =
+  override def run: ZIO[ZIOAppArgs, Any, Any] =
     migrateActiveCohorts
-      .provideCustomLayer(ConsoleLogging.impl("MigrationHandler") to env)
+      .provideLayer(ConsoleLogging.impl("MigrationHandler") to env)
       .exitCode
 
   override def handleRequest(unused: Unit, context: Context): Unit =
     Runtime.default.unsafeRun(
       migrateActiveCohorts
-        .provideCustomLayer(LambdaLogging.impl(context, "MigrationHandler") to env)
+        .provideLayer(LambdaLogging.impl(context, "MigrationHandler") to env)
     )
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -28,7 +28,7 @@ object NotificationHandler extends CohortHandler {
 
   def main(
       brazeCampaignName: String
-  ): ZIO[Logging with CohortTable with SalesforceClient with Clock with EmailSender, Failure, HandlerOutput] = {
+  ): ZIO[Logging with CohortTable with SalesforceClient with EmailSender, Failure, HandlerOutput] = {
     for {
       today <- Time.today
       subscriptions <- CohortTable.fetch(
@@ -45,7 +45,7 @@ object NotificationHandler extends CohortHandler {
 
   def sendNotification(brazeCampaignName: String)(
       cohortItem: CohortItem
-  ): ZIO[EmailSender with SalesforceClient with CohortTable with Clock with Logging, Failure, Int] = {
+  ): ZIO[EmailSender with SalesforceClient with CohortTable with Logging, Failure, Int] = {
     val result = for {
       sfSubscription <-
         SalesforceClient
@@ -71,7 +71,7 @@ object NotificationHandler extends CohortHandler {
       brazeCampaignName: String,
       cohortItem: CohortItem,
       sfSubscription: SalesforceSubscription
-  ): ZIO[EmailSender with SalesforceClient with CohortTable with Clock with Logging, Failure, Int] =
+  ): ZIO[EmailSender with SalesforceClient with CohortTable with Logging, Failure, Int] =
     for {
       _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
       contact <- SalesforceClient.getContact(sfSubscription.Buyer__c)
@@ -198,6 +198,6 @@ object NotificationHandler extends CohortHandler {
     (LiveLayer.cohortTable(cohortSpec) and LiveLayer.salesforce and LiveLayer.emailSender and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
-  def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =
-    main(input.brazeCampaignName).provideSomeLayer[ZEnv with Logging](env(input))
+  def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
+    main(input.brazeCampaignName).provideSomeLayer[Logging](env(input))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -13,7 +13,7 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
   // TODO: move to config
   private val batchSize = 2000
 
-  private val main: ZIO[CohortTable with SalesforceClient with Clock with Logging, Failure, HandlerOutput] =
+  private val main: ZIO[CohortTable with SalesforceClient with Logging, Failure, HandlerOutput] =
     for {
       cohortItems <- CohortTable.fetch(AmendmentComplete, None)
       count <-
@@ -30,7 +30,7 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
 
   private def updateSfWithNewSubscriptionId(
       item: CohortItem
-  ): ZIO[CohortTable with SalesforceClient with Clock with Logging, Failure, Unit] =
+  ): ZIO[CohortTable with SalesforceClient with Logging, Failure, Unit] =
     for {
       priceRise <- ZIO.fromEither(buildPriceRise(item))
       salesforcePriceRiseId <-
@@ -61,6 +61,6 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
     (LiveLayer.cohortTable(cohortSpec) and LiveLayer.salesforce and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
-  def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =
-    main.provideSomeLayer[ZEnv with Logging](env(input))
+  def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
+    main.provideSomeLayer[Logging](env(input))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
@@ -9,7 +9,7 @@ import java.time.{LocalDate, ZoneOffset}
 
 object SalesforceNotificationDateUpdateHandler extends CohortHandler {
 
-  val main: ZIO[Logging with CohortTable with SalesforceClient with Clock, Failure, HandlerOutput] =
+  val main: ZIO[Logging with CohortTable with SalesforceClient, Failure, HandlerOutput] =
     for {
       cohortItems <- CohortTable.fetch(NotificationSendComplete, None)
       _ <- cohortItems.foreach(updateDateLetterSentInSF)
@@ -17,7 +17,7 @@ object SalesforceNotificationDateUpdateHandler extends CohortHandler {
 
   private def updateDateLetterSentInSF(
       item: CohortItem
-  ): ZIO[Logging with CohortTable with SalesforceClient with Clock, Failure, Unit] =
+  ): ZIO[Logging with CohortTable with SalesforceClient, Failure, Unit] =
     for {
       _ <- updateSalesforce(item)
         .tapBoth(
@@ -72,6 +72,6 @@ object SalesforceNotificationDateUpdateHandler extends CohortHandler {
     (LiveLayer.cohortTable(cohortSpec) and LiveLayer.salesforce and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
-  def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =
-    main.provideSomeLayer[ZEnv with Logging](env(input))
+  def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
+    main.provideSomeLayer[Logging](env(input))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
@@ -38,7 +38,7 @@ object SubscriptionIdUploadHandler extends CohortHandler {
 
   def main(
       cohortSpec: CohortSpec
-  ): ZIO[CohortTable with S3 with StageConfiguration with Clock with Logging, Failure, HandlerOutput] =
+  ): ZIO[CohortTable with S3 with StageConfiguration with Logging, Failure, HandlerOutput] =
     (for {
       today <- Time.today
       _ <-
@@ -125,6 +125,6 @@ object SubscriptionIdUploadHandler extends CohortHandler {
     (LiveLayer.cohortTable(cohortSpec) and LiveLayer.s3 and EnvConfiguration.stageImp and LiveLayer.logging)
       .tapError(e => Logging.error(s"Failed to create service environment: $e"))
 
-  def handle(input: CohortSpec): ZIO[ZEnv with Logging, Failure, HandlerOutput] =
-    main(input).provideSomeLayer[ZEnv with Logging](env(input))
+  def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
+    main(input).provideSomeLayer[Logging](env(input))
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/Time.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/Time.scala
@@ -7,12 +7,12 @@ import java.time.{Instant, LocalDate, OffsetDateTime}
 
 object Time {
 
-  private val nowHere: ZIO[Clock, TimeFailure, OffsetDateTime] =
+  private val nowHere: IO[TimeFailure, OffsetDateTime] =
     Clock.currentDateTime
 
-  val today: ZIO[Clock, TimeFailure, LocalDate] =
+  val today: IO[TimeFailure, LocalDate] =
     nowHere.map(_.toLocalDate)
 
-  val thisInstant: ZIO[Clock, TimeFailure, Instant] =
+  val thisInstant: IO[TimeFailure, Instant] =
     nowHere.map(_.toInstant)
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/Time.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/Time.scala
@@ -1,18 +1,17 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.model.TimeFailure
 import zio._
 
 import java.time.{Instant, LocalDate, OffsetDateTime}
 
 object Time {
 
-  private val nowHere: IO[TimeFailure, OffsetDateTime] =
+  private val nowHere: UIO[OffsetDateTime] =
     Clock.currentDateTime
 
-  val today: IO[TimeFailure, LocalDate] =
+  val today: UIO[LocalDate] =
     nowHere.map(_.toLocalDate)
 
-  val thisInstant: IO[TimeFailure, Instant] =
+  val thisInstant: UIO[Instant] =
     nowHere.map(_.toInstant)
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -7,8 +7,6 @@ sealed trait Failure {
 case class InputFailure(reason: String) extends Failure
 case class ConfigurationFailure(reason: String) extends Failure
 
-case class TimeFailure(reason: String) extends Failure
-
 case class CohortStateMachineFailure(reason: String) extends Failure
 
 case class CohortSpecFetchFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
@@ -2,10 +2,9 @@ package pricemigrationengine.services
 
 import pricemigrationengine.handlers.Time
 import pricemigrationengine.model._
-import pricemigrationengine.services
 import software.amazon.awssdk.services.sfn.model.{StartExecutionRequest, StartExecutionResponse}
 import upickle.default.{ReadWriter, macroRW, write}
-import zio.{Clock, IO, ZIO, ZLayer}
+import zio.{IO, ZIO, ZLayer}
 
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -26,7 +25,7 @@ object CohortStateMachineLive {
         override def startExecution(spec: CohortSpec): IO[CohortStateMachineFailure, StartExecutionResponse] =
           for {
             _ <- logging.info(s"Starting execution with input: ${spec.toString} ...")
-            time <- Time.thisInstant.mapError(e => CohortStateMachineFailure(e.toString))
+            time <- Time.thisInstant
             timeStr <- ZIO
               .attempt(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm").withZone(ZoneId.systemDefault).format(time))
               .mapError(e => CohortStateMachineFailure(e.toString))

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdlLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdlLive.scala
@@ -18,11 +18,9 @@ object CohortTableDdlLive {
   private val stageAttribute = "processingStage"
   private val startDateAttribute = "startDate"
 
-  val impl
-      : ZLayer[DynamoDBClient with StageConfiguration with Clock with Logging, ConfigurationFailure, CohortTableDdl] =
+  val impl: ZLayer[DynamoDBClient with StageConfiguration with Logging, ConfigurationFailure, CohortTableDdl] =
     ZLayer.fromZIO(
       for {
-        clock <- ZIO.service[Clock]
         logging <- ZIO.service[Logging]
         stageConfig <- StageConfiguration.stageConfig
         dynamoDbClient <- ZIO.service[DynamoDBClient]
@@ -75,7 +73,6 @@ object CohortTableDdlLive {
             .retry(
               exponential(1.second) && recurs(8)
             )
-            .provideService(clock) // have to wait for table to be created before enabling backups
 
           result.mapError(e => CohortTableCreateFailure(e.toString))
         }

--- a/lambda/src/main/scala/pricemigrationengine/services/ConsoleLogging.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ConsoleLogging.scala
@@ -1,23 +1,12 @@
 package pricemigrationengine.services
 
-import pricemigrationengine.model.CohortSpec
-import zio.{Console, UIO, URLayer, ZIO, ZLayer}
+import zio.{Console, UIO, ULayer, ZLayer}
 
 object ConsoleLogging {
 
-  def impl(cohortName: String): URLayer[Console, Logging] =
-    ZLayer.fromZIO(
-      for {
-        console <- ZIO.service[Console]
-      } yield new Logging.Service {
-        /*
-         * If putStrLn fails, an exception will be thrown.
-         * TODO: Fail with a LoggingFailure instead.
-         *  Then all services that rely on logging will need changes to their return type
-         *  so that they return a Failure on error rather than a more specific Failure type.
-         */
-        def info(s: String): UIO[Unit] = console.printLine(s"cohortName: $cohortName, INFO: $s").orDie
-        def error(s: String): UIO[Unit] = console.printLine(s"cohortName: $cohortName, ERROR: $s").orDie
-      }
-    )
+  def impl(cohortName: String): ULayer[Logging] =
+    ZLayer.succeed(new Logging.Service {
+      def info(s: String): UIO[Unit] = Console.printLine(s"cohortName: $cohortName, INFO: $s").orDie
+      def error(s: String): UIO[Unit] = Console.printLine(s"cohortName: $cohortName, ERROR: $s").orDie
+    })
 }

--- a/lambda/src/test/scala/pricemigrationengine/StubClock.scala
+++ b/lambda/src/test/scala/pricemigrationengine/StubClock.scala
@@ -1,29 +1,36 @@
 package pricemigrationengine
 
-import zio.{Clock, IO, Scheduler, UIO, ZLayer, ZTraceElement}
+import zio.{Clock, IO, Scheduler, UIO, ZEnv, ZIO, ZTraceElement}
 
+import java.time
 import java.time.{Instant, LocalDateTime, OffsetDateTime, ZoneOffset}
 import java.util.concurrent.TimeUnit
 
 object StubClock {
-  val expectedCurrentTime = Instant.parse("2020-05-21T15:16:37Z")
-  val clock = ZLayer.succeed(
-    new Clock {
+  val expectedCurrentTime: Instant = Instant.parse("2020-05-21T15:16:37Z")
+  private val clock: Clock = new Clock {
 
-      override def currentTime(unit: => TimeUnit)(implicit trace: ZTraceElement): UIO[Long] = ???
+    override def currentTime(unit: => TimeUnit)(implicit trace: ZTraceElement): UIO[Long] = ???
 
-      override def currentDateTime(implicit trace: ZTraceElement): UIO[OffsetDateTime] =
-        IO.succeed(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+    override def currentDateTime(implicit trace: ZTraceElement): UIO[OffsetDateTime] =
+      IO.succeed(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
 
-      override def instant(implicit trace: ZTraceElement): UIO[Instant] = ???
+    override def instant(implicit trace: ZTraceElement): UIO[Instant] = ???
 
-      override def localDateTime(implicit trace: ZTraceElement): UIO[LocalDateTime] = ???
+    override def localDateTime(implicit trace: ZTraceElement): UIO[LocalDateTime] = ???
 
-      override def nanoTime(implicit trace: ZTraceElement): UIO[Long] = ???
+    override def nanoTime(implicit trace: ZTraceElement): UIO[Long] = ???
 
-      override def scheduler(implicit trace: ZTraceElement): UIO[Scheduler] = ???
+    override def scheduler(implicit trace: ZTraceElement): UIO[Scheduler] = ???
 
-      override def sleep(duration: => zio.Duration)(implicit trace: ZTraceElement): UIO[Unit] = ???
-    }
-  )
+    override def sleep(duration: => zio.Duration)(implicit trace: ZTraceElement): UIO[Unit] = ???
+
+    override def javaClock(implicit trace: ZTraceElement): UIO[time.Clock] = ???
+  }
+
+  private def withClock[R, E, A](clock: Clock)(zio: ZIO[R, E, A]) =
+    ZEnv.services.locallyWith(_.add(clock))(zio)
+
+  def withStubClock[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] =
+    withClock(clock)(zio)
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -1,8 +1,9 @@
 package pricemigrationengine.handlers
 
+import pricemigrationengine.StubClock.withStubClock
+
 import java.time._
 import java.time.temporal.ChronoUnit
-
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.model.membershipworkflow.EmailMessage
@@ -189,11 +190,13 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler
-          .main(brazeCampaignName)
-          .provideLayer(
-            TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
-          )
+        withStubClock(
+          NotificationHandler
+            .main(brazeCampaignName)
+            .provideLayer(
+              TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
+            )
+        )
       ),
       Success(HandlerOutput(isComplete = true))
     )
@@ -255,11 +258,13 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler
-          .main(brazeCampaignName)
-          .provideLayer(
-            TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
-          )
+        withStubClock(
+          NotificationHandler
+            .main(brazeCampaignName)
+            .provideLayer(
+              TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
+            )
+        )
       ),
       Success(HandlerOutput(isComplete = true))
     )
@@ -288,11 +293,13 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler
-          .main(brazeCampaignName)
-          .provideLayer(
-            TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
-          )
+        withStubClock(
+          NotificationHandler
+            .main(brazeCampaignName)
+            .provideLayer(
+              TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
+            )
+        )
       ),
       Success(HandlerOutput(isComplete = true))
     )
@@ -313,11 +320,13 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler
-          .main(brazeCampaignName)
-          .provideLayer(
-            TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
-          )
+        withStubClock(
+          NotificationHandler
+            .main(brazeCampaignName)
+            .provideLayer(
+              TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
+            )
+        )
       ),
       Success(HandlerOutput(isComplete = true))
     )
@@ -334,11 +343,13 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler
-          .main(brazeCampaignName)
-          .provideLayer(
-            TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ failingStubEmailSender
-          )
+        withStubClock(
+          NotificationHandler
+            .main(brazeCampaignName)
+            .provideLayer(
+              TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ failingStubEmailSender
+            )
+        )
       ),
       Success(HandlerOutput(isComplete = true))
     )
@@ -364,11 +375,13 @@ class NotificationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        NotificationHandler
-          .main(brazeCampaignName)
-          .provideLayer(
-            TestLogging.logging ++ stubCohortTable ++ StubClock.clock ++ stubSalesforceClient ++ stubEmailSender
-          )
+        withStubClock(
+          NotificationHandler
+            .main(brazeCampaignName)
+            .provideLayer(
+              TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
+            )
+        )
       ),
       Success(HandlerOutput(isComplete = true))
     )

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -1,7 +1,8 @@
 package pricemigrationengine.handlers
 
-import java.time.{LocalDate, ZoneOffset}
+import pricemigrationengine.StubClock.withStubClock
 
+import java.time.{LocalDate, ZoneOffset}
 import pricemigrationengine.model.CohortTableFilter.{NotificationSendComplete, NotificationSendDateWrittenToSalesforce}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
@@ -85,10 +86,12 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        SalesforceNotificationDateUpdateHandler.main
-          .provideLayer(
-            TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ StubClock.clock
-          )
+        withStubClock(
+          SalesforceNotificationDateUpdateHandler.main
+            .provideLayer(
+              TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient
+            )
+        )
       ),
       Success(HandlerOutput(isComplete = true))
     )

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -1,7 +1,8 @@
 package pricemigrationengine.handlers
 
-import java.time.LocalDate
+import pricemigrationengine.StubClock.withStubClock
 
+import java.time.LocalDate
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiceCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
@@ -111,10 +112,12 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        SalesforcePriceRiseCreationHandler.main
-          .provideLayer(
-            TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ StubClock.clock
-          )
+        withStubClock(
+          SalesforcePriceRiseCreationHandler.main
+            .provideLayer(
+              TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient
+            )
+        )
       ),
       Success(expectedHandlerOutput)
     )
@@ -170,10 +173,12 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
     assertEquals(
       default.unsafeRunSync(
-        SalesforcePriceRiseCreationHandler.main
-          .provideLayer(
-            TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ StubClock.clock
-          )
+        withStubClock(
+          SalesforcePriceRiseCreationHandler.main
+            .provideLayer(
+              TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient
+            )
+        )
       ),
       Success(expectedHandlerOutput)
     )

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -77,7 +77,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
             )
           )
           .provideLayer(
-            TestLogging.logging ++ stubConfiguration ++ stubCohortTable ++ stubS3 ++ StubClock.clock
+            TestLogging.logging ++ stubConfiguration ++ stubCohortTable ++ stubS3
           )
       ),
       Success(HandlerOutput(isComplete = true))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  private val zioVersion = "2.0.0-RC3"
+  private val zioVersion = "2.0.0-RC4"
   private val awsSdkVersion = "2.17.182"
 
   lazy val awsDynamoDb = "software.amazon.awssdk" % "dynamodb" % awsSdkVersion


### PR DESCRIPTION
This is the fewest changes required to upgrade to RC 4.

The main change is that the services provided by ZIO are no longer in the environment of effects but built into the ZIO runtime.  This means that there's less boilerplate to work with the provided live implementations but there's a bit more work to use alternative implementations.  The reasoning I think is that you'd be unlikely to need alternative implementations of these services apart from the provided live and test implementations.  We're currently using stub implementations of `Clock` and `Random` in some cases so I've changed the way these are accessed in tests.  But we should probably move to the standard test ZIO implementations.

As all services in the environment are now custom services, `provideCustomLayer` has moved to `provideLayer`.

See:

* https://github.com/zio/zio/releases/tag/v2.0.0-RC4
