### PR TITLE
Update spreadEarliestStartDate for less than one year old GW subscriptions

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.handlers
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.services._
-import zio.{IO, Random, ZIO}
+import zio.{Clock, IO, Random, ZIO}
 
 import java.time.LocalDate
 
@@ -88,7 +88,10 @@ object EstimationHandler extends CohortHandler {
 
     lazy val earliestStartDateForAMonthlySub =
       for {
-        randomFactor <- Random.nextIntBetween(12, 15)
+        yearAgo <- Clock.localDateTime.map(_.toLocalDate.minusYears(1))
+        randomFactor <-
+          if (subscription.termStartDate.isBefore(yearAgo)) Random.nextIntBetween(0, 3)
+          else Random.nextIntBetween(12, 15)
         actualEarliestStartDate = earliestStartDate.plusMonths(randomFactor)
       } yield actualEarliestStartDate
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -88,7 +88,7 @@ object EstimationHandler extends CohortHandler {
 
     lazy val earliestStartDateForAMonthlySub =
       for {
-        randomFactor <- Random.nextIntBetween(0, 3)
+        randomFactor <- Random.nextIntBetween(12, 15)
         actualEarliestStartDate = earliestStartDate.plusMonths(randomFactor)
       } yield actualEarliestStartDate
 


### PR DESCRIPTION
We have already estimated the GW subscriptions that were older than one year. When we did so, we spread the rate plan earliest date between now and in three months in the future. 

We are now going to estimate GW subscriptions that are less than a year old. We still want to spread the earliest date over three months, but we also want to avoid any such subscription to have an updated rate plan start date before their first year anniversary. Choosing a random number between 12 and 15 ensure that all subscriptions are at least 12 months old and spreads the increase over 3 months as before. 

Thanks @kelvin-chappell for the amendment :)


