### PR TITLE
Set alarms to ignore missing data

### DIFF
--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -467,7 +467,7 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
-      TreatMissingData: missing
+      TreatMissingData: ignore
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
 
@@ -491,6 +491,6 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
-      TreatMissingData: missing
+      TreatMissingData: ignore
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev


### PR DESCRIPTION
So that alarms don't change to OK until a successful run has happened.

See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data
