### PR TITLE
Use customerAcceptanceDate in spreadEarliestStartDate

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -90,7 +90,7 @@ object EstimationHandler extends CohortHandler {
       for {
         yearAgo <- Clock.localDateTime.map(_.toLocalDate.minusYears(1))
         randomFactor <-
-          if (subscription.termStartDate.isBefore(yearAgo)) Random.nextIntBetween(0, 3)
+          if (subscription.customerAcceptanceDate.isBefore(yearAgo)) Random.nextIntBetween(0, 3)
           else Random.nextIntBetween(12, 15)
         actualEarliestStartDate = earliestStartDate.plusMonths(randomFactor)
       } yield actualEarliestStartDate


### PR DESCRIPTION
This PR is a follow up of https://github.com/guardian/price-migration-engine/pull/698 . We incorporates the suggestion of using ~contractAcceptanceDate~ customerAcceptanceDate instead of `termStartDate` for in in spreadEarliestStartDate.