### PR TITLE
Update billing-preview call look ahead

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -71,7 +71,7 @@ object EstimationHandler extends CohortHandler {
           .fetchSubscription(item.subscriptionName)
           .filterOrFail(_.status != "Cancelled")(CancelledSubscriptionFailure(item.subscriptionName))
       account <- Zuora.fetchAccount(subscription.accountNumber, subscription.subscriptionNumber)
-      invoicePreviewTargetDate = earliestStartDate.plusMonths(13)
+      invoicePreviewTargetDate = earliestStartDate.plusMonths(16)
       invoicePreview <- Zuora.fetchInvoicePreview(subscription.accountId, invoicePreviewTargetDate)
       earliestStartDate <- spreadEarliestStartDate(subscription, invoicePreview, earliestStartDate)
       result <- ZIO.fromEither(EstimationResult(account, catalogue, subscription, invoicePreview, earliestStartDate))

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
@@ -134,6 +134,18 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         serviceStartDate = LocalDate.of(2023, 7, 1),
         chargeNumber = "C4",
         productName = "P1"
+      ),
+      ZuoraInvoiceItem(
+        subscriptionNumber = "S1",
+        serviceStartDate = LocalDate.of(2023, 8, 1),
+        chargeNumber = "C2",
+        productName = "P1"
+      ),
+      ZuoraInvoiceItem(
+        subscriptionNumber = "S1",
+        serviceStartDate = LocalDate.of(2023, 9, 1),
+        chargeNumber = "C1",
+        productName = "P1"
       )
     )
   )
@@ -190,7 +202,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         result = value(account)
       )
       val expectedInvoiceFetch = MockZuora.FetchInvoicePreview(
-        assertion = equalTo("A11", LocalDate.of(2023, 6, 1)),
+        assertion = equalTo("A11", LocalDate.of(2023, 9, 1)),
         result = value(invoicePreview)
       )
       val expectedZuoraUse = expectedSubscriptionFetch and expectedInvoiceFetch and expectedAccountToFetch
@@ -245,7 +257,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         result = value(account)
       )
       val expectedInvoiceFetch = MockZuora.FetchInvoicePreview(
-        assertion = equalTo("A11", LocalDate.of(2023, 6, 1)),
+        assertion = equalTo("A11", LocalDate.of(2023, 9, 1)),
         result = value(invoicePreview)
       )
       val expectedZuoraUse = expectedSubscriptionFetch and expectedInvoiceFetch and expectedAccountToFetch
@@ -310,7 +322,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         result = value(account)
       )
       val expectedInvoiceFetch = MockZuora.FetchInvoicePreview(
-        assertion = equalTo("A11", LocalDate.of(2023, 6, 1)),
+        assertion = equalTo("A11", LocalDate.of(2023, 9, 1)),
         result = value(invoicePreview)
       )
       val expectedZuoraUse = expectedSubscriptionFetch and expectedInvoiceFetch and expectedAccountToFetch


### PR DESCRIPTION
  This is to accomodate this PR: https://github.com/guardian/price-migration-engine/pull/698