### PR TITLE
Bump ZIO to 2.0.0

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
@@ -3,6 +3,7 @@ package pricemigrationengine.handlers
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import pricemigrationengine.model.CohortSpec
 import pricemigrationengine.services._
+import pricemigrationengine.util.Runner.unsafeRun
 import zio.{Clock, Runtime, ZIO, ZIOAppArgs, ZIOAppDefault}
 
 /** Executes price migration for active cohorts.
@@ -32,7 +33,7 @@ object MigrationHandler extends ZIOAppDefault with RequestHandler[Unit, Unit] {
       )
 
   override def handleRequest(unused: Unit, context: Context): Unit =
-    Runtime.default.unsafeRun(
+    unsafeRun(Runtime.default)(
       migrateActiveCohorts
         .provide(
           LambdaLogging.impl(context, "MigrationHandler"),

--- a/lambda/src/main/scala/pricemigrationengine/util/Runner.scala
+++ b/lambda/src/main/scala/pricemigrationengine/util/Runner.scala
@@ -1,0 +1,12 @@
+package pricemigrationengine.util
+
+import zio._
+
+object Runner {
+
+  def unsafeRun[R, E, A](runtime: Runtime[R])(zio: ZIO[R, E, A]): A =
+    Unsafe.unsafe(implicit u => runtime.unsafe.run(zio).getOrThrowFiberFailure())
+
+  def unsafeRunSync[R, E, A](runtime: Runtime[R])(zio: ZIO[R, E, A]): Exit[E, A] =
+    Unsafe.unsafe(implicit u => runtime.unsafe.run(zio))
+}

--- a/lambda/src/test/scala/pricemigrationengine/TestLogging.scala
+++ b/lambda/src/test/scala/pricemigrationengine/TestLogging.scala
@@ -1,8 +1,7 @@
 package pricemigrationengine
 
 import pricemigrationengine.services.ConsoleLogging
-import zio.Console
 
 object TestLogging {
-  val logging = Console.live >>> ConsoleLogging.impl("TestCohort")
+  val logging = ConsoleLogging.impl("TestCohort")
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -4,6 +4,7 @@ import pricemigrationengine.TestLogging
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.services._
+import pricemigrationengine.util.Runner.unsafeRunSync
 import software.amazon.awssdk.services.s3.model.{ObjectCannedACL, PutObjectResponse}
 import zio.Exit.Success
 import zio.Runtime.default
@@ -91,7 +92,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
     val stubCohortTable = createStubCohortTable(List(cohortItem))
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         CohortTableDatalakeExportHandler
           .main(cohortSpec)
           .provideLayer(
@@ -126,7 +127,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
     val stubCohortTable = createStubCohortTable(List(cohortItem))
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         CohortTableDatalakeExportHandler
           .main(cohortSpec)
           .provideLayer(

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
@@ -12,7 +12,7 @@ import java.time._
 
 object EstimationHandlerSpec extends ZIOSpecDefault {
 
-  private val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 16, 10, 2), ZoneOffset.ofHours(0))
+  private val time = OffsetDateTime.of(LocalDateTime.of(2022, 5, 16, 10, 2), ZoneOffset.ofHours(0)).toInstant
 
   private val subscription = ZuoraSubscription(
     subscriptionNumber = "S1",
@@ -101,7 +101,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         oldPrice = Some(1.23),
         estimatedNewPrice = Some(2.45),
         billingPeriod = Some("Month"),
-        whenEstimationDone = Some(Instant.from(time))
+        whenEstimationDone = Some(time)
       )
       val expectedSubscriptionFetch = MockZuora.FetchSubscription(
         assertion = equalTo("S1"),
@@ -117,7 +117,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         result = unit
       )
       for {
-        _ <- TestClock.setDateTime(time)
+        _ <- TestClock.setTime(time)
         _ <- EstimationHandler
           .estimate(productCatalogue, earliestStartDate = LocalDate.of(2022, 5, 1))(cohortItemRead)
           .provide(expectedZuoraUse, expectedCohortTableUpdate)
@@ -166,14 +166,14 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         oldPrice = Some(1.23),
         estimatedNewPrice = Some(1.15),
         billingPeriod = Some("Month"),
-        whenEstimationDone = Some(Instant.from(time))
+        whenEstimationDone = Some(time)
       )
       val expectedCohortTableUpdate = MockCohortTable.Update(
         assertion = equalTo(cohortItemExpectedToWrite),
         result = unit
       )
       for {
-        _ <- TestClock.setDateTime(time)
+        _ <- TestClock.setTime(time)
         _ <- EstimationHandler
           .estimate(productCatalogue, earliestStartDate = LocalDate.of(2022, 5, 1))(cohortItemRead)
           .provide(expectedZuoraUse, expectedCohortTableUpdate)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -5,14 +5,15 @@ import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.model.membershipworkflow.EmailMessage
 import pricemigrationengine.services._
+import pricemigrationengine.util.Runner.unsafeRunSync
 import zio.Exit.Success
 import zio.Runtime.default
 import zio._
 import zio.stream.ZStream
 import zio.test.{TestClock, testEnvironment}
 
-import java.time.{Instant, LocalDate, ZoneOffset}
 import java.time.temporal.ChronoUnit
+import java.time.{Instant, LocalDate, ZoneOffset}
 import scala.collection.mutable.ArrayBuffer
 
 class NotificationHandlerTest extends munit.FunSuite {
@@ -194,9 +195,9 @@ class NotificationHandlerTest extends munit.FunSuite {
     val stubEmailSender = createStubEmailSender(sentMessages)
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         (for {
-          _ <- TestClock.setDateTime(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+          _ <- TestClock.setTime(expectedCurrentTime)
           program <- NotificationHandler.main(brazeCampaignName)
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
@@ -261,9 +262,9 @@ class NotificationHandlerTest extends munit.FunSuite {
     val stubEmailSender = createStubEmailSender(sentMessages)
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         (for {
-          _ <- TestClock.setDateTime(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+          _ <- TestClock.setTime(expectedCurrentTime)
           program <- NotificationHandler.main(brazeCampaignName)
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
@@ -295,9 +296,9 @@ class NotificationHandlerTest extends munit.FunSuite {
     val stubEmailSender = createStubEmailSender(sentMessages)
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         (for {
-          _ <- TestClock.setDateTime(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+          _ <- TestClock.setTime(expectedCurrentTime)
           program <- NotificationHandler.main(brazeCampaignName)
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
@@ -321,9 +322,9 @@ class NotificationHandlerTest extends munit.FunSuite {
     val stubEmailSender = createStubEmailSender(sentMessages)
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         (for {
-          _ <- TestClock.setDateTime(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+          _ <- TestClock.setTime(expectedCurrentTime)
           program <- NotificationHandler.main(brazeCampaignName)
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
@@ -343,9 +344,9 @@ class NotificationHandlerTest extends munit.FunSuite {
     val failingStubEmailSender = createFailingStubEmailSender()
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         (for {
-          _ <- TestClock.setDateTime(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+          _ <- TestClock.setTime(expectedCurrentTime)
           program <- NotificationHandler.main(brazeCampaignName)
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ failingStubEmailSender
@@ -374,9 +375,9 @@ class NotificationHandlerTest extends munit.FunSuite {
     val stubEmailSender = createStubEmailSender(sentMessages)
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         (for {
-          _ <- TestClock.setDateTime(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+          _ <- TestClock.setTime(expectedCurrentTime)
           program <- NotificationHandler.main(brazeCampaignName)
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -4,6 +4,7 @@ import pricemigrationengine.TestLogging
 import pricemigrationengine.model.CohortTableFilter.{NotificationSendComplete, NotificationSendDateWrittenToSalesforce}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
+import pricemigrationengine.util.Runner.unsafeRunSync
 import zio.Exit.Success
 import zio.Runtime.default
 import zio.stream.ZStream
@@ -90,9 +91,9 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
     val stubCohortTable = createStubCohortTable(updatedResultsWrittenToCohortTable, cohortItem)
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         (for {
-          _ <- TestClock.setDateTime(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+          _ <- TestClock.setTime(expectedCurrentTime)
           program <- SalesforceNotificationDateUpdateHandler.main
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -4,13 +4,14 @@ import pricemigrationengine.TestLogging
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiceCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
+import pricemigrationengine.util.Runner.unsafeRunSync
 import zio.Exit.Success
 import zio.Runtime.default
 import zio.stream.ZStream
 import zio.test.{TestClock, testEnvironment}
 import zio.{IO, ZIO, ZLayer}
 
-import java.time.{Instant, LocalDate, ZoneOffset}
+import java.time.{Instant, LocalDate}
 import scala.collection.mutable.ArrayBuffer
 
 class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
@@ -114,9 +115,9 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     val stubCohortTable = createStubCohortTable(updatedResultsWrittenToCohortTable, cohortItem)
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         (for {
-          _ <- TestClock.setDateTime(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+          _ <- TestClock.setTime(expectedCurrentTime)
           program <- SalesforcePriceRiseCreationHandler.main
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient
@@ -175,9 +176,9 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
       )
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         (for {
-          _ <- TestClock.setDateTime(expectedCurrentTime.atOffset(ZoneOffset.of("-08:00")))
+          _ <- TestClock.setTime(expectedCurrentTime)
           program <- SalesforcePriceRiseCreationHandler.main
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -3,6 +3,7 @@ package pricemigrationengine.handlers
 import pricemigrationengine.TestLogging
 import pricemigrationengine.model._
 import pricemigrationengine.services._
+import pricemigrationengine.util.Runner.unsafeRunSync
 import software.amazon.awssdk.services.s3.model.{ObjectCannedACL, PutObjectResponse}
 import zio.Exit.Success
 import zio.Runtime.default
@@ -64,7 +65,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
     })
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         SubscriptionIdUploadHandler
           .main(
             CohortSpec(

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -2,6 +2,7 @@ package pricemigrationengine.model
 
 import pricemigrationengine.model.CohortTableFilter.ReadyForEstimation
 import pricemigrationengine.services._
+import pricemigrationengine.util.Runner.unsafeRunSync
 import software.amazon.awssdk.services.dynamodb.model.AttributeAction.PUT
 import software.amazon.awssdk.services.dynamodb.model._
 import zio.Exit.Success
@@ -76,7 +77,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
 
     assertEquals(
-      Runtime.default.unsafeRunSync(
+      unsafeRunSync(Runtime.default)(
         for {
           resultList <- CohortTable
             .fetch(ReadyForEstimation, None)
@@ -100,7 +101,7 @@ class CohortTableLiveTest extends munit.FunSuite {
       Map(":processingStage" -> AttributeValue.builder.s("ReadyForEstimation").build()).asJava
     )
     assertEquals(
-      Runtime.default.unsafeRunSync(
+      unsafeRunSync(Runtime.default)(
         receivedDeserialiser.get.deserialise(
           Map(
             "subscriptionNumber" -> AttributeValue.builder.s(expectedSubscriptionId).build(),
@@ -175,7 +176,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
 
     assertEquals(
-      Runtime.default.unsafeRunSync(
+      unsafeRunSync(Runtime.default)(
         for {
           resultList <- CohortTable
             .fetch(ReadyForEstimation, Some(expectedLatestDate))
@@ -261,7 +262,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
 
     assertEquals(
-      Runtime.default.unsafeRunSync(
+      unsafeRunSync(Runtime.default)(
         CohortTable
           .update(cohortItem)
           .provideLayer(
@@ -436,7 +437,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     )
 
     assertEquals(
-      Runtime.default.unsafeRunSync(
+      unsafeRunSync(Runtime.default)(
         CohortTable
           .update(cohortItem)
           .provideLayer(
@@ -506,7 +507,7 @@ class CohortTableLiveTest extends munit.FunSuite {
     val cohortItem = CohortItem("Subscription-id", ReadyForEstimation)
 
     assertEquals(
-      Runtime.default.unsafeRunSync(
+      unsafeRunSync(Runtime.default)(
         CohortTable
           .create(cohortItem)
           .provideLayer(

--- a/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/DynamoDBZIOLiveTest.scala
@@ -2,6 +2,7 @@ package pricemigrationengine.model
 
 import pricemigrationengine.TestLogging
 import pricemigrationengine.services._
+import pricemigrationengine.util.Runner.unsafeRunSync
 import software.amazon.awssdk.services.dynamodb.model.AttributeAction.PUT
 import software.amazon.awssdk.services.dynamodb.model._
 import zio.Exit.Success
@@ -45,14 +46,14 @@ class DynamoDBZIOLiveTest extends munit.FunSuite {
       }
     )
 
-    default.unsafeRunSync(
+    unsafeRunSync(default)(
       DynamoDBZIO
         .query(queryRequest)
         .provideLayer((stubDynamoDBClient ++ TestLogging.logging) >>> DynamoDBZIOLive.impl)
     ) match {
       case Success(results) =>
         assertEquals(
-          default.unsafeRunSync(results.run(ZSink.collectAll[String])),
+          unsafeRunSync(default)(results.run(ZSink.collectAll[String])),
           Success(Chunk("id-1", "id-2", "id-3"))
         )
       case failure =>
@@ -105,7 +106,7 @@ class DynamoDBZIOLiveTest extends munit.FunSuite {
     )
 
     assertEquals(
-      default.unsafeRunSync(
+      unsafeRunSync(default)(
         DynamoDBZIO
           .update("a-table", "key", "value")
           .provideLayer((stubDynamoDBClient ++ TestLogging.logging) >>> DynamoDBZIOLive.impl)

--- a/lambda/src/test/scala/pricemigrationengine/service/MockCohortTable.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/MockCohortTable.scala
@@ -2,6 +2,7 @@ package pricemigrationengine.service
 
 import pricemigrationengine.model.{CohortFetchFailure, CohortItem, CohortTableFilter, CohortUpdateFailure, Failure}
 import pricemigrationengine.services.CohortTable
+import pricemigrationengine.util.Runner.unsafeRun
 import zio.mock.{Mock, Proxy}
 import zio.stream.ZStream
 import zio.{IO, URLayer, ZIO, ZLayer}
@@ -24,10 +25,10 @@ object MockCohortTable extends Mock[CohortTable] {
 
             override def fetch(filter: CohortTableFilter, beforeDateInclusive: Option[LocalDate])
                 : ZStream[Any, CohortFetchFailure, CohortItem] =
-              runtime.unsafeRun(proxy(Fetch, filter, beforeDateInclusive))
+              unsafeRun(runtime)(proxy(Fetch, filter, beforeDateInclusive))
 
             override def fetchAll(): ZStream[Any, CohortFetchFailure, CohortItem] =
-              runtime.unsafeRun(proxy(FetchAll, ()))
+              unsafeRun(runtime)(proxy(FetchAll, ()))
 
             override def create(cohortItem: CohortItem): IO[Failure, Unit] =
               proxy(Create, cohortItem)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  private val zioVersion = "2.0.0-RC6"
+  private val zioVersion = "2.0.0"
   private val awsSdkVersion = "2.17.221"
 
   lazy val awsDynamoDb = "software.amazon.awssdk" % "dynamodb" % awsSdkVersion
@@ -12,7 +12,7 @@ object Dependencies {
   lazy val zioStreams = "dev.zio" %% "zio-streams" % zioVersion
   lazy val zioTest = "dev.zio" %% "zio-test" % zioVersion
   lazy val zioTestSbt = "dev.zio" %% "zio-test-sbt" % zioVersion
-  lazy val zioMock = "dev.zio" %% "zio-mock" % "1.0.0-RC6"
+  lazy val zioMock = "dev.zio" %% "zio-mock" % "1.0.0-RC8"
   lazy val upickle = "com.lihaoyi" %% "upickle" % "2.0.0"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"


### PR DESCRIPTION
The main last minute change was how the runtime is called in a handler or test environment.
This has become more complicated.  I'm not sure why.  But I've enscapsulated the change in a new `Runner` object and updated all the calls to the runtime to use these references.

This PR also updates the zio-mock library as it's impossible to update either library (zio or zio-mock) independently.
