### PR TITLE
Don't remove trailing commas

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,3 +4,5 @@ runner.dialect = scala213
 maxColumn = 120
 
 docstrings.wrap = no
+
+rewrite.trailingCommas.style = keep


### PR DESCRIPTION
If they've been added deliberately.

See https://scalameta.org/scalafmt/docs/configuration.html#trailing-commas-keep
