### PR TITLE
Add currency code as prefix of the payment amount

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -5,6 +5,7 @@ import pricemigrationengine.model._
 import pricemigrationengine.model.membershipworkflow._
 import pricemigrationengine.services._
 import zio.{Clock, ZIO}
+import com.gu.i18n
 
 object NotificationHandler extends CohortHandler {
 
@@ -52,6 +53,10 @@ object NotificationHandler extends CohortHandler {
     }
   }
 
+  def currencyISOtoSymbol(iso: String): ZIO[Any, Nothing, String] = {
+    ZIO.succeed(i18n.Currency.fromString(iso: String).map(_.identifier).getOrElse(""))
+  }
+
   def sendNotification(
       brazeCampaignName: String,
       cohortItem: CohortItem,
@@ -72,6 +77,9 @@ object NotificationHandler extends CohortHandler {
       startDate <- requiredField(cohortItem.startDate.map(_.toString()), "CohortItem.startDate")
       billingPeriod <- requiredField(cohortItem.billingPeriod, "CohortItem.billingPeriod")
       paymentFrequency <- paymentFrequency(billingPeriod)
+      currencyISOCode <- requiredField(cohortItem.currency, "CohortItem.currency")
+      currencySymbol <- currencyISOtoSymbol(currencyISOCode)
+      estimatedNewPriceWithCurrencySymbol = s"${currencySymbol}${estimatedNewPrice}"
 
       _ <- logMissingEmailAddress(cohortItem, contact)
 
@@ -95,7 +103,7 @@ object NotificationHandler extends CohortHandler {
                 billing_postal_code = postalCode,
                 billing_state = address.state,
                 billing_country = country,
-                payment_amount = estimatedNewPrice,
+                payment_amount = estimatedNewPriceWithCurrencySymbol,
                 next_payment_date = startDate,
                 payment_frequency = paymentFrequency,
                 subscription_id = cohortItem.subscriptionName,

--- a/lambda/src/main/scala/pricemigrationengine/util/Currency.scala
+++ b/lambda/src/main/scala/pricemigrationengine/util/Currency.scala
@@ -1,0 +1,214 @@
+package com.gu.i18n
+
+sealed trait Currency {
+  def prefix: Option[String] = None
+  def glyph: String
+  def identifier: String = prefix.getOrElse("") + glyph
+  def iso: String
+}
+
+case class OtherCurrency(iso: String, glyph: String) extends Currency
+
+object Currency {
+  val websiteSupportedCurrencies = List(
+    GBP,
+    USD,
+    AUD,
+    CAD,
+    EUR,
+    NZD,
+  )
+
+  val otherCurrencies = Map(
+    "SEK" -> "kr",
+    "CHF" -> "fr.",
+    "NOK" -> "kr",
+    "DKK" -> "kr.",
+    "AFN" -> "؋",
+    "ALL" -> "Lek",
+    "DZD" -> "د.ج",
+    "AOA" -> "is",
+    "XCD" -> "$",
+    "ARS" -> "$",
+    "AMD" -> "Դ",
+    "AWG" -> "ƒ",
+    "AZN" -> "₼",
+    "BSD" -> "$",
+    "BHD" -> "ب.د",
+    "BDT" -> "৳",
+    "BBD" -> "$",
+    "BYN" -> "p.",
+    "BZD" -> "$",
+    "BMD" -> "$",
+    "BTN" -> "",
+    "BOB" -> "Bs.",
+    "BOV" -> "Mvdol",
+    "BES" -> "$",
+    "BAM" -> "КМ",
+    "BWP" -> "P",
+    "BRL" -> "R$",
+    "BND" -> "$",
+    "BGN" -> "лв",
+    "BIF" -> "₣",
+    "CVE" -> "",
+    "KHR" -> "៛",
+    "KYD" -> "$",
+    "XAF" -> "₣",
+    "CLP" -> "$",
+    "CNY" -> "¥",
+    "COP" -> "$",
+    "KMF" -> "",
+    "CDF" -> "₣",
+    "CRC" -> "₡",
+    "HRK" -> "Kn",
+    "CUP" -> "",
+    "CZK" -> "Kč",
+    "DJF" -> "₣",
+    "DOP" -> "$",
+    "EGP" -> "£",
+    "ERN" -> "Nfk",
+    "ETB" -> "",
+    "FKP" -> "£",
+    "FJD" -> "$",
+    "XPF" -> "₣",
+    "GMD" -> "D",
+    "GEL" -> "ლ",
+    "GHS" -> "₵",
+    "GIP" -> "£",
+    "GTQ" -> "Q",
+    "GNF" -> "₣",
+    "GYD" -> "$",
+    "HTG" -> "G",
+    "HNL" -> "L",
+    "HKD" -> "$",
+    "HUF" -> "Ft",
+    "ISK" -> "Kr",
+    "INR" -> "₨",
+    "IDR" -> "Rp",
+    "IRR" -> "﷼",
+    "IQD" -> "ع.د",
+    "ILS" -> "₪",
+    "JMD" -> "$",
+    "JPY" -> "¥",
+    "JOD" -> "د.ا",
+    "KZT" -> "〒",
+    "KES" -> "Sh",
+    "KPW" -> "",
+    "KRW" -> "",
+    "KWD" -> "د.ك",
+    "KGS" -> "",
+    "LAK" -> "",
+    "LBP" -> "ل.ل",
+    "LSL" -> "L",
+    "LRD" -> "$",
+    "LYD" -> "ل.د",
+    "MOP" -> "P",
+    "MGA" -> "MK",
+    "MWK" -> "",
+    "MYR" -> "RM",
+    "MVR" -> "ރ",
+    "MRU" -> "UM",
+    "MUR" -> "₨",
+    "MXN" -> "$",
+    "MXV" -> "",
+    "MDL" -> "L",
+    "MNT" -> "₮",
+    "MAD" -> "د.م.",
+    "MZN" -> "MTn",
+    "MMK" -> "ကျပ်",
+    "NAD" -> "$",
+    "NPR" -> "₨",
+    "NIO" -> "C$",
+    "NGN" -> "₦",
+    "OMR" -> "",
+    "PKR" -> "₨",
+    "PAB" -> "B/.",
+    "PGK" -> "K",
+    "PYG" -> "₲",
+    "PEN" -> "S/.",
+    "PHP" -> "₱",
+    "PLN" -> "zł",
+    "QAR" -> "ر.ق",
+    "MKD" -> "",
+    "RON" -> "L",
+    "RUB" -> "",
+    "RWF" -> "₣",
+    "SHP" -> "£",
+    "WST" -> "",
+    "STN" -> "Db",
+    "SAR" -> "ر.س",
+    "RSD" -> "din",
+    "SCR" -> "",
+    "SLL" -> "Le",
+    "SGD" -> "",
+    "ANG" -> "",
+    "SBD" -> "$",
+    "SOS" -> "Sh",
+    "ZAR" -> "R",
+    "SSP" -> "",
+    "LKR" -> "Rs",
+    "SDG" -> "£",
+    "SRD" -> "$",
+    "SZL" -> "L",
+    "SYP" -> "",
+    "TWD" -> "NT$",
+    "TJS" -> "ЅМ",
+    "TZS" -> "Sh",
+    "THB" -> "฿",
+    "XOF" -> "",
+    "TOP" -> "T$",
+    "TTD" -> "$",
+    "TND" -> "د.ت",
+    "TRY" -> "",
+    "TMT" -> "m",
+    "UGX" -> "Sh",
+    "UAH" -> "₴",
+    "AED" -> "",
+    "UYU" -> "$",
+    "UZS" -> "",
+    "VUV" -> "Vt",
+    "VEF" -> "",
+    "VND" -> "₫",
+    "YER" -> "﷼",
+    "ZMW" -> "ZK",
+    "ZWL" -> "$",
+  )
+
+  def fromString(iso: String): Option[Currency] = {
+    websiteSupportedCurrencies
+      .find(_.iso == iso)
+      .orElse(
+        otherCurrencies.get(iso).map(glyph => OtherCurrency(iso, glyph)),
+      )
+  }
+
+  case object GBP extends Currency {
+    override def glyph: String = "£"
+    override def iso: String = "GBP"
+  }
+  case object USD extends Currency {
+    override def glyph: String = "$"
+    override def prefix: Option[String] = Some("US")
+    override def iso: String = "USD"
+  }
+  case object AUD extends Currency {
+    override def glyph: String = "$"
+    override def prefix: Option[String] = Some("AU")
+    override def iso: String = "AUD"
+  }
+  case object CAD extends Currency {
+    override def glyph: String = "$"
+    override def prefix: Option[String] = Some("CA")
+    override def iso: String = "CAD"
+  }
+  case object EUR extends Currency {
+    override def glyph: String = "€"
+    override def iso: String = "EUR"
+  }
+  case object NZD extends Currency {
+    override def glyph: String = "$"
+    override def prefix: Option[String] = Some("NZ")
+    override def iso: String = "NZD"
+  }
+
+}

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -24,6 +24,7 @@ class NotificationHandlerTest extends munit.FunSuite {
   private val expectedBillingPeriodInNotification = "Monthly"
   private val expectedOldPrice = BigDecimal(11.11)
   private val expectedEstimatedNewPrice = BigDecimal(22.22)
+  private val expectedEstimatedNewPriceWithCurrencySymbolPrefix = "£22.22"
   private val expectedSFSubscriptionId = "1234"
   private val expectedBuyerId = "buyer-1"
   private val expectedIdentityId = "buyer1-identity-id"
@@ -222,7 +223,7 @@ class NotificationHandlerTest extends munit.FunSuite {
     assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.last_name, expectedLastName)
     assertEquals(
       sentMessages(0).To.ContactAttributes.SubscriberAttributes.payment_amount,
-      expectedEstimatedNewPrice.toString()
+      expectedEstimatedNewPriceWithCurrencySymbolPrefix
     )
     assertEquals(
       sentMessages(0).To.ContactAttributes.SubscriberAttributes.next_payment_date,


### PR DESCRIPTION
Using the currency ISO code to symbol conversion found here ( https://github.com/guardian/support-frontend/blob/fc932544ff7730b9cec71e562a5f6ca12a08694c/support-internationalisation/src/main/scala/com/gu/i18n/Currency.scala ), we update the `payment_amount` field to be prefixed with the corresponding currency symbol.

  