### PR TITLE
Bump codeql action to v2

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -32,6 +32,6 @@ jobs:
           args: --sarif-file-output=snyk.sarif
 
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: snyk.sarif


### PR DESCRIPTION
See https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/