### PR TITLE
Add exception handling for billing periods we want to ignore

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/GuardianWeekly.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/GuardianWeekly.scala
@@ -17,8 +17,6 @@ object BillingPeriod extends Enumeration {
  */
 case class GuardianWeekly(productRatePlan: ZuoraProductRatePlan, chargePairs: Seq[RatePlanChargePair])
 object GuardianWeekly {
-  private val restOfWorldCountries = List("United States")
-
   // we need to know:
   // billingPeriod - monthly, quarterly, annually
   // Whether it should change to Domestic or ROW
@@ -35,6 +33,7 @@ object GuardianWeekly {
           case "Quarter" => "Quarterly"
           case "Month"   => "Monthly"
           case "Annual"  => "Annual"
+          case default => Left(AmendmentDataFailure(s"billingPeriod is $default for ratePlan"))
         }
 
       case None => Left(AmendmentDataFailure("billingPeriod is null for ratePlan"))

--- a/lambda/src/main/scala/pricemigrationengine/model/GuardianWeekly.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/GuardianWeekly.scala
@@ -33,7 +33,7 @@ object GuardianWeekly {
           case "Quarter" => "Quarterly"
           case "Month"   => "Monthly"
           case "Annual"  => "Annual"
-          case default => Left(AmendmentDataFailure(s"billingPeriod is $default for ratePlan"))
+          case default   => Left(AmendmentDataFailure(s"billingPeriod is $default for ratePlan"))
         }
 
       case None => Left(AmendmentDataFailure("billingPeriod is null for ratePlan"))


### PR DESCRIPTION
We are currently doing the price-rise for Guardian Weekly subscriptions. We only want to process monthly, quarterly and annual subscriptions. However, there are a few subs with different billing periods like '6 weeks' and '12 weeks' in the cohort. This makes sure any sub without monthly, quarterly or annual billing period is handled as a failure. We can then delete these failures from the dynamoDB after if we do not want to consider them for manual processing.