### PR TITLE
All monthly subscriptions less than one year old to be risen on their 13th month

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -95,7 +95,12 @@ object EstimationHandler extends CohortHandler {
         yearAgo <- Clock.localDateTime.map(_.toLocalDate.minusYears(1))
         randomFactor <-
           if (subscription.customerAcceptanceDate.isBefore(yearAgo)) Random.nextIntBetween(0, 3)
-          else ZIO.succeed(relu(ChronoUnit.MONTHS.between(earliestStartDate, subscription.customerAcceptanceDate.plusMonths(13)).toInt))
+          else
+            ZIO.succeed(
+              relu(
+                ChronoUnit.MONTHS.between(earliestStartDate, subscription.customerAcceptanceDate.plusMonths(13)).toInt
+              )
+            )
         actualEarliestStartDate = earliestStartDate.plusMonths(randomFactor)
       } yield actualEarliestStartDate
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.handlers
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.services._
-import zio.{Clock, IO, Random, ZIO}
+import zio.{Clock, UIO, IO, Random, ZIO}
 
 import java.time.LocalDate
 import java.time.temporal._
@@ -90,17 +90,24 @@ object EstimationHandler extends CohortHandler {
     def relu(number: Int): Int =
       if (number < 0) 0 else number
 
+    /*
+      Any subscription less than one year old (i.e.: purchased within the last year), should only be risen at least one year after purchase, hence we raise them on the thirteenth month.
+     */
+    def startOnThirteenthMonth: UIO[Int] = {
+      ZIO.succeed(
+        relu(
+          ChronoUnit.MONTHS.between(earliestStartDate, subscription.customerAcceptanceDate.plusMonths(13)).toInt
+        )
+      )
+    }
+
     lazy val earliestStartDateForAMonthlySub =
       for {
         yearAgo <- Clock.localDateTime.map(_.toLocalDate.minusYears(1))
         randomFactor <-
           if (subscription.customerAcceptanceDate.isBefore(yearAgo)) Random.nextIntBetween(0, 3)
           else
-            ZIO.succeed(
-              relu(
-                ChronoUnit.MONTHS.between(earliestStartDate, subscription.customerAcceptanceDate.plusMonths(13)).toInt
-              )
-            )
+            startOnThirteenthMonth
         actualEarliestStartDate = earliestStartDate.plusMonths(randomFactor)
       } yield actualEarliestStartDate
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
@@ -2,7 +2,12 @@ package pricemigrationengine.handlers
 
 import pricemigrationengine.Fixtures.{invoiceListFromJson, subscriptionFromJson}
 import pricemigrationengine.handlers.EstimationHandler.spreadEarliestStartDate
-import pricemigrationengine.model.CohortTableFilter.{CappedPriceIncrease, EstimationComplete, NoPriceIncrease, ReadyForEstimation}
+import pricemigrationengine.model.CohortTableFilter.{
+  CappedPriceIncrease,
+  EstimationComplete,
+  NoPriceIncrease,
+  ReadyForEstimation
+}
 import pricemigrationengine.model._
 import pricemigrationengine.service.{MockCohortTable, MockZuora}
 import zio._
@@ -150,9 +155,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
   private val migrationStartDate2022 = LocalDate.of(2022, 11, 14)
   private val testTime1 = OffsetDateTime.of(LocalDateTime.of(2022, 7, 10, 10, 2), ZoneOffset.ofHours(0)).toInstant
 
-
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("estimate")(
-
     test("Start date is correct for subscription less than one year old (1)") {
       val invoiceList = invoiceListFromJson("NewspaperDelivery/Sixday+/InvoicePreview.json")
       val subscription = subscriptionFromJson("NewspaperDelivery/Sixday+/Subscription.json")
@@ -163,7 +166,6 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         startDate <- spreadEarliestStartDate(subscription, invoiceList, migrationStartDate2022)
       } yield assert(startDate)(equalTo(expectedStartDate))
     },
-
     test("Start date is correct for subscription less than one year old (2)") {
       val invoiceList = invoiceListFromJson("NewspaperDelivery/Waitrose25%Discount/InvoicePreview.json")
       val subscription = subscriptionFromJson("NewspaperDelivery/Waitrose25%Discount/Subscription.json")
@@ -174,7 +176,6 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         startDate <- spreadEarliestStartDate(subscription, invoiceList, migrationStartDate2022)
       } yield assert(startDate)(equalTo(expectedStartDate))
     },
-
     test("Start date is correct for subscription less than one year old (3)") {
       val invoiceList = invoiceListFromJson("NewspaperDelivery/Everyday/InvoicePreview.json")
       val subscription = subscriptionFromJson("NewspaperDelivery/Everyday/Subscription.json")
@@ -185,7 +186,6 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         startDate <- spreadEarliestStartDate(subscription, invoiceList, migrationStartDate2022)
       } yield assert(startDate)(equalTo(expectedStartDate))
     },
-
     test("updates cohort table with EstimationComplete when data is complete") {
       val productCatalogue = ZuoraProductCatalogue(products =
         Set(

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
@@ -1,18 +1,21 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.Fixtures
+import pricemigrationengine.handlers.EstimationHandlerSpec.testTime1
 import zio.test._
 
-import java.time.LocalDate
+import java.time.{LocalDate, LocalDateTime, OffsetDateTime, ZoneOffset}
 
 object EstimationHandlerTest extends ZIOSpecDefault {
 
   private val absoluteEarliestStartDate = LocalDate.of(2020, 6, 2)
+  private val testTime1 = OffsetDateTime.of(LocalDateTime.of(2022, 7, 10, 10, 2), ZoneOffset.ofHours(0)).toInstant
 
   override def spec: Spec[TestEnvironment, Any] =
     suite("spreadEarliestStartDate")(
       test("gives default value for a quarterly subscription") {
         for {
+          _ <- TestClock.setTime(testTime1)
           _ <- TestRandom.feedInts(1)
           earliestStartDate <- EstimationHandler.spreadEarliestStartDate(
             subscription = Fixtures.subscriptionFromJson("NewspaperVoucher/QuarterlyVoucher/Subscription.json"),
@@ -23,6 +26,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
       },
       test("gives randomised value for a monthly subscription") {
         for {
+          _ <- TestClock.setTime(testTime1)
           _ <- TestRandom.feedInts(1)
           earliestStartDate <- EstimationHandler.spreadEarliestStartDate(
             subscription = Fixtures.subscriptionFromJson("NewspaperVoucher/Monthly/Subscription.json"),


### PR DESCRIPTION
  This is to fix the generation of start dates of subscriptions less than one year old introduced in [this PR](https://github.com/guardian/price-migration-engine/pull/698)

With the old code, when running a test cohort of GW subscriptions, we get the next billing date for a subscription and add between 12 and 15 months onto it to obtain the startDate. This means all start dates are around the start of 2024 (this is wrong):

<img width="927" alt="Screenshot 2022-09-20 at 16 15 15" src="https://user-images.githubusercontent.com/91546670/191298717-f0897b09-4703-42a2-b748-cc55c46eaaee.png">

To be clear, any subscription that is less than one year old, must be price-risen as soon as their first year is over, i.e.: on the 13th month.    @paulbrown1982 mentioned this before but now only that I have run some subscriptions through the estimation process I've been able to visualise what the resulting start dates would be.

Tests have been provided for this.