### PR TITLE
Better AmendmentDataFailure error message

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
@@ -76,7 +76,7 @@ object ZuoraSubscriptionUpdate {
     } yield ratePlan).distinct
 
     if (ratePlans.isEmpty)
-      Left(AmendmentDataFailure("No rate plans to update"))
+      Left(AmendmentDataFailure(s"No rate plans to update for subscription ${subscription.subscriptionNumber}"))
     else if (ratePlans.size > 1)
       Left(AmendmentDataFailure(s"Multiple rate plans to update: ${ratePlans.map(_.id)}"))
     else {


### PR DESCRIPTION
Add the subscription number to the AmendmentDataFailure's message when no rate plans could be found, to help with investigations. 