### PR TITLE
Flatten type of CohortTable fetchAll

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -18,122 +18,100 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
   private val csvFormat = CSVFormat.Builder.create().setHeader("").setQuoteMode(ALL).build()
   private val TempFileDirectory = "/tmp/"
 
-  def main(
-      cohortSpec: CohortSpec
-  ): ZIO[Logging with CohortTable with S3 with ExportConfig, Failure, HandlerOutput] =
-    for {
-      config <- ZIO.service[ExportConfig]
-      records <- CohortTable.fetchAll()
-      s3Location = S3Location(
-        config.exportBucketName,
-        s"data/${cohortSpec.cohortName}.csv"
-      )
-      _ <- writeCsvToS3(records, s3Location, cohortSpec)
-    } yield HandlerOutput(isComplete = true)
-
-  def writeCsvToS3(
-      cohortItems: ZStream[Any, CohortFetchFailure, CohortItem],
-      s3Location: S3Location,
-      cohortSpec: CohortSpec
-  ): ZIO[S3 with Logging, Failure, Unit] =
+  private[handlers] def main(cohortSpec: CohortSpec) =
     ZIO.scoped(for {
+      config <- ZIO.service[ExportConfig]
+      records = CohortTable.fetchAll()
       filePath <- localTempFile()
       tempFileOutputStream <- openOutputStream(filePath)
-      recordsWritten <- writeCsvToStream(cohortItems, tempFileOutputStream, cohortSpec)
-
-      putResult <-
-        S3.putObject(s3Location, filePath.toFile, Some(ObjectCannedACL.BUCKET_OWNER_READ))
-          .mapError { failure =>
-            CohortTableDatalakeExportFailure(s"Failed to write CohortItems to s3: ${failure.reason}")
-          }
-
+      recordsWritten <- print(records, cohortSpec, tempFileOutputStream)
+      s3Location = S3Location(config.exportBucketName, s"data/${cohortSpec.cohortName}.csv")
+      putResult <- S3
+        .putObject(s3Location, filePath.toFile, Some(ObjectCannedACL.BUCKET_OWNER_READ))
+        .mapError(failure => CohortTableDatalakeExportFailure(s"Failed to write CohortItems to s3: ${failure.reason}"))
       _ <- Logging.info(
-        s"Successfully wrote cohort '${cohortSpec.cohortName}' containing $recordsWritten items " +
-          s"to $s3Location: $putResult"
+        s"Successfully wrote cohort '${cohortSpec.cohortName}' containing $recordsWritten items to $s3Location: $putResult"
       )
-    } yield ())
+    } yield HandlerOutput(isComplete = true))
 
-  def localTempFile(): ZIO[Scope, CohortTableDatalakeExportFailure, Path] =
+  private def localTempFile() =
     ZIO.acquireRelease(
       ZIO
         .attempt(Files.createTempFile(new File(TempFileDirectory).toPath, "CohortTableExport", "csv"))
-        .mapError { throwable =>
+        .mapError(throwable =>
           CohortTableDatalakeExportFailure(s"Failed to create temp file in $TempFileDirectory: ${throwable.getMessage}")
-        }
+        )
     )(path => ZIO.succeed(Try(Files.delete(path))))
 
