### PR TITLE
Remove requirement for address.postalCode in the NotificationHandler

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -117,7 +117,7 @@ object NotificationHandler extends CohortHandler {
       lastName <- requiredField(contact.LastName, "Contact.LastName")
       address <- targetAddress(contact)
       street <- requiredField(address.street, "Contact.OtherAddress.street")
-      postalCode <- requiredField(address.postalCode, "Contact.OtherAddress.postalCode")
+      postalCode = address.postalCode.getOrElse("")
       country <- requiredField(address.country, "Contact.OtherAddress.country")
       estimatedNewPrice <- requiredField(cohortItem.estimatedNewPrice.map(_.toString()), "CohortItem.estimatedNewPrice")
       startDate <- requiredField(cohortItem.startDate.map(_.toString()), "CohortItem.startDate")


### PR DESCRIPTION
### What
We remove the requirement for a post code in the address of a customer about to be notified.

### Why
Turns out that not all addresses (notably outside the UK) have a post code. That requirement was preventing some subscriptions from being correctly process by the Notification Handler. 

( Interestingly we have had this problem for a long time, but those subscriptions were silently sitting in `SalesforcePriceRiseCreationComplete` stage, and now there comes a point where they become close to their `startDate` and hit the check introduced by this change https://github.com/guardian/price-migration-engine/pull/747 )