### PR TITLE
Add new state for subs where price isn't rising

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -1,9 +1,9 @@
 package pricemigrationengine.model
 
-import pricemigrationengine.model.CohortTableFilter.{AmendmentComplete, Cancelled, EstimationComplete, EstimationFailed}
+import pricemigrationengine.model.CohortTableFilter._
 import zio.{Clock, UIO}
 
-import java.time._
+import java.time.{Instant, LocalDate}
 
 case class CohortItem(
     subscriptionName: String,
@@ -39,6 +39,9 @@ object CohortItem {
       billingPeriod = Some(result.billingPeriod),
       whenEstimationDone = Some(thisInstant)
     )
+
+  def fromNoPriceIncreaseEstimationResult(result: SuccessfulEstimationResult): UIO[CohortItem] =
+    fromSuccessfulEstimationResult(result).map(_.copy(processingStage = NoPriceIncrease))
 
   def fromFailedEstimationResult(result: FailedEstimationResult): CohortItem =
     CohortItem(result.subscriptionNumber, EstimationFailed)

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -28,13 +28,19 @@ object CohortTableFilter {
     override val value: String = "AmendmentWrittenToSalesforce"
   }
 
-  // ++++++++++ Exceptional states ++++++++++
-
   /*
    * Status of a sub that has been cancelled since the price migration process began,
    * so is ineligible for further processing.
    */
   case object Cancelled extends CohortTableFilter { override val value: String = "Cancelled" }
+
+  /*
+   * Status of a sub where the estimation indicates that its price will not increase,
+   * so is ineligible for further processing.
+   */
+  case object NoPriceIncrease extends CohortTableFilter { override val value: String = "NoPriceIncrease" }
+
+  // ++++++++++ Exceptional states ++++++++++
 
   case object EstimationFailed extends CohortTableFilter { override val value: String = "EstimationFailed" }
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
@@ -1,7 +1,6 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.handlers.EstimationHandlerSpec.time
-import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, ReadyForEstimation}
+import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, NoPriceIncrease, ReadyForEstimation}
 import pricemigrationengine.model._
 import pricemigrationengine.service.{MockCohortTable, MockZuora}
 import zio._
@@ -14,28 +13,6 @@ import java.time._
 object EstimationHandlerSpec extends ZIOSpecDefault {
 
   private val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 16, 10, 2), ZoneOffset.ofHours(0))
-
-  private val productCatalogue = ZuoraProductCatalogue(products =
-    Set(
-      ZuoraProduct(
-        "P1",
-        Set(
-          ZuoraProductRatePlan(
-            id = "PRP1",
-            name = "RP1",
-            status = "Active",
-            productRatePlanCharges = Set(
-              ZuoraProductRatePlanCharge(
-                id = "PRPC1",
-                billingPeriod = Some("Month"),
-                pricing = Set(ZuoraPricing(currency = "GBP", price = Some(BigDecimal("2.45"))))
-              )
-            )
-          )
-        )
-      )
-    )
-  )
 
   private val subscription = ZuoraSubscription(
     subscriptionNumber = "S1",
@@ -91,6 +68,27 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
 
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("estimate")(
     test("updates cohort table with EstimationComplete when data is complete") {
+      val productCatalogue = ZuoraProductCatalogue(products =
+        Set(
+          ZuoraProduct(
+            "P1",
+            Set(
+              ZuoraProductRatePlan(
+                id = "PRP1",
+                name = "RP1",
+                status = "Active",
+                productRatePlanCharges = Set(
+                  ZuoraProductRatePlanCharge(
+                    id = "PRPC1",
+                    billingPeriod = Some("Month"),
+                    pricing = Set(ZuoraPricing(currency = "GBP", price = Some(BigDecimal("2.45"))))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
       val cohortItemRead = CohortItem(
         subscriptionName = "S1",
         processingStage = ReadyForEstimation
@@ -114,6 +112,62 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         result = value(invoicePreview)
       )
       val expectedZuoraUse = expectedSubscriptionFetch and expectedInvoiceFetch
+      val expectedCohortTableUpdate = MockCohortTable.Update(
+        assertion = equalTo(cohortItemExpectedToWrite),
+        result = unit
+      )
+      for {
+        _ <- TestClock.setDateTime(time)
+        _ <- EstimationHandler
+          .estimate(productCatalogue, earliestStartDate = LocalDate.of(2022, 5, 1))(cohortItemRead)
+          .provide(expectedZuoraUse, expectedCohortTableUpdate)
+      } yield assertTrue(true)
+    },
+    test("updates cohort table with NoPriceIncrease when estimated new price <= old price") {
+      val productCatalogue = ZuoraProductCatalogue(products =
+        Set(
+          ZuoraProduct(
+            "P1",
+            Set(
+              ZuoraProductRatePlan(
+                id = "PRP1",
+                name = "RP1",
+                status = "Active",
+                productRatePlanCharges = Set(
+                  ZuoraProductRatePlanCharge(
+                    id = "PRPC1",
+                    billingPeriod = Some("Month"),
+                    pricing = Set(ZuoraPricing(currency = "GBP", price = Some(BigDecimal("1.15"))))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+      val cohortItemRead = CohortItem(
+        subscriptionName = "S1",
+        processingStage = ReadyForEstimation
+      )
+      val expectedSubscriptionFetch = MockZuora.FetchSubscription(
+        assertion = equalTo("S1"),
+        result = value(subscription)
+      )
+      val expectedInvoiceFetch = MockZuora.FetchInvoicePreview(
+        assertion = equalTo("A11", LocalDate.of(2023, 6, 1)),
+        result = value(invoicePreview)
+      )
+      val expectedZuoraUse = expectedSubscriptionFetch and expectedInvoiceFetch
+      val cohortItemExpectedToWrite = CohortItem(
+        subscriptionName = "S1",
+        processingStage = NoPriceIncrease,
+        startDate = Some(LocalDate.of(2022, 7, 1)),
+        currency = Some("GBP"),
+        oldPrice = Some(1.23),
+        estimatedNewPrice = Some(1.15),
+        billingPeriod = Some("Month"),
+        whenEstimationDone = Some(Instant.from(time))
+      )
       val expectedCohortTableUpdate = MockCohortTable.Update(
         assertion = equalTo(cohortItemExpectedToWrite),
         result = unit


### PR DESCRIPTION
Previously, subs where the new price wasn't greater than the old price were considered to be estimation failures.  This meant they kept coming up when we analysing failure cases.  But we didn't want to remove them from the cohort as that would then raise the question why they had been excluded.

To solve the problem, in this change we no longer consider price falls or price constant as failures.  
Instead they are given a new state in the cohort table, 'NoPriceIncrease', which isn't processed any further.
This will allow us to analyse them separately if necessary.
