### PR TITLE
Use ZIO clock for relative time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val lambda = (project in file("lambda"))
       slf4jNop % Runtime,
       munit % Test,
       zioTest % Test,
-      zioTestSbt % Test
+      zioTestSbt % Test,
+      zioMock % Test
     ),
     testFrameworks += new TestFramework("munit.Framework"),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -34,7 +34,7 @@ object EstimationHandler extends CohortHandler {
           .tapError(e => Logging.error(e.toString))
     } yield HandlerOutput(isComplete = count < batchSize)
 
-  private def estimate(
+  private[handlers] def estimate(
       catalogue: ZuoraProductCatalogue,
       earliestStartDate: LocalDate
   )(
@@ -51,7 +51,10 @@ object EstimationHandler extends CohortHandler {
         case e => ZIO.fail(e)
       },
       success = { result =>
-        CohortTable.update(CohortItem.fromSuccessfulEstimationResult(result)).as(result)
+        for {
+          cohortItem <- CohortItem.fromSuccessfulEstimationResult(result)
+          _ <- CohortTable.update(cohortItem)
+        } yield result
       }
     )
 

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -1,8 +1,9 @@
 package pricemigrationengine.model
 
-import java.time.{Instant, LocalDate}
-
 import pricemigrationengine.model.CohortTableFilter.{AmendmentComplete, Cancelled, EstimationComplete, EstimationFailed}
+import zio.{Clock, UIO}
+
+import java.time._
 
 case class CohortItem(
     subscriptionName: String,
@@ -25,8 +26,10 @@ case class CohortItem(
 
 object CohortItem {
 
-  def fromSuccessfulEstimationResult(result: SuccessfulEstimationResult): CohortItem =
-    CohortItem(
+  def fromSuccessfulEstimationResult(result: SuccessfulEstimationResult): UIO[CohortItem] =
+    for {
+      thisInstant <- Clock.instant
+    } yield CohortItem(
       result.subscriptionName,
       processingStage = EstimationComplete,
       oldPrice = Some(result.oldPrice),
@@ -34,7 +37,7 @@ object CohortItem {
       currency = Some(result.currency),
       startDate = Some(result.startDate),
       billingPeriod = Some(result.billingPeriod),
-      whenEstimationDone = Some(Instant.now())
+      whenEstimationDone = Some(thisInstant)
     )
 
   def fromFailedEstimationResult(result: FailedEstimationResult): CohortItem =

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
@@ -1,0 +1,126 @@
+package pricemigrationengine.handlers
+
+import pricemigrationengine.handlers.EstimationHandlerSpec.time
+import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, ReadyForEstimation}
+import pricemigrationengine.model._
+import pricemigrationengine.service.{MockCohortTable, MockZuora}
+import zio._
+import zio.mock.Expectation._
+import zio.test.Assertion._
+import zio.test._
+
+import java.time._
+
+object EstimationHandlerSpec extends ZIOSpecDefault {
+
+  private val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 16, 10, 2), ZoneOffset.ofHours(0))
+
+  private val productCatalogue = ZuoraProductCatalogue(products =
+    Set(
+      ZuoraProduct(
+        "P1",
+        Set(
+          ZuoraProductRatePlan(
+            id = "PRP1",
+            name = "RP1",
+            status = "Active",
+            productRatePlanCharges = Set(
+              ZuoraProductRatePlanCharge(
+                id = "PRPC1",
+                billingPeriod = Some("Month"),
+                pricing = Set(ZuoraPricing(currency = "GBP", price = Some(BigDecimal("2.45"))))
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+
+  private val subscription = ZuoraSubscription(
+    subscriptionNumber = "S1",
+    customerAcceptanceDate = LocalDate.of(2022, 1, 1),
+    contractEffectiveDate = LocalDate.of(2022, 1, 1),
+    ratePlans = List(
+      ZuoraRatePlan(
+        id = "R1",
+        productName = "P1",
+        productRatePlanId = "PRP1",
+        ratePlanName = "RP1",
+        ratePlanCharges = List(
+          ZuoraRatePlanCharge(
+            productRatePlanChargeId = "PRPC1",
+            name = "N2",
+            number = "C3",
+            currency = "GBP",
+            price = Some(BigDecimal("1.23")),
+            billingPeriod = Some("Month")
+          )
+        )
+      )
+    ),
+    accountNumber = "A1",
+    accountId = "A11",
+    status = "Active",
+    termStartDate = LocalDate.of(2022, 1, 1),
+    termEndDate = LocalDate.of(2023, 1, 1)
+  )
+
+  private val invoicePreview = ZuoraInvoiceList(
+    Seq(
+      ZuoraInvoiceItem(
+        subscriptionNumber = "S1",
+        serviceStartDate = LocalDate.of(2022, 5, 1),
+        chargeNumber = "C1"
+      ),
+      ZuoraInvoiceItem(
+        subscriptionNumber = "S1",
+        serviceStartDate = LocalDate.of(2022, 6, 1),
+        chargeNumber = "C2"
+      ),
+      ZuoraInvoiceItem(
+        subscriptionNumber = "S1",
+        serviceStartDate = LocalDate.of(2022, 7, 1),
+        chargeNumber = "C3"
+      )
+    )
+  )
+
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("estimate")(
+    test("updates cohort table with EstimationComplete when data is complete") {
+      val cohortItemRead = CohortItem(
+        subscriptionName = "S1",
+        processingStage = ReadyForEstimation
+      )
+      val cohortItemExpectedToWrite = CohortItem(
+        subscriptionName = "S1",
+        processingStage = EstimationComplete,
+        startDate = Some(LocalDate.of(2022, 7, 1)),
+        currency = Some("GBP"),
+        oldPrice = Some(1.23),
+        estimatedNewPrice = Some(2.45),
+        billingPeriod = Some("Month"),
+        whenEstimationDone = Some(Instant.from(time))
+      )
+      val expectedSubscriptionFetch = MockZuora.FetchSubscription(
+        assertion = equalTo("S1"),
+        result = value(subscription)
+      )
+      val expectedInvoiceFetch = MockZuora.FetchInvoicePreview(
+        assertion = equalTo("A11", LocalDate.of(2023, 6, 1)),
+        result = value(invoicePreview)
+      )
+      val expectedZuoraUse = expectedSubscriptionFetch and expectedInvoiceFetch
+      val expectedCohortTableUpdate = MockCohortTable.Update(
+        assertion = equalTo(cohortItemExpectedToWrite),
+        result = unit
+      )
+      for {
+        _ <- TestClock.setDateTime(time)
+        _ <- EstimationHandler
+          .estimate(productCatalogue, earliestStartDate = LocalDate.of(2022, 5, 1))(cohortItemRead)
+          .provide(expectedZuoraUse, expectedCohortTableUpdate)
+      } yield assertTrue(true)
+    }
+  )
+}

--- a/lambda/src/test/scala/pricemigrationengine/service/MockCohortTable.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/MockCohortTable.scala
@@ -1,0 +1,40 @@
+package pricemigrationengine.service
+
+import pricemigrationengine.model.{CohortFetchFailure, CohortItem, CohortTableFilter, CohortUpdateFailure, Failure}
+import pricemigrationengine.services.CohortTable
+import zio.mock.{Mock, Proxy}
+import zio.stream.ZStream
+import zio.{IO, URLayer, ZIO, ZLayer}
+
+import java.time.LocalDate
+
+object MockCohortTable extends Mock[CohortTable] {
+
+  object Fetch
+      extends Effect[
+        (CohortTableFilter, Option[LocalDate]),
+        CohortFetchFailure,
+        ZStream[Any, CohortFetchFailure, CohortItem]
+      ]
+  object FetchAll extends Effect[Unit, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
+  object Create extends Effect[CohortItem, Failure, Unit]
+  object Update extends Effect[CohortItem, CohortUpdateFailure, Unit]
+
+  val compose: URLayer[Proxy, CohortTable] = ZLayer.fromZIO(ZIO.service[Proxy].map { proxy =>
+    new CohortTable {
+
+      override def fetch(filter: CohortTableFilter, beforeDateInclusive: Option[LocalDate])
+          : IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
+        proxy(Fetch, filter, beforeDateInclusive)
+
+      override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
+        proxy(FetchAll, ())
+
+      override def create(cohortItem: CohortItem): IO[Failure, Unit] =
+        proxy(Create, cohortItem)
+
+      override def update(result: CohortItem): IO[CohortUpdateFailure, Unit] =
+        proxy(Update, result)
+    }
+  })
+}

--- a/lambda/src/test/scala/pricemigrationengine/service/MockZuora.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/MockZuora.scala
@@ -1,0 +1,35 @@
+package pricemigrationengine.service
+
+import pricemigrationengine.model._
+import pricemigrationengine.services.Zuora
+import zio._
+import zio.mock._
+
+import java.time.LocalDate
+
+object MockZuora extends Mock[Zuora] {
+
+  object FetchSubscription extends Effect[String, ZuoraFetchFailure, ZuoraSubscription]
+  object FetchInvoicePreview extends Effect[(String, LocalDate), ZuoraFetchFailure, ZuoraInvoiceList]
+  object FetchProductCatalogue extends Effect[Unit, ZuoraFetchFailure, ZuoraProductCatalogue]
+  object UpdateSubscription
+      extends Effect[(ZuoraSubscription, ZuoraSubscriptionUpdate), ZuoraUpdateFailure, ZuoraSubscriptionId]
+
+  val compose: URLayer[Proxy, Zuora] = ZLayer.fromZIO(ZIO.service[Proxy].map { proxy =>
+    new Zuora {
+
+      override def fetchSubscription(subscriptionNumber: String): ZIO[Any, ZuoraFetchFailure, ZuoraSubscription] =
+        proxy(FetchSubscription, subscriptionNumber)
+
+      override def fetchInvoicePreview(accountId: String, targetDate: LocalDate)
+          : ZIO[Any, ZuoraFetchFailure, ZuoraInvoiceList] = proxy(FetchInvoicePreview, accountId, targetDate)
+
+      override val fetchProductCatalogue: ZIO[Any, ZuoraFetchFailure, ZuoraProductCatalogue] =
+        proxy(FetchProductCatalogue)
+
+      override def updateSubscription(subscription: ZuoraSubscription, update: ZuoraSubscriptionUpdate)
+          : ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId] =
+        proxy(UpdateSubscription, subscription, update)
+    }
+  })
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,6 +12,7 @@ object Dependencies {
   lazy val zioStreams = "dev.zio" %% "zio-streams" % zioVersion
   lazy val zioTest = "dev.zio" %% "zio-test" % zioVersion
   lazy val zioTestSbt = "dev.zio" %% "zio-test-sbt" % zioVersion
+  lazy val zioMock = "dev.zio" %% "zio-mock" % "1.0.0-RC6"
   lazy val upickle = "com.lihaoyi" %% "upickle" % "2.0.0"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"


### PR DESCRIPTION
There was one [instance](https://github.com/guardian/price-migration-engine/compare/kc-est-update?expand=1#diff-586551da3acd4a0574ffe4c45970f0ea7ef9d450f56bd756f0e81d8af8742d4cL37) where a relative time was being used directly.

I've added some mock services to test it.
