### PR TITLE
Add build number to logs

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/services/ConsoleLogging.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ConsoleLogging.scala
@@ -1,12 +1,17 @@
 package pricemigrationengine.services
 
+import build.BuildInfo.buildNumber
 import zio.{Console, UIO, ULayer, ZLayer}
 
 object ConsoleLogging {
 
   def impl(cohortName: String): ULayer[Logging] =
     ZLayer.succeed(new Logging {
-      override def info(s: String): UIO[Unit] = Console.printLine(s"cohortName: $cohortName, INFO: $s").orDie
-      override def error(s: String): UIO[Unit] = Console.printLine(s"cohortName: $cohortName, ERROR: $s").orDie
+
+      private val logPrefix = s"CohortName: $cohortName, BuildNumber: $buildNumber"
+
+      override def info(s: String): UIO[Unit] = Console.printLine(s"$logPrefix, INFO: $s").orDie
+
+      override def error(s: String): UIO[Unit] = Console.printLine(s"$logPrefix, ERROR: $s").orDie
     })
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/ConsoleLogging.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ConsoleLogging.scala
@@ -1,17 +1,12 @@
 package pricemigrationengine.services
 
-import build.BuildInfo.buildNumber
 import zio.{Console, UIO, ULayer, ZLayer}
 
 object ConsoleLogging {
 
   def impl(cohortName: String): ULayer[Logging] =
     ZLayer.succeed(new Logging {
-
-      private val logPrefix = s"CohortName: $cohortName, BuildNumber: $buildNumber"
-
-      override def info(s: String): UIO[Unit] = Console.printLine(s"$logPrefix, INFO: $s").orDie
-
-      override def error(s: String): UIO[Unit] = Console.printLine(s"$logPrefix, ERROR: $s").orDie
+      override def info(s: String): UIO[Unit] = Console.printLine(s"cohortName: $cohortName, INFO: $s").orDie
+      override def error(s: String): UIO[Unit] = Console.printLine(s"cohortName: $cohortName, ERROR: $s").orDie
     })
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/LambdaLogging.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/LambdaLogging.scala
@@ -1,17 +1,20 @@
 package pricemigrationengine.services
 
+import build.BuildInfo.buildNumber
 import com.amazonaws.services.lambda.runtime.{Context, LambdaLogger}
-import zio.{UIO, ULayer, ZIO, ZLayer}
 import upickle.default.{ReadWriter, macroRW, write}
+import zio.{UIO, ULayer, ZIO, ZLayer}
 
 object LambdaLogging {
   private case class InfoMessage(
       CohortName: String,
+      BuildNumber: String,
       INFO: String
   )
 
   private case class ErrorMessage(
       CohortName: String,
+      BuildNumber: String,
       ERROR: String
   )
 
@@ -23,9 +26,9 @@ object LambdaLogging {
       new Logging {
         val logger: LambdaLogger = context.getLogger
         override def info(s: String): UIO[Unit] =
-          ZIO.succeed(logger.log(write(InfoMessage(cohortName, s))))
+          ZIO.succeed(logger.log(write(InfoMessage(cohortName, buildNumber, s))))
         override def error(s: String): UIO[Unit] =
-          ZIO.succeed(logger.log(write(ErrorMessage(cohortName, s))))
+          ZIO.succeed(logger.log(write(ErrorMessage(cohortName, buildNumber, s))))
       }
     )
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/LambdaLogging.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/LambdaLogging.scala
@@ -7,14 +7,14 @@ import zio.{UIO, ULayer, ZIO, ZLayer}
 
 object LambdaLogging {
   private case class InfoMessage(
+      Build: String,
       CohortName: String,
-      BuildNumber: String,
       INFO: String
   )
 
   private case class ErrorMessage(
+      Build: String,
       CohortName: String,
-      BuildNumber: String,
       ERROR: String
   )
 
@@ -26,9 +26,9 @@ object LambdaLogging {
       new Logging {
         val logger: LambdaLogger = context.getLogger
         override def info(s: String): UIO[Unit] =
-          ZIO.succeed(logger.log(write(InfoMessage(cohortName, buildNumber, s))))
+          ZIO.succeed(logger.log(write(InfoMessage(buildNumber, cohortName, s))))
         override def error(s: String): UIO[Unit] =
-          ZIO.succeed(logger.log(write(ErrorMessage(cohortName, buildNumber, s))))
+          ZIO.succeed(logger.log(write(ErrorMessage(buildNumber, cohortName, s))))
       }
     )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")


### PR DESCRIPTION
When looking back through a log it's difficult to tell which build was deployed at the time.

If we include build numbers in the log, we can cross-refer changes and also tell if the version we think should be deployed actually is deployed.

The build number will be the Riffraff build number or "unknown" for an artefact deployed by other means or running locally.
