### PR TITLE
Add new NoPriceIncrease state to set of all

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -2,6 +2,7 @@ package pricemigrationengine.model
 
 sealed trait CohortTableFilter { val value: String }
 
+// When adding a state, remember to update 'all'.
 object CohortTableFilter {
 
   // ++++++++++ Normal states ++++++++++
@@ -50,13 +51,15 @@ object CohortTableFilter {
 
   case object AmendmentFailed extends CohortTableFilter { override val value: String = "AmendmentFailed" }
 
-  val all = Set(
+  // Set of all states.  Remember to update when adding a state.
+  val all: Set[CohortTableFilter] = Set(
     AmendmentComplete,
     AmendmentFailed,
     AmendmentWrittenToSalesforce,
     Cancelled,
     EstimationComplete,
     EstimationFailed,
+    NoPriceIncrease,
     NotificationSendComplete,
     NotificationSendDateWrittenToSalesforce,
     NotificationSendProcessingOrError,


### PR DESCRIPTION
We're seeing an alarm go off because [this code](https://github.com/guardian/price-migration-engine/blob/main/lambda/src/main/scala/pricemigrationengine/model/dynamodb/Conversions.scala#L60-L62) does a check for invalid subscription processing states before exporting data to the lake.
Error is:
> DynamoDBZIOError(The 'processingStage' contained an invalid CohortTableFilter 'NoPriceIncrease')