-  def openOutputStream(path: Path): ZIO[Scope, CohortTableDatalakeExportFailure, OutputStream] =
-    ZIO.acquireRelease(
+  private def openOutputStream(path: Path) =
+    ZIO.fromAutoCloseable(
       ZIO
         .attempt(Files.newOutputStream(path))
-        .mapError { throwable =>
+        .mapError(throwable =>
           CohortTableDatalakeExportFailure(s"Failed to write to temp files $path: ${throwable.getMessage}")
-        }
-    )(stream => ZIO.succeed(stream.close()))
-
-  def writeCsvToStream(
-      cohortItems: ZStream[Any, Failure, CohortItem],
-      outputStream: OutputStream,
-      cohortSpec: CohortSpec
-  ): IO[Failure, Long] = {
-    ZIO.scoped(
-      managedCSVPrinter(
-        outputStream,
-        List(
-          "cohort_name",
-          "subscription_name",
-          "processing_stage",
-          "start_date",
-          "currency",
-          "old_price",
-          "estimated_new_price",
-          "billing_period",
-          "when_estimation_done",
-          "salesforce_price_rise_id",
-          "when_sf_show_estimate",
-          "new_price",
-          "new_subscription_id",
-          "when_amendment_done",
-          "when_notification_sent",
-          "when_notification_sent_written_to_salesforce",
-          "when_amendment_written_to_salesforce"
         )
-      ).flatMap { printer =>
-        cohortItems.mapZIO { cohortItem =>
-          ZIO
-            .attempt(
-              printer.printRecord(
-                cohortSpec.cohortName,
-                cohortItem.subscriptionName,
-                cohortItem.processingStage.value,
-                cohortItem.startDate.getOrElse(""),
-                cohortItem.currency.getOrElse(""),
-                cohortItem.oldPrice.getOrElse(""),
-                cohortItem.estimatedNewPrice.getOrElse(""),
-                cohortItem.billingPeriod.getOrElse(""),
-                cohortItem.whenEstimationDone.getOrElse(""),
-                cohortItem.salesforcePriceRiseId.getOrElse(""),
-                cohortItem.whenSfShowEstimate.getOrElse(""),
-                cohortItem.newPrice.getOrElse(""),
-                cohortItem.newSubscriptionId.getOrElse(""),
-                cohortItem.whenAmendmentDone.getOrElse(""),
-                cohortItem.whenNotificationSent.getOrElse(""),
-                cohortItem.whenNotificationSentWrittenToSalesforce.getOrElse(""),
-                cohortItem.whenAmendmentWrittenToSalesforce.getOrElse("")
-              )
-            )
-            .mapError { ex =>
-              CohortTableDatalakeExportFailure(s"Failed to write CohortItem as CSV to s3: ${ex.getMessage}")
-            }
-        }.runCount
-      }
     )
-  }
 
-  private def managedCSVPrinter(
-      outputStream: OutputStream,
-      headers: List[String]
-  ): ZIO[Scope, CohortTableDatalakeExportFailure, CSVPrinter] = {
+  private def print(
+      cohortStream: ZStream[CohortTable, CohortFetchFailure, CohortItem],
+      cohortSpec: CohortSpec,
+      outputStream: OutputStream
+  ) =
+    ZIO.scoped(for {
+      printer <- buildPrinter(outputStream)
+      count <- cohortStream.mapZIO(printItem(cohortSpec, printer)).runCount
+    } yield count)
+
+  private def printItem(cohortSpec: CohortSpec, printer: CSVPrinter)(cohortItem: CohortItem) =
+    ZIO
+      .attempt(
+        printer.printRecord(
+          cohortSpec.cohortName,
+          cohortItem.subscriptionName,
+          cohortItem.processingStage.value,
+          cohortItem.startDate.getOrElse(""),
+          cohortItem.currency.getOrElse(""),
+          cohortItem.oldPrice.getOrElse(""),
+          cohortItem.estimatedNewPrice.getOrElse(""),
+          cohortItem.billingPeriod.getOrElse(""),
+          cohortItem.whenEstimationDone.getOrElse(""),
+          cohortItem.salesforcePriceRiseId.getOrElse(""),
+          cohortItem.whenSfShowEstimate.getOrElse(""),
+          cohortItem.newPrice.getOrElse(""),
+          cohortItem.newSubscriptionId.getOrElse(""),
+          cohortItem.whenAmendmentDone.getOrElse(""),
+          cohortItem.whenNotificationSent.getOrElse(""),
+          cohortItem.whenNotificationSentWrittenToSalesforce.getOrElse(""),
+          cohortItem.whenAmendmentWrittenToSalesforce.getOrElse("")
+        )
+      )
+      .mapError(ex => CohortTableDatalakeExportFailure(s"Failed to write CohortItem as CSV to s3: ${ex.getMessage}"))
+
+  private def buildPrinter(outputStream: OutputStream) =
+    managedCSVPrinter(
+      outputStream,
+      List(
+        "cohort_name",
+        "subscription_name",
+        "processing_stage",
+        "start_date",
+        "currency",
+        "old_price",
+        "estimated_new_price",
+        "billing_period",
+        "when_estimation_done",
+        "salesforce_price_rise_id",
+        "when_sf_show_estimate",
+        "new_price",
+        "new_subscription_id",
+        "when_amendment_done",
+        "when_notification_sent",
+        "when_notification_sent_written_to_salesforce",
+        "when_amendment_written_to_salesforce"
+      )
+    )
+
+  private def managedCSVPrinter(outputStream: OutputStream, headers: List[String]) =
     ZIO
       .acquireRelease(
         ZIO.attempt(
@@ -146,7 +124,6 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
       .mapError { ex =>
         CohortTableDatalakeExportFailure(s"Failed to write CohortItems as CSV to s3: ${ex.getMessage}")
       }
-  }
 
   private def env(
       cohortSpec: CohortSpec

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -14,7 +14,7 @@ trait CohortTable {
       beforeDateInclusive: Option[LocalDate]
   ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
 
-  def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
+  def fetchAll(): ZStream[Any, CohortFetchFailure, CohortItem]
 
   def create(cohortItem: CohortItem): IO[Failure, Unit]
 
@@ -29,8 +29,8 @@ object CohortTable {
   ): ZIO[CohortTable, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
     ZIO.environmentWithZIO(_.get.fetch(filter, beforeDateInclusive))
 
-  def fetchAll(): ZIO[CohortTable, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
-    ZIO.environmentWithZIO(_.get.fetchAll())
+  def fetchAll(): ZStream[CohortTable, CohortFetchFailure, CohortItem] =
+    ZStream.serviceWithStream(_.fetchAll())
 
   def create(subscription: CohortItem): ZIO[CohortTable, Failure, Unit] =
     ZIO.environmentWithZIO(_.get.create(subscription))

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -175,19 +175,15 @@ object CohortTableLive {
             )
         }
 
-        override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
-          ZIO
-            .from {
-              val queryRequest = ScanRequest.builder
-                .tableName(tableName)
-                .limit(cohortTableConfig.batchSize)
-                .build()
-              for {
-                queryResults <- dynamoDbZio.scan(queryRequest).mapError(error => CohortFetchFailure(error.toString))
-              } yield queryResults
-            }
-            .mapError(error => CohortFetchFailure(error.toString))
-        }
+        override def fetchAll(): ZStream[Any, CohortFetchFailure, CohortItem] = {
+          val queryRequest = ScanRequest.builder
+            .tableName(tableName)
+            .limit(cohortTableConfig.batchSize)
+            .build()
+          for {
+            queryResults <- dynamoDbZio.scan(queryRequest).mapError(error => CohortFetchFailure(error.toString))
+          } yield queryResults
+        }.mapError(error => CohortFetchFailure(error.toString))
       }
     }
   }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -30,9 +30,8 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
 
-        override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = {
-          ZIO.succeed(ZStream.fromIterable(cohortItems))
-        }
+        override def fetchAll(): ZStream[Any, CohortFetchFailure, CohortItem] =
+          ZStream.fromIterable(cohortItems)
       }
     )
   }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -74,7 +74,7 @@ class NotificationHandlerTest extends munit.FunSuite {
           ZIO.succeed(())
         }
 
-        override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
+        override def fetchAll(): ZStream[Any, CohortFetchFailure, CohortItem] = ???
       }
     )
   }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -38,7 +38,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
           ZIO.succeed(())
         }
 
-        override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
+        override def fetchAll(): ZStream[Any, CohortFetchFailure, CohortItem] = ???
       }
     )
   }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -40,7 +40,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
 
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] = ???
 
-        override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
+        override def fetchAll(): ZStream[Any, CohortFetchFailure, CohortItem] = ???
 
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = {
           updatedResultsWrittenToCohortTable.addOne(result)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -26,7 +26,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
             beforeDateInclusive: Option[LocalDate]
         ): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
         override def update(result: CohortItem): ZIO[Any, CohortUpdateFailure, Unit] = ???
-        override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] = ???
+        override def fetchAll(): ZStream[Any, CohortFetchFailure, CohortItem] = ???
         override def create(cohortItem: CohortItem): ZIO[Any, Failure, Unit] =
           ZIO
             .attempt {

--- a/lambda/src/test/scala/pricemigrationengine/service/MockCohortTable.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/MockCohortTable.scala
@@ -16,25 +16,31 @@ object MockCohortTable extends Mock[CohortTable] {
         CohortFetchFailure,
         ZStream[Any, CohortFetchFailure, CohortItem]
       ]
-  object FetchAll extends Effect[Unit, CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]
+  object FetchAll extends Stream[Unit, CohortFetchFailure, CohortItem]
   object Create extends Effect[CohortItem, Failure, Unit]
   object Update extends Effect[CohortItem, CohortUpdateFailure, Unit]
 
-  val compose: URLayer[Proxy, CohortTable] = ZLayer.fromZIO(ZIO.service[Proxy].map { proxy =>
-    new CohortTable {
+  val compose: URLayer[Proxy, CohortTable] = ZLayer.fromZIO(
+    ZIO.serviceWithZIO[Proxy](proxy =>
+      ZIO
+        .runtime[Any]
+        .map(runtime =>
+          new CohortTable {
 
-      override def fetch(filter: CohortTableFilter, beforeDateInclusive: Option[LocalDate])
-          : IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
-        proxy(Fetch, filter, beforeDateInclusive)
+            override def fetch(filter: CohortTableFilter, beforeDateInclusive: Option[LocalDate])
+                : IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
+              proxy(Fetch, filter, beforeDateInclusive)
 
-      override def fetchAll(): IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]] =
-        proxy(FetchAll, ())
+            override def fetchAll(): ZStream[Any, CohortFetchFailure, CohortItem] =
+              runtime.unsafeRun(proxy(FetchAll, ()))
 
-      override def create(cohortItem: CohortItem): IO[Failure, Unit] =
-        proxy(Create, cohortItem)
+            override def create(cohortItem: CohortItem): IO[Failure, Unit] =
+              proxy(Create, cohortItem)
 
-      override def update(result: CohortItem): IO[CohortUpdateFailure, Unit] =
-        proxy(Update, result)
-    }
-  })
+            override def update(result: CohortItem): IO[CohortUpdateFailure, Unit] =
+              proxy(Update, result)
+          }
+        )
+    )
+  )
 }


### PR DESCRIPTION
Same as #588 but for `CohortTable.fetchAll`.

The `fetchAll` method of `CohortTable` has return type
`IO[CohortFetchFailure, ZStream[Any, CohortFetchFailure, CohortItem]]`,
which seems unnecessarily convoluted.

This change flattens the type to 
`ZStream[Any, CohortFetchFailure, CohortItem]`.
That's hopefully a lot easier to follow and simplifies the code where it's being created and used.
