### PR TITLE
Retry subscription update on failure

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -185,18 +185,17 @@ object ZuoraLive {
         override def updateSubscription(
             subscription: ZuoraSubscription,
             update: ZuoraSubscriptionUpdate
-        ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId] = {
-          put[SubscriptionUpdateResponse](
-            path = s"subscriptions/${subscription.subscriptionNumber}",
-            body = write(update)
-          ).mapBoth(
-            e =>
-              ZuoraUpdateFailure(
-                s"Subscription ${subscription.subscriptionNumber} and update $update: ${e.reason}"
-              ),
-            response => response.subscriptionId
-          )
-        } <* logging.info(s"Updated subscription ${subscription.subscriptionNumber} with: $update")
+        ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId] =
+          retry(
+            put[SubscriptionUpdateResponse](
+              path = s"subscriptions/${subscription.subscriptionNumber}",
+              body = write(update)
+            ).mapBoth(
+              e =>
+                ZuoraUpdateFailure(s"Subscription ${subscription.subscriptionNumber} and update $update: ${e.reason}"),
+              response => response.subscriptionId
+            )
+          ) <* logging.info(s"Updated subscription ${subscription.subscriptionNumber} with: $update")
       }
     )
 }


### PR DESCRIPTION
This is in response to a timeout in the amendment step log:
> request for PUT ... returned error java.net.SocketTimeoutException: Read timed out

The read timeout threshold is 30 s, which seems adequate when the systems are working normally.

Solution is to wrap the request in a retry so that it makes 5 attempts backing off exponentially.
