### PR TITLE
Upgrade to scala 2.13.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbt.Keys.{description, name}
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / scalaVersion := "2.13.10"
 
 ThisBuild / scalacOptions ++= Seq(
   "-deprecation",


### PR DESCRIPTION
This upgrade the version of Scala we are using from 2.13.8 to [2.13.10](https://github.com/scala/scala/releases/tag/v2.13.10). (This will keep us clear from https://www.cve.org/CVERecord?id=CVE-2022-36944).