### PR TITLE
Eliminate LiveLayer.exportConfig

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -2,6 +2,7 @@ package pricemigrationengine.handlers
 
 import org.apache.commons.csv.QuoteMode.ALL
 import org.apache.commons.csv.{CSVFormat, CSVPrinter}
+import pricemigrationengine.handlers.LiveLayer.dynamoDbClient
 import pricemigrationengine.model._
 import pricemigrationengine.services._
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
@@ -148,12 +149,14 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
       }
   }
 
-  private def env(
-      cohortSpec: CohortSpec
-  ): ZLayer[Logging, Failure, CohortTable with S3 with Logging with ExportConfig] =
-    (LiveLayer.cohortTable(cohortSpec) and LiveLayer.s3 and LiveLayer.logging and LiveLayer.exportConfig)
-      .tapError(e => Logging.error(s"Failed to create service environment: $e"))
-
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
-    main(input).provideSomeLayer[Logging](env(input))
+    main(input).provideSome[Logging](
+      EnvConfig.cohortTable.layer,
+      EnvConfig.stage.layer,
+      EnvConfig.export.layer,
+      DynamoDBClientLive.impl,
+      DynamoDBZIOLive.impl,
+      CohortTableLive.impl(input),
+      S3Live.impl
+    )
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/LiveLayer.scala
@@ -36,7 +36,4 @@ object LiveLayer {
 
   val s3: ZLayer[Logging, ConfigFailure, S3] =
     logging to S3Live.impl
-
-  val exportConfig: ZLayer[Any, ConfigFailure, ExportConfig] =
-    EnvConfig.export.layer
 }


### PR DESCRIPTION
This is the first step in eliminating the LiveLayer object as there's no longer any need for complex layer building in ZIO v2.

See https://zio.dev/next/howto/migrate/zio-2.x-migration-guide/#building-the-dependency-graph
