### PR TITLE
Upgrade ZIO v2 to RC6

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -34,7 +34,7 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
     for {
       priceRise <- ZIO.fromEither(buildPriceRise(item))
       salesforcePriceRiseId <-
-        IO
+        ZIO
           .fromOption(item.salesforcePriceRiseId)
           .orElseFail(SalesforcePriceRiseWriteFailure("salesforcePriceRiseId is required to update Salesforce"))
       _ <- SalesforceClient.updatePriceRise(salesforcePriceRiseId, priceRise)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.handlers
 import pricemigrationengine.model.CohortTableFilter.{NotificationSendComplete, NotificationSendDateWrittenToSalesforce}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
-import zio.{Clock, IO, ZEnv, ZIO, ZLayer}
+import zio.{IO, ZIO, ZLayer}
 
 import java.time.{LocalDate, ZoneOffset}
 
@@ -41,7 +41,7 @@ object SalesforceNotificationDateUpdateHandler extends CohortHandler {
     for {
       priceRise <- buildPriceRise(cohortItem)
       salesforcePriceRiseId <-
-        IO
+        ZIO
           .fromOption(cohortItem.salesforcePriceRiseId)
           .orElseFail(
             SalesforcePriceRiseWriteFailure(

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -17,42 +17,44 @@ object CohortTableLive {
   private val ProcessingStageAndStartDateIndexName = "ProcessingStageStartDateIndexV1"
 
   private implicit val cohortItemDeserialiser: DynamoDBDeserialiser[CohortItem] = { cohortItem =>
-    IO.fromEither(
-      for {
-        subscriptionNumber <- getStringFromResults(cohortItem, keyAttribName)
-        processingStage <- getCohortTableFilter(cohortItem, "processingStage")
-        startDate <- getOptionalDateFromResults(cohortItem, "startDate")
-        currency <- getOptionalStringFromResults(cohortItem, "currency")
-        oldPrice <- getOptionalBigDecimalFromResults(cohortItem, "oldPrice")
-        estimatedNewPrice <- getOptionalBigDecimalFromResults(cohortItem, "estimatedNewPrice")
-        billingPeriod <- getOptionalStringFromResults(cohortItem, "billingPeriod")
-        whenEstimationDone <- getOptionalInstantFromResults(cohortItem, "whenEstimationDone")
-        salesforcePriceRiseId <- getOptionalStringFromResults(cohortItem, "salesforcePriceRiseId")
-        whenSfShowEstimate <- getOptionalInstantFromResults(cohortItem, "whenSfShowEstimate")
-        newPrice <- getOptionalBigDecimalFromResults(cohortItem, "newPrice")
-        newSubscriptionId <- getOptionalStringFromResults(cohortItem, "newSubscriptionId")
-        whenAmendmentDone <- getOptionalInstantFromResults(cohortItem, "whenAmendmentDone")
-        whenNotificationSent <- getOptionalInstantFromResults(cohortItem, "whenNotificationSent")
-        whenNotificationSentWrittenToSalesforce <-
-          getOptionalInstantFromResults(cohortItem, "whenNotificationSentWrittenToSalesforce")
-      } yield CohortItem(
-        subscriptionName = subscriptionNumber,
-        processingStage = processingStage,
-        startDate = startDate,
-        currency = currency,
-        oldPrice = oldPrice,
-        estimatedNewPrice = estimatedNewPrice,
-        billingPeriod = billingPeriod,
-        whenEstimationDone = whenEstimationDone,
-        salesforcePriceRiseId = salesforcePriceRiseId,
-        whenSfShowEstimate = whenSfShowEstimate,
-        newPrice = newPrice,
-        newSubscriptionId = newSubscriptionId,
-        whenAmendmentDone = whenAmendmentDone,
-        whenNotificationSent = whenNotificationSent,
-        whenNotificationSentWrittenToSalesforce = whenNotificationSentWrittenToSalesforce
+    ZIO
+      .fromEither(
+        for {
+          subscriptionNumber <- getStringFromResults(cohortItem, keyAttribName)
+          processingStage <- getCohortTableFilter(cohortItem, "processingStage")
+          startDate <- getOptionalDateFromResults(cohortItem, "startDate")
+          currency <- getOptionalStringFromResults(cohortItem, "currency")
+          oldPrice <- getOptionalBigDecimalFromResults(cohortItem, "oldPrice")
+          estimatedNewPrice <- getOptionalBigDecimalFromResults(cohortItem, "estimatedNewPrice")
+          billingPeriod <- getOptionalStringFromResults(cohortItem, "billingPeriod")
+          whenEstimationDone <- getOptionalInstantFromResults(cohortItem, "whenEstimationDone")
+          salesforcePriceRiseId <- getOptionalStringFromResults(cohortItem, "salesforcePriceRiseId")
+          whenSfShowEstimate <- getOptionalInstantFromResults(cohortItem, "whenSfShowEstimate")
+          newPrice <- getOptionalBigDecimalFromResults(cohortItem, "newPrice")
+          newSubscriptionId <- getOptionalStringFromResults(cohortItem, "newSubscriptionId")
+          whenAmendmentDone <- getOptionalInstantFromResults(cohortItem, "whenAmendmentDone")
+          whenNotificationSent <- getOptionalInstantFromResults(cohortItem, "whenNotificationSent")
+          whenNotificationSentWrittenToSalesforce <-
+            getOptionalInstantFromResults(cohortItem, "whenNotificationSentWrittenToSalesforce")
+        } yield CohortItem(
+          subscriptionName = subscriptionNumber,
+          processingStage = processingStage,
+          startDate = startDate,
+          currency = currency,
+          oldPrice = oldPrice,
+          estimatedNewPrice = estimatedNewPrice,
+          billingPeriod = billingPeriod,
+          whenEstimationDone = whenEstimationDone,
+          salesforcePriceRiseId = salesforcePriceRiseId,
+          whenSfShowEstimate = whenSfShowEstimate,
+          newPrice = newPrice,
+          newSubscriptionId = newSubscriptionId,
+          whenAmendmentDone = whenAmendmentDone,
+          whenNotificationSent = whenNotificationSent,
+          whenNotificationSentWrittenToSalesforce = whenNotificationSentWrittenToSalesforce
+        )
       )
-    ).mapError(e => DynamoDBZIOError(e))
+      .mapError(e => DynamoDBZIOError(e))
   }
 
   private implicit val cohortItemUpdateSerialiser: DynamoDBUpdateSerialiser[CohortItem] =

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClient.scala
@@ -15,7 +15,7 @@ import software.amazon.awssdk.services.dynamodb.model.{
   UpdateItemRequest,
   UpdateItemResponse
 }
-import zio.{RIO, Task}
+import zio.{RIO, Task, ZIO}
 
 object DynamoDBClient {
   trait Service {
@@ -29,25 +29,25 @@ object DynamoDBClient {
   }
 
   def query(queryRequest: QueryRequest): RIO[DynamoDBClient, QueryResponse] =
-    RIO.environmentWithZIO(_.get.query(queryRequest))
+    ZIO.environmentWithZIO(_.get.query(queryRequest))
 
   def scan(scanRequest: ScanRequest): RIO[DynamoDBClient, ScanResponse] =
-    RIO.environmentWithZIO(_.get.scan(scanRequest))
+    ZIO.environmentWithZIO(_.get.scan(scanRequest))
 
   def updateItem(updateRequest: UpdateItemRequest): RIO[DynamoDBClient, UpdateItemResponse] =
-    RIO.environmentWithZIO(_.get.updateItem(updateRequest))
+    ZIO.environmentWithZIO(_.get.updateItem(updateRequest))
 
   def createItem(createRequest: PutItemRequest, keyName: String): RIO[DynamoDBClient, PutItemResponse] =
-    RIO.environmentWithZIO(_.get.createItem(createRequest, keyName))
+    ZIO.environmentWithZIO(_.get.createItem(createRequest, keyName))
 
   def describeTable(tableName: String): RIO[DynamoDBClient, DescribeTableResponse] =
-    RIO.environmentWithZIO(_.get.describeTable(tableName))
+    ZIO.environmentWithZIO(_.get.describeTable(tableName))
 
   def createTable(request: CreateTableRequest): RIO[DynamoDBClient, CreateTableResponse] =
-    RIO.environmentWithZIO(_.get.createTable(request))
+    ZIO.environmentWithZIO(_.get.createTable(request))
 
   def updateContinuousBackups(
       request: UpdateContinuousBackupsRequest
   ): RIO[DynamoDBClient, UpdateContinuousBackupsResponse] =
-    RIO.environmentWithZIO(_.get.updateContinuousBackups(request))
+    ZIO.environmentWithZIO(_.get.updateContinuousBackups(request))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClientLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/DynamoDBClientLive.scala
@@ -29,26 +29,26 @@ object DynamoDBClientLive {
       for {
         dynamoDb <- ZIO.service[DynamoDbClient]
       } yield new DynamoDBClient {
-        def query(queryRequest: QueryRequest): Task[QueryResponse] = Task.attempt(dynamoDb.query(queryRequest))
+        def query(queryRequest: QueryRequest): Task[QueryResponse] = ZIO.attempt(dynamoDb.query(queryRequest))
 
-        def scan(scanRequest: ScanRequest): Task[ScanResponse] = Task.attempt(dynamoDb.scan(scanRequest))
+        def scan(scanRequest: ScanRequest): Task[ScanResponse] = ZIO.attempt(dynamoDb.scan(scanRequest))
 
         def updateItem(updateRequest: UpdateItemRequest): Task[UpdateItemResponse] =
-          Task.attempt(dynamoDb.updateItem(updateRequest))
+          ZIO.attempt(dynamoDb.updateItem(updateRequest))
 
         def createItem(createRequest: PutItemRequest, keyName: String): Task[PutItemResponse] =
-          Task.attempt(
+          ZIO.attempt(
             dynamoDb.putItem(createRequest.copy(x => x.conditionExpression(s"attribute_not_exists($keyName)")))
           )
 
         def describeTable(tableName: String): Task[DescribeTableResponse] =
-          Task.attempt(dynamoDb.describeTable(DescribeTableRequest.builder.tableName(tableName).build()))
+          ZIO.attempt(dynamoDb.describeTable(DescribeTableRequest.builder.tableName(tableName).build()))
 
         def createTable(request: CreateTableRequest): Task[CreateTableResponse] =
-          Task.attempt(dynamoDb.createTable(request))
+          ZIO.attempt(dynamoDb.createTable(request))
 
         def updateContinuousBackups(request: UpdateContinuousBackupsRequest): Task[UpdateContinuousBackupsResponse] =
-          Task.attempt(dynamoDb.updateContinuousBackups(request))
+          ZIO.attempt(dynamoDb.updateContinuousBackups(request))
       }
     }
 

--- a/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/S3Live.scala
@@ -37,21 +37,23 @@ object S3Live {
             localFile: File,
             cannedAcl: Option[ObjectCannedACL]
         ): IO[S3Failure, PutObjectResponse] =
-          IO.attempt {
-            val requestWithoutAcl = PutObjectRequest.builder.bucket(s3Location.bucket).key(s3Location.key)
-            val putObjectRequest = cannedAcl.fold(requestWithoutAcl)(requestWithoutAcl.acl).build()
-            val requestBody = RequestBody.fromFile(localFile)
-            s3.putObject(putObjectRequest, requestBody)
-          }.mapError(ex => S3Failure(s"Failed to write s3 object $s3Location: ${ex.getMessage}"))
+          ZIO
+            .attempt {
+              val requestWithoutAcl = PutObjectRequest.builder.bucket(s3Location.bucket).key(s3Location.key)
+              val putObjectRequest = cannedAcl.fold(requestWithoutAcl)(requestWithoutAcl.acl).build()
+              val requestBody = RequestBody.fromFile(localFile)
+              s3.putObject(putObjectRequest, requestBody)
+            }
+            .mapError(ex => S3Failure(s"Failed to write s3 object $s3Location: ${ex.getMessage}"))
 
         override def deleteObject(s3Location: S3Location): IO[S3Failure, Unit] = {
           val listObjectsRequest = ListObjectsRequest.builder.bucket(s3Location.bucket).prefix(s3Location.key).build()
           def deleteObjectRequest(s3Object: S3Object) =
             DeleteObjectRequest.builder.bucket(s3Location.bucket).key(s3Object.key).build()
           (for {
-            listObjectsResponse <- IO.attempt(s3.listObjects(listObjectsRequest))
-            _ <- IO.foreachDiscard(listObjectsResponse.contents.asScala)(obj =>
-              IO.attempt(s3.deleteObject(deleteObjectRequest(obj))) <* logging.info(s"Deleted $obj")
+            listObjectsResponse <- ZIO.attempt(s3.listObjects(listObjectsRequest))
+            _ <- ZIO.foreachDiscard(listObjectsResponse.contents.asScala)(obj =>
+              ZIO.attempt(s3.deleteObject(deleteObjectRequest(obj))) <* logging.info(s"Deleted $obj")
             )
           } yield ()).mapError(ex => S3Failure(s"Failed to delete s3 object $s3Location: ${ex.getMessage}"))
         }

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
@@ -43,18 +43,18 @@ object SalesforceClientLive {
 
   private def sendRequest(request: HttpRequest) =
     for {
-      response <- IO
+      response <- ZIO
         .attempt(request.option(connTimeout).option(readTimeout).asString)
         .mapError(ex => SalesforceClientFailure(s"Request for ${requestAsMessage(request)} failed: $ex"))
       valid200Response <-
-        if ((response.code / 100) == 2) { IO.succeed(response) }
-        else { IO.fail(SalesforceClientFailure(failureMessage(request, response))) }
+        if ((response.code / 100) == 2) { ZIO.succeed(response) }
+        else { ZIO.fail(SalesforceClientFailure(failureMessage(request, response))) }
     } yield valid200Response
 
   private def sendRequestAndParseResponse[A](request: HttpRequest)(implicit reader: Reader[A]) =
     for {
       valid200Response <- sendRequest(request)
-      parsedResponse <- IO
+      parsedResponse <- ZIO
         .attempt(read[A](valid200Response.body))
         .mapError(ex => SalesforceClientFailure(s"${requestAsMessage(request)} failed to deserialise: $ex"))
     } yield parsedResponse

--- a/lambda/src/test/scala/pricemigrationengine/StubClock.scala
+++ b/lambda/src/test/scala/pricemigrationengine/StubClock.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine
 
-import zio.{Clock, IO, Scheduler, UIO, ZEnv, ZIO, ZTraceElement}
+import zio.{Clock, Scheduler, Trace, UIO, ZEnv, ZIO}
 
 import java.time
 import java.time.{Instant, LocalDateTime, OffsetDateTime, ZoneOffset}
@@ -10,22 +10,22 @@ object StubClock {
   val expectedCurrentTime: Instant = Instant.parse("2020-05-21T15:16:37Z")
   private val clock: Clock = new Clock {
 
-    override def currentTime(unit: => TimeUnit)(implicit trace: ZTraceElement): UIO[Long] = ???
+    override def currentTime(unit: => TimeUnit)(implicit trace: Trace): UIO[Long] = ???
 
-    override def currentDateTime(implicit trace: ZTraceElement): UIO[OffsetDateTime] =
-      IO.succeed(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+    override def currentDateTime(implicit trace: Trace): UIO[OffsetDateTime] =
+      ZIO.succeed(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
 
-    override def instant(implicit trace: ZTraceElement): UIO[Instant] = ???
+    override def instant(implicit trace: Trace): UIO[Instant] = ???
 
-    override def localDateTime(implicit trace: ZTraceElement): UIO[LocalDateTime] = ???
+    override def localDateTime(implicit trace: Trace): UIO[LocalDateTime] = ???
 
-    override def nanoTime(implicit trace: ZTraceElement): UIO[Long] = ???
+    override def nanoTime(implicit trace: Trace): UIO[Long] = ???
 
-    override def scheduler(implicit trace: ZTraceElement): UIO[Scheduler] = ???
+    override def scheduler(implicit trace: Trace): UIO[Scheduler] = ???
 
-    override def sleep(duration: => zio.Duration)(implicit trace: ZTraceElement): UIO[Unit] = ???
+    override def sleep(duration: => zio.Duration)(implicit trace: Trace): UIO[Unit] = ???
 
-    override def javaClock(implicit trace: ZTraceElement): UIO[time.Clock] = ???
+    override def javaClock(implicit trace: Trace): UIO[time.Clock] = ???
   }
 
   private def withClock[R, E, A](clock: Clock)(zio: ZIO[R, E, A]) =

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -30,7 +30,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
 
         override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
-          IO.succeed(ZStream.fromIterable(cohortItems))
+          ZIO.succeed(ZStream.fromIterable(cohortItems))
         }
       }
     )

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.Fixtures
-import zio.{Chunk, Random, Runtime, UIO, ZEnv, ZIO, ZTraceElement}
+import zio.{Chunk, Random, Runtime, Trace, UIO, ZEnv, ZIO}
 
 import java.time.LocalDate
 import java.util.UUID
@@ -13,51 +13,50 @@ class EstimationHandlerTest extends munit.FunSuite {
   private val random =
     new Random {
 
-      override def nextBoolean(implicit trace: ZTraceElement): UIO[Boolean] = ???
+      override def nextBoolean(implicit trace: Trace): UIO[Boolean] = ???
 
-      override def nextBytes(length: => Int)(implicit trace: ZTraceElement): UIO[Chunk[Byte]] = ???
+      override def nextBytes(length: => Int)(implicit trace: Trace): UIO[Chunk[Byte]] = ???
 
-      override def nextDouble(implicit trace: ZTraceElement): UIO[Double] = ???
+      override def nextDouble(implicit trace: Trace): UIO[Double] = ???
 
       override def nextDoubleBetween(minInclusive: => Double, maxExclusive: => Double)(implicit
-          trace: ZTraceElement
+          trace: Trace
       ): UIO[Double] = ???
 
-      override def nextFloat(implicit trace: ZTraceElement): UIO[Float] = ???
+      override def nextFloat(implicit trace: Trace): UIO[Float] = ???
 
       override def nextFloatBetween(minInclusive: => Float, maxExclusive: => Float)(implicit
-          trace: ZTraceElement
+          trace: Trace
       ): UIO[Float] = ???
 
-      override def nextGaussian(implicit trace: ZTraceElement): UIO[Double] = ???
+      override def nextGaussian(implicit trace: Trace): UIO[Double] = ???
 
-      override def nextInt(implicit trace: ZTraceElement): UIO[Int] = ???
+      override def nextInt(implicit trace: Trace): UIO[Int] = ???
 
-      override def nextIntBetween(minInclusive: => Int, maxExclusive: => Int)(implicit trace: ZTraceElement): UIO[Int] =
-        UIO.succeed(1)
+      override def nextIntBetween(minInclusive: => Int, maxExclusive: => Int)(implicit trace: Trace): UIO[Int] =
+        ZIO.succeed(1)
 
-      override def nextIntBounded(n: => Int)(implicit trace: ZTraceElement): UIO[Int] = ???
+      override def nextIntBounded(n: => Int)(implicit trace: Trace): UIO[Int] = ???
 
-      override def nextLong(implicit trace: ZTraceElement): UIO[Long] = ???
+      override def nextLong(implicit trace: Trace): UIO[Long] = ???
 
       override def nextLongBetween(minInclusive: => Long, maxExclusive: => Long)(implicit
-          trace: ZTraceElement
+          trace: Trace
       ): UIO[Long] = ???
 
-      override def nextLongBounded(n: => Long)(implicit trace: ZTraceElement): UIO[Long] = ???
+      override def nextLongBounded(n: => Long)(implicit trace: Trace): UIO[Long] = ???
 
-      override def nextPrintableChar(implicit trace: ZTraceElement): UIO[Char] = ???
+      override def nextPrintableChar(implicit trace: Trace): UIO[Char] = ???
 
-      override def nextString(length: => Int)(implicit trace: ZTraceElement): UIO[String] = ???
+      override def nextString(length: => Int)(implicit trace: Trace): UIO[String] = ???
 
-      override def nextUUID(implicit trace: ZTraceElement): UIO[UUID] = ???
+      override def nextUUID(implicit trace: Trace): UIO[UUID] = ???
 
-      override def setSeed(seed: => Long)(implicit trace: ZTraceElement): UIO[Unit] = ???
+      override def setSeed(seed: => Long)(implicit trace: Trace): UIO[Unit] = ???
 
-      override def shuffle[A, Collection[+Element] <: Iterable[Element]](collection: => Collection[A])(implicit
-          bf: zio.BuildFrom[Collection[A], A, Collection[A]],
-          trace: ZTraceElement
-      ): UIO[Collection[A]] = ???
+      override def shuffle[A, Collection[+Element] <: Iterable[Element]](
+          collection: => Collection[A]
+      )(implicit bf: zio.BuildFrom[Collection[A], A, Collection[A]], trace: Trace): UIO[Collection[A]] = ???
     }
 
   private def withStubRandom[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] =

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerSpec.scala
@@ -21,7 +21,7 @@ object NotificationHandlerSpec extends ZIOSpecDefault {
     country = Some("United Kingdom")
   )
 
-  override def spec: Spec[Any, TestFailure[NotificationHandlerFailure], TestSuccess] = suite("targetAddress")(
+  override def spec: Spec[Any, NotificationHandlerFailure] = suite("targetAddress")(
     test("should use mailing address if billing address has no street") {
       val contact = SalesforceContact(
         Id = "id",

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -63,14 +63,14 @@ class NotificationHandlerTest extends munit.FunSuite {
                 .from(StubClock.expectedCurrentTime.plus(37, ChronoUnit.DAYS).atOffset(ZoneOffset.UTC))
             )
           )
-          IO.succeed(ZStream(cohortItem))
+          ZIO.succeed(ZStream(cohortItem))
         }
 
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)
-          IO.succeed(())
+          ZIO.succeed(())
         }
 
         override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -27,14 +27,14 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
             beforeDateInclusive: Option[LocalDate]
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
           assertEquals(filter, NotificationSendComplete)
-          IO.succeed(ZStream(cohortItem))
+          ZIO.succeed(ZStream(cohortItem))
         }
 
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)
-          IO.succeed(())
+          ZIO.succeed(())
         }
 
         override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -34,7 +34,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
             beforeDateInclusive: Option[LocalDate]
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
           assertEquals(filter, EstimationComplete)
-          IO.succeed(ZStream(cohortItem))
+          ZIO.succeed(ZStream(cohortItem))
         }
 
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???
@@ -43,7 +43,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)
-          IO.succeed(())
+          ZIO.succeed(())
         }
       }
     )
@@ -58,15 +58,17 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
         override def getSubscriptionByName(
             subscriptionName: String
         ): IO[SalesforceClientFailure, SalesforceSubscription] = {
-          IO.attempt(
-            SalesforceSubscription(
-              s"SubscritionId-$subscriptionName",
-              subscriptionName,
-              s"Buyer-$subscriptionName",
-              "Active",
-              Some("Newspaper - Digital Voucher")
+          ZIO
+            .attempt(
+              SalesforceSubscription(
+                s"SubscritionId-$subscriptionName",
+                subscriptionName,
+                s"Buyer-$subscriptionName",
+                "Active",
+                Some("Newspaper - Digital Voucher")
+              )
             )
-          ).orElseFail(SalesforceClientFailure(""))
+            .orElseFail(SalesforceClientFailure(""))
         }
 
         override def createPriceRise(

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -1,8 +1,8 @@
 package pricemigrationengine.handlers
 
+import pricemigrationengine.TestLogging
 import pricemigrationengine.model._
 import pricemigrationengine.services._
-import pricemigrationengine.{StubClock, TestLogging}
 import software.amazon.awssdk.services.s3.model.{ObjectCannedACL, PutObjectResponse}
 import zio.Exit.Success
 import zio.Runtime.default
@@ -18,7 +18,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
     val stubConfiguration = ZLayer.succeed(
       new StageConfiguration.Service {
         override val config: IO[ConfigurationFailure, StageConfig] =
-          IO.succeed(StageConfig("DEV"))
+          ZIO.succeed(StageConfig("DEV"))
       }
     )
 
@@ -33,10 +33,12 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
         override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] =
-          IO.attempt {
-            subscriptionsWrittenToCohortTable.addOne(cohortItem)
-            ()
-          }.orElseFail(CohortUpdateFailure(""))
+          ZIO
+            .attempt {
+              subscriptionsWrittenToCohortTable.addOne(cohortItem)
+              ()
+            }
+            .orElseFail(CohortUpdateFailure(""))
       }
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
@@ -6,7 +6,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeAction.PUT
 import software.amazon.awssdk.services.dynamodb.model._
 import zio.Exit.Success
 import zio.Runtime.default
-import zio.stream.Sink
+import zio.stream.ZSink
 import zio.{Chunk, Task, ZIO, ZLayer}
 
 import java.util
@@ -28,7 +28,7 @@ class DynamoDBZIOLiveTest extends munit.FunSuite {
     )
     val stubDynamoDBClient = ZLayer.succeed(
       new DynamoDBClient.Service {
-        def query(queryRequest: QueryRequest): Task[QueryResponse] = Task.succeed(responseMap(queryRequest))
+        def query(queryRequest: QueryRequest): Task[QueryResponse] = ZIO.succeed(responseMap(queryRequest))
 
         def scan(scanRequest: ScanRequest): Task[ScanResponse] = ???
 
@@ -52,7 +52,7 @@ class DynamoDBZIOLiveTest extends munit.FunSuite {
     ) match {
       case Success(results) =>
         assertEquals(
-          default.unsafeRunSync(results.run(Sink.collectAll[String])),
+          default.unsafeRunSync(results.run(ZSink.collectAll[String])),
           Success(Chunk("id-1", "id-2", "id-3"))
         )
       case failure =>
@@ -85,7 +85,7 @@ class DynamoDBZIOLiveTest extends munit.FunSuite {
         def scan(scanRequest: ScanRequest): Task[ScanResponse] = ???
 
         def updateItem(updateItemRequest: UpdateItemRequest): Task[UpdateItemResponse] =
-          Task.succeed {
+          ZIO.succeed {
             receivedUpdateItemRequest = Some(updateItemRequest)
             UpdateItemResponse.builder.build()
           }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  private val zioVersion = "2.0.0-RC5"
+  private val zioVersion = "2.0.0-RC6"
   private val awsSdkVersion = "2.17.182"
 
   lazy val awsDynamoDb = "software.amazon.awssdk" % "dynamodb" % awsSdkVersion


### PR DESCRIPTION
This is final step to bring code up to date.
The main change here is that all the duplicated methods in ZIO type aliases have been removed, which makes things a lot simpler as everything is a direct method of `ZIO`.

See https://github.com/zio/zio/releases/tag/v2.0.0-RC6
