### PR TITLE
start date in user friendly format

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -7,6 +7,9 @@ import pricemigrationengine.services._
 import zio.{Clock, ZIO}
 import com.gu.i18n
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 object NotificationHandler extends CohortHandler {
 
   val Successful = 1
@@ -57,6 +60,18 @@ object NotificationHandler extends CohortHandler {
     ZIO.succeed(i18n.Currency.fromString(iso: String).map(_.identifier).getOrElse(""))
   }
 
+  def dateStrToLocalDate(startDate: String): LocalDate = {
+    LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+  }
+
+  def emailUserFriendlyDateFormatter(startDate: LocalDate): String = {
+    startDate.format(DateTimeFormatter.ofPattern("d MMMM uuuu"));
+  }
+
+  def startDateConversion(startDate: String): String = {
+    emailUserFriendlyDateFormatter(dateStrToLocalDate(startDate: String))
+  }
+
   def sendNotification(
       brazeCampaignName: String,
       cohortItem: CohortItem,
@@ -104,7 +119,7 @@ object NotificationHandler extends CohortHandler {
                 billing_state = address.state,
                 billing_country = country,
                 payment_amount = estimatedNewPriceWithCurrencySymbol,
-                next_payment_date = startDate,
+                next_payment_date = startDateConversion(startDate),
                 payment_frequency = paymentFrequency,
                 subscription_id = cohortItem.subscriptionName,
                 product_type = sfSubscription.Product_Type__c.getOrElse("")

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.TestLogging
+import pricemigrationengine.{TestLogging, handlers}
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.model.membershipworkflow.EmailMessage
@@ -19,6 +19,7 @@ import scala.collection.mutable.ArrayBuffer
 class NotificationHandlerTest extends munit.FunSuite {
   private val expectedSubscriptionName = "Sub-0001"
   private val expectedStartDate = LocalDate.of(2020, 1, 1)
+  private val expectedStartDateUserFriendlyFormat = "1 January 2020"
   private val expectedCurrency = "GBP"
   private val expectedBillingPeriod = "Month"
   private val expectedBillingPeriodInNotification = "Monthly"
@@ -227,7 +228,7 @@ class NotificationHandlerTest extends munit.FunSuite {
     )
     assertEquals(
       sentMessages(0).To.ContactAttributes.SubscriberAttributes.next_payment_date,
-      expectedStartDate.toString
+      expectedStartDateUserFriendlyFormat
     )
     assertEquals(
       sentMessages(0).To.ContactAttributes.SubscriberAttributes.payment_frequency,


### PR DESCRIPTION
At the moment the start date is read from the database in standard ISO YYYY-MM-DD format and echoed as such in the letter. This can cause problems to users unfamiliar with that format (for instance US readers).

This change  introduce the `startDateConversion` function which takes such as string, for instance `2022-08-30` and returns the more friendly `30 August 2022`. The functions uses two helpers (instead of being written in one single self contained function) to allow the start date test data to carry on being defined as a LocalDate. 