### PR TITLE
Flatten type of CohortTable fetch

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -15,12 +15,11 @@ object AmendmentHandler extends CohortHandler {
   val main: ZIO[Logging with CohortTable with Zuora, Failure, HandlerOutput] =
     for {
       catalogue <- Zuora.fetchProductCatalogue
-      cohortItems <- CohortTable.fetch(NotificationSendDateWrittenToSalesforce, None)
-      count <-
-        cohortItems
-          .take(batchSize)
-          .mapZIO(item => amend(catalogue, item).tapBoth(Logging.logFailure(item), Logging.logSuccess(item)))
-          .runCount
+      count <- CohortTable
+        .fetch(NotificationSendDateWrittenToSalesforce, None)
+        .take(batchSize)
+        .mapZIO(item => amend(catalogue, item).tapBoth(Logging.logFailure(item), Logging.logSuccess(item)))
+        .runCount
     } yield HandlerOutput(isComplete = count < batchSize)
 
   private def amend(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -30,14 +30,10 @@ object NotificationHandler extends CohortHandler {
   ): ZIO[Logging with CohortTable with SalesforceClient with EmailSender, Failure, HandlerOutput] = {
     for {
       today <- Clock.currentDateTime.map(_.toLocalDate)
-      subscriptions <- CohortTable.fetch(
-        SalesforcePriceRiceCreationComplete,
-        Some(today.plusDays(NotificationLeadTimeDays))
-      )
-      count <-
-        subscriptions
-          .mapZIO(sendNotification(brazeCampaignName))
-          .runFold(0) { (sum, count) => sum + count }
+      count <- CohortTable
+        .fetch(SalesforcePriceRiceCreationComplete, Some(today.plusDays(NotificationLeadTimeDays)))
+        .mapZIO(sendNotification(brazeCampaignName))
+        .runFold(0) { (sum, count) => sum + count }
       _ <- Logging.info(s"Successfully sent $count price rise notifications")
     } yield HandlerOutput(isComplete = true)
   }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -14,17 +14,16 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
 
   private val main: ZIO[CohortTable with SalesforceClient with Logging, Failure, HandlerOutput] =
     for {
-      cohortItems <- CohortTable.fetch(AmendmentComplete, None)
-      count <-
-        cohortItems
-          .take(batchSize)
-          .mapZIO(item =>
-            updateSfWithNewSubscriptionId(item).tapBoth(
-              e => Logging.error(s"Failed to update price rise record for ${item.subscriptionName}: $e"),
-              _ => Logging.info(s"Amendment of ${item.subscriptionName} recorded in Salesforce")
-            )
+      count <- CohortTable
+        .fetch(AmendmentComplete, None)
+        .take(batchSize)
+        .mapZIO(item =>
+          updateSfWithNewSubscriptionId(item).tapBoth(
+            e => Logging.error(s"Failed to update price rise record for ${item.subscriptionName}: $e"),
+            _ => Logging.info(s"Amendment of ${item.subscriptionName} recorded in Salesforce")
           )
-          .runCount
+        )
+        .runCount
     } yield HandlerOutput(isComplete = count < batchSize)
 
   private def updateSfWithNewSubscriptionId(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
@@ -11,8 +11,7 @@ object SalesforceNotificationDateUpdateHandler extends CohortHandler {
 
   val main: ZIO[Logging with CohortTable with SalesforceClient, Failure, HandlerOutput] =
     for {
-      cohortItems <- CohortTable.fetch(NotificationSendComplete, None)
-      _ <- cohortItems.foreach(updateDateLetterSentInSF)
+      _ <- CohortTable.fetch(NotificationSendComplete, None).foreach(updateDateLetterSentInSF)
     } yield HandlerOutput(isComplete = true)
 
   private def updateDateLetterSentInSF(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -12,8 +12,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
 
   private[handlers] val main: ZIO[Logging with CohortTable with SalesforceClient, Failure, HandlerOutput] =
     for {
-      cohortItems <- CohortTable.fetch(EstimationComplete, None)
-      count <- cohortItems.take(batchSize).mapZIO(createSalesforcePriceRise).runCount
+      count <- CohortTable.fetch(EstimationComplete, None).take(batchSize).mapZIO(createSalesforcePriceRise).runCount
     } yield HandlerOutput(isComplete = count < batchSize)
 
   private def createSalesforcePriceRise(

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -9,10 +9,11 @@ import zio.{IO, ZIO}
 case class CohortTableKey(subscriptionNumber: String)
 
 trait CohortTable {
+
   def fetch(
       filter: CohortTableFilter,
       beforeDateInclusive: Option[LocalDate]
-  ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
+  ): ZStream[Any, CohortFetchFailure, CohortItem]
 
   def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
 
@@ -26,8 +27,8 @@ object CohortTable {
   def fetch(
       filter: CohortTableFilter,
       beforeDateInclusive: Option[LocalDate]
-  ): ZIO[CohortTable, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
-    ZIO.environmentWithZIO(_.get.fetch(filter, beforeDateInclusive))
+  ): ZStream[CohortTable, CohortFetchFailure, CohortItem] =
+    ZStream.serviceWithStream(_.fetch(filter, beforeDateInclusive))
 
   def fetchAll(): ZIO[CohortTable, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
     ZIO.environmentWithZIO(_.get.fetchAll())

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -123,36 +123,32 @@ object CohortTableLive {
         override def fetch(
             filter: CohortTableFilter,
             latestStartDateInclusive: Option[LocalDate]
-        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
-          ZIO
-            .from {
-              val indexName =
-                latestStartDateInclusive
-                  .fold(ProcessingStageIndexName)(_ => ProcessingStageAndStartDateIndexName)
-              val queryRequest =
-                QueryRequest.builder
-                  .tableName(tableName)
-                  .indexName(indexName)
-                  .keyConditionExpression(
-                    "processingStage = :processingStage" + latestStartDateInclusive.fold("") { _ =>
-                      " AND startDate <= :latestStartDateInclusive"
-                    }
-                  )
-                  .expressionAttributeValues(
-                    List(
-                      Some(":processingStage" -> AttributeValue.builder.s(filter.value).build()),
-                      latestStartDateInclusive.map { latestStartDateInclusive =>
-                        ":latestStartDateInclusive" -> AttributeValue.builder
-                          .s(latestStartDateInclusive.toString)
-                          .build()
-                      }
-                    ).flatten.toMap.asJava
-                  )
-                  .limit(cohortTableConfig.batchSize)
-                  .build()
-              dynamoDbZio.query(queryRequest).mapError(error => CohortFetchFailure(error.toString))
-            }
-            .mapError(error => CohortFetchFailure(error.toString))
+        ): ZStream[Any, CohortFetchFailure, CohortItem] = {
+          val indexName =
+            latestStartDateInclusive
+              .fold(ProcessingStageIndexName)(_ => ProcessingStageAndStartDateIndexName)
+          val queryRequest =
+            QueryRequest.builder
+              .tableName(tableName)
+              .indexName(indexName)
+              .keyConditionExpression(
+                "processingStage = :processingStage" + latestStartDateInclusive.fold("") { _ =>
+                  " AND startDate <= :latestStartDateInclusive"
+                }
+              )
+              .expressionAttributeValues(
+                List(
+                  Some(":processingStage" -> AttributeValue.builder.s(filter.value).build()),
+                  latestStartDateInclusive.map { latestStartDateInclusive =>
+                    ":latestStartDateInclusive" -> AttributeValue.builder
+                      .s(latestStartDateInclusive.toString)
+                      .build()
+                  }
+                ).flatten.toMap.asJava
+              )
+              .limit(cohortTableConfig.batchSize)
+              .build()
+          dynamoDbZio.query(queryRequest).mapError(error => CohortFetchFailure(error.toString))
         }
 
         override def create(cohortItem: CohortItem): IO[Failure, Unit] = {

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -24,7 +24,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
         override def fetch(
             filter: CohortTableFilter,
             beforeDateInclusive: Option[LocalDate]
-        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
+        ): ZStream[Any, CohortFetchFailure, CohortItem] = ???
 
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -55,7 +55,7 @@ class NotificationHandlerTest extends munit.FunSuite {
         override def fetch(
             filter: CohortTableFilter,
             beforeDateInclusive: Option[LocalDate]
-        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
+        ): ZStream[Any, CohortFetchFailure, CohortItem] = {
           assertEquals(filter, SalesforcePriceRiceCreationComplete)
           assertEquals(
             beforeDateInclusive,
@@ -64,7 +64,7 @@ class NotificationHandlerTest extends munit.FunSuite {
                 .from(StubClock.expectedCurrentTime.plus(37, ChronoUnit.DAYS).atOffset(ZoneOffset.UTC))
             )
           )
-          ZIO.succeed(ZStream(cohortItem))
+          ZStream(cohortItem)
         }
 
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -26,9 +26,9 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
         override def fetch(
             filter: CohortTableFilter,
             beforeDateInclusive: Option[LocalDate]
-        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
+        ): ZStream[Any, CohortFetchFailure, CohortItem] = {
           assertEquals(filter, NotificationSendComplete)
-          ZIO.succeed(ZStream(cohortItem))
+          ZStream(cohortItem)
         }
 
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -33,9 +33,9 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
         override def fetch(
             filter: CohortTableFilter,
             beforeDateInclusive: Option[LocalDate]
-        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
+        ): ZStream[Any, CohortFetchFailure, CohortItem] = {
           assertEquals(filter, EstimationComplete)
-          ZIO.succeed(ZStream(cohortItem))
+          ZStream(cohortItem)
         }
 
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -24,7 +24,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
         override def fetch(
             filter: CohortTableFilter,
             beforeDateInclusive: Option[LocalDate]
-        ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
+        ): ZStream[Any, CohortFetchFailure, CohortItem] = ???
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
         override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] =

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -78,15 +78,14 @@ class CohortTableLiveTest extends munit.FunSuite {
     assertEquals(
       Runtime.default.unsafeRunSync(
         for {
-          result <-
-            CohortTable
-              .fetch(ReadyForEstimation, None)
-              .provideLayer(
-                stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging
-                  .impl("TestCohort") >>>
-                  CohortTableLive.impl(cohortSpec)
-              )
-          resultList <- result.run(ZSink.collectAll[CohortItem])
+          resultList <- CohortTable
+            .fetch(ReadyForEstimation, None)
+            .provideLayer(
+              stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl(
+                "TestCohort"
+              ) >>> CohortTableLive.impl(cohortSpec)
+            )
+            .run(ZSink.collectAll[CohortItem])
           _ = assertEquals(resultList, Chunk(item1, item2))
         } yield ()
       ),
@@ -178,15 +177,14 @@ class CohortTableLiveTest extends munit.FunSuite {
     assertEquals(
       Runtime.default.unsafeRunSync(
         for {
-          result <-
-            CohortTable
-              .fetch(ReadyForEstimation, Some(expectedLatestDate))
-              .provideLayer(
-                stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging
-                  .impl("TestCohort") >>>
-                  CohortTableLive.impl(cohortSpec)
-              )
-          resultList <- result.run(ZSink.collectAll[CohortItem])
+          resultList <- CohortTable
+            .fetch(ReadyForEstimation, Some(expectedLatestDate))
+            .provideLayer(
+              stubCohortTableConfiguration ++ stubStageConfiguration ++ stubDynamoDBZIO ++ ConsoleLogging.impl(
+                "TestCohort"
+              ) >>> CohortTableLive.impl(cohortSpec)
+            )
+            .run(ZSink.collectAll[CohortItem])
           _ = assertEquals(resultList, Chunk(item1))
         } yield ()
       ),

--- a/lambda/src/test/scala/pricemigrationengine/service/MockCohortTable.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/MockCohortTable.scala
@@ -10,31 +10,32 @@ import java.time.LocalDate
 
 object MockCohortTable extends Mock[CohortTable] {
 
-  object Fetch
-      extends Effect[
-        (CohortTableFilter, Option[LocalDate]),
-        CohortFetchFailure,
-        ZStream[Any, CohortFetchFailure, CohortItem]
-      ]
+  object Fetch extends Stream[(CohortTableFilter, Option[LocalDate]), CohortFetchFailure, CohortItem]
   object FetchAll extends Effect[Unit, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
   object Create extends Effect[CohortItem, Failure, Unit]
   object Update extends Effect[CohortItem, CohortUpdateFailure, Unit]
 
-  val compose: URLayer[Proxy, CohortTable] = ZLayer.fromZIO(ZIO.service[Proxy].map { proxy =>
-    new CohortTable {
+  val compose: URLayer[Proxy, CohortTable] = ZLayer.fromZIO(
+    ZIO.serviceWithZIO[Proxy](proxy =>
+      ZIO
+        .runtime[Any]
+        .map(runtime =>
+          new CohortTable {
 
-      override def fetch(filter: CohortTableFilter, beforeDateInclusive: Option[LocalDate])
-          : IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
-        proxy(Fetch, filter, beforeDateInclusive)
+            override def fetch(filter: CohortTableFilter, beforeDateInclusive: Option[LocalDate])
+                : ZStream[Any, CohortFetchFailure, CohortItem] =
+              runtime.unsafeRun(proxy(Fetch, filter, beforeDateInclusive))
 
-      override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
-        proxy(FetchAll, ())
+            override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
+              proxy(FetchAll, ())
 
-      override def create(cohortItem: CohortItem): IO[Failure, Unit] =
-        proxy(Create, cohortItem)
+            override def create(cohortItem: CohortItem): IO[Failure, Unit] =
+              proxy(Create, cohortItem)
 
-      override def update(result: CohortItem): IO[CohortUpdateFailure, Unit] =
-        proxy(Update, result)
-    }
-  })
+            override def update(result: CohortItem): IO[CohortUpdateFailure, Unit] =
+              proxy(Update, result)
+          }
+        )
+    )
+  )
 }


### PR DESCRIPTION
The `fetch` method of `CohortTable` has return type 
`IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]`, 
which seems unnecessarily convoluted.

This change flattens the type to `ZStream[Any, CohortFetchFailure, CohortItem]`.  
That's hopefully a lot easier to follow and simplifies the code where it's being created and used.
