### PR TITLE
Reimplement price capping

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -109,7 +109,7 @@ object AmendmentHandler extends CohortHandler {
           )
         )
 
-      _ <- checkNewPrice(item, oldPrice, newPrice)
+      _ <- ZIO.fromEither(checkNewPrice(item, oldPrice, newPrice))
 
       whenDone <- Clock.instant
     } yield SuccessfulAmendmentResult(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -47,16 +47,15 @@ object AmendmentHandler extends CohortHandler {
       item: CohortItem,
       oldPrice: BigDecimal,
       newPrice: BigDecimal
-  ): ZIO[Any, AmendmentDataFailure, Unit] = {
+  ): Either[AmendmentDataFailure, Unit] = 
     if (newPrice > PriceCapper.cappedPrice(oldPrice, newPrice)) {
-      ZIO.succeed(())
+      Right(())
     } else
-      ZIO.fail(
+      Left(
         AmendmentDataFailure(
           s"Cohort item: ${item.subscriptionName}. The new price ${newPrice} after amendment is higher than the old price ${oldPrice} + 20%"
         )
-      )
-  }
+      )  
 
   private def doAmendment(
       catalogue: ZuoraProductCatalogue,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -47,15 +47,15 @@ object AmendmentHandler extends CohortHandler {
       item: CohortItem,
       oldPrice: BigDecimal,
       newPrice: BigDecimal
-  ): Either[AmendmentDataFailure, Unit] = 
-    if (newPrice > PriceCapper.cappedPrice(oldPrice, newPrice)) {
+  ): Either[AmendmentDataFailure, Unit] =
+    if (newPrice <= PriceCapper.cappedPrice(oldPrice, newPrice)) {
       Right(())
     } else
       Left(
         AmendmentDataFailure(
           s"Cohort item: ${item.subscriptionName}. The new price ${newPrice} after amendment is higher than the old price ${oldPrice} + 20%"
         )
-      )  
+      )
 
   private def doAmendment(
       catalogue: ZuoraProductCatalogue,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -18,7 +18,6 @@ object EstimationHandler extends CohortHandler {
 
   // TODO: move to config
   private val batchSize = 150
-  private val priceCappingMultiplier = 1.2
 
   def main(earliestStartDate: LocalDate): ZIO[Logging with CohortTable with Zuora, Failure, HandlerOutput] =
     for {

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -103,10 +103,6 @@ object NotificationHandler extends CohortHandler {
     emailUserFriendlyDateFormatter(dateStrToLocalDate(startDate: String))
   }
 
-  def cappedNewPrice(oldPrice: BigDecimal, newPrice: BigDecimal): BigDecimal = {
-    List(oldPrice * 1.2, newPrice).min
-  }
-
   def sendNotification(
       brazeCampaignName: String,
       cohortItem: CohortItem,
@@ -130,7 +126,7 @@ object NotificationHandler extends CohortHandler {
       paymentFrequency <- paymentFrequency(billingPeriod)
       currencyISOCode <- requiredField(cohortItem.currency, "CohortItem.currency")
       currencySymbol <- currencyISOtoSymbol(currencyISOCode)
-      cappedEstimatedNewPriceWithCurrencySymbol = s"${currencySymbol}${cappedNewPrice(oldPrice, estimatedNewPrice)}"
+      cappedEstimatedNewPriceWithCurrencySymbol = s"${currencySymbol}${PriceCapper.cappedPrice(oldPrice, estimatedNewPrice)}"
 
       _ <- logMissingEmailAddress(cohortItem, contact)
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -103,6 +103,10 @@ object NotificationHandler extends CohortHandler {
     emailUserFriendlyDateFormatter(dateStrToLocalDate(startDate: String))
   }
 
+  def cappedNewPrice(oldPrice: BigDecimal, newPrice: BigDecimal): BigDecimal = {
+    List(oldPrice * 1.2, newPrice).min
+  }
+
   def sendNotification(
       brazeCampaignName: String,
       cohortItem: CohortItem,
@@ -119,13 +123,14 @@ object NotificationHandler extends CohortHandler {
       street <- requiredField(address.street, "Contact.OtherAddress.street")
       postalCode = address.postalCode.getOrElse("")
       country <- requiredField(address.country, "Contact.OtherAddress.country")
-      estimatedNewPrice <- requiredField(cohortItem.estimatedNewPrice.map(_.toString()), "CohortItem.estimatedNewPrice")
+      oldPrice <- requiredField(cohortItem.oldPrice, "CohortItem.oldPrice")
+      estimatedNewPrice <- requiredField(cohortItem.estimatedNewPrice, "CohortItem.estimatedNewPrice")
       startDate <- requiredField(cohortItem.startDate.map(_.toString()), "CohortItem.startDate")
       billingPeriod <- requiredField(cohortItem.billingPeriod, "CohortItem.billingPeriod")
       paymentFrequency <- paymentFrequency(billingPeriod)
       currencyISOCode <- requiredField(cohortItem.currency, "CohortItem.currency")
       currencySymbol <- currencyISOtoSymbol(currencyISOCode)
-      estimatedNewPriceWithCurrencySymbol = s"${currencySymbol}${estimatedNewPrice}"
+      cappedEstimatedNewPriceWithCurrencySymbol = s"${currencySymbol}${cappedNewPrice(oldPrice, estimatedNewPrice)}"
 
       _ <- logMissingEmailAddress(cohortItem, contact)
 
@@ -149,7 +154,7 @@ object NotificationHandler extends CohortHandler {
                 billing_postal_code = postalCode,
                 billing_state = address.state,
                 billing_country = country,
-                payment_amount = estimatedNewPriceWithCurrencySymbol,
+                payment_amount = cappedEstimatedNewPriceWithCurrencySymbol,
                 next_payment_date = startDateConversion(startDate),
                 payment_frequency = paymentFrequency,
                 subscription_id = cohortItem.subscriptionName,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -63,10 +63,11 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
         ZIO
           .fromOption(cohortItem.oldPrice)
           .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have an oldPrice"))
-      newPrice <-
+      newPriceNonCapped <-
         ZIO
           .fromOption(cohortItem.estimatedNewPrice)
           .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have an estimatedNewPrice"))
+      newPriceCapped = List(newPriceNonCapped, currentPrice * 1.2).min
       priceRiseDate <-
         ZIO
           .fromOption(cohortItem.startDate)
@@ -75,7 +76,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
       Some(subscription.Name),
       Some(subscription.Buyer__c),
       Some(currentPrice),
-      Some(newPrice),
+      Some(newPriceCapped),
       Some(priceRiseDate),
       Some(subscription.Id)
     )

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -280,3 +280,23 @@ object AmendmentData {
     "Annual" -> 12
   )
 }
+
+object PriceCapper {
+
+  /*
+    This object implements the policy of not increasing subscription prices, and
+    therefore what our customers pay, by more then 20% during a single price rise.
+   */
+
+  private val priceCappingMultiplier = 1.2 // old price + 25%
+  def cappedPrice(oldPrice: BigDecimal, estimatedNewPrice: BigDecimal): BigDecimal =
+    List(estimatedNewPrice, oldPrice * priceCappingMultiplier).min
+
+  def priceCorrectionFactor(oldPrice: BigDecimal, estimatedNewPrice: BigDecimal): BigDecimal = {
+    if (estimatedNewPrice == 0 || estimatedNewPrice < oldPrice * priceCappingMultiplier) {
+      1
+    } else {
+      (oldPrice * priceCappingMultiplier) / estimatedNewPrice
+    }
+  }
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -293,7 +293,7 @@ object PriceCapper {
     List(estimatedNewPrice, oldPrice * priceCappingMultiplier).min
 
   def priceCorrectionFactor(oldPrice: BigDecimal, estimatedNewPrice: BigDecimal): BigDecimal = {
-    if (estimatedNewPrice == 0 || estimatedNewPrice < oldPrice * priceCappingMultiplier) {
+    if (estimatedNewPrice == 0 || estimatedNewPrice.compareTo(oldPrice * priceCappingMultiplier) <= 0) {
       1
     } else {
       (oldPrice * priceCappingMultiplier) / estimatedNewPrice

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -288,7 +288,7 @@ object PriceCapper {
     therefore what our customers pay, by more then 20% during a single price rise.
    */
 
-  private val priceCappingMultiplier = 1.2 // old price + 25%
+  private val priceCappingMultiplier = 1.2 // old price + 20%
   def cappedPrice(oldPrice: BigDecimal, estimatedNewPrice: BigDecimal): BigDecimal =
     List(estimatedNewPrice, oldPrice * priceCappingMultiplier).min
 

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -1,7 +1,5 @@
 package pricemigrationengine.model
 
-import pricemigrationengine.model.ChargeCap.ChargeCapBuilderFromMultiplier
-
 import java.time.LocalDate
 
 trait EstimationResult
@@ -16,25 +14,22 @@ case class SuccessfulEstimationResult(
 ) extends EstimationResult
 
 object EstimationResult {
-
   def apply(
       account: ZuoraAccount,
       catalogue: ZuoraProductCatalogue,
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,
       earliestStartDate: LocalDate,
-      chargeCapBuilderOpt: Option[ChargeCapBuilderFromMultiplier]
   ): Either[AmendmentDataFailure, SuccessfulEstimationResult] =
-    AmendmentData(account, catalogue, subscription, invoiceList, earliestStartDate, chargeCapBuilderOpt) map {
-      amendmentData =>
-        SuccessfulEstimationResult(
-          subscription.subscriptionNumber,
-          amendmentData.startDate,
-          amendmentData.priceData.currency,
-          amendmentData.priceData.oldPrice,
-          amendmentData.priceData.newPrice,
-          amendmentData.priceData.billingPeriod
-        )
+    AmendmentData(account, catalogue, subscription, invoiceList, earliestStartDate) map { amendmentData =>
+      SuccessfulEstimationResult(
+        subscription.subscriptionNumber,
+        amendmentData.startDate,
+        amendmentData.priceData.currency,
+        amendmentData.priceData.oldPrice,
+        amendmentData.priceData.newPrice,
+        amendmentData.priceData.billingPeriod
+      )
     }
 }
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -24,9 +24,14 @@ class NotificationHandlerTest extends munit.FunSuite {
   private val expectedCurrency = "GBP"
   private val expectedBillingPeriod = "Month"
   private val expectedBillingPeriodInNotification = "Monthly"
-  private val expectedOldPrice = BigDecimal(11.11)
-  private val expectedEstimatedNewPrice = BigDecimal(22.22)
-  private val expectedEstimatedNewPriceWithCurrencySymbolPrefix = "£22.22"
+  private val expectedOldPrice = BigDecimal(10.00)
+
+  // The estimated new price is the price without cap
+  private val expectedEstimatedNewPrice = BigDecimal(15.00)
+
+  // The price that is displayed to the customer is capped using the old price as base
+  private val expectedCappedEstimatedNewPriceWithCurrencySymbolPrefix = "£12.00"
+
   private val expectedSFSubscriptionId = "1234"
   private val expectedBuyerId = "buyer-1"
   private val expectedIdentityId = "buyer1-identity-id"
@@ -225,7 +230,7 @@ class NotificationHandlerTest extends munit.FunSuite {
     assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.last_name, expectedLastName)
     assertEquals(
       sentMessages(0).To.ContactAttributes.SubscriberAttributes.payment_amount,
-      expectedEstimatedNewPriceWithCurrencySymbolPrefix
+      expectedCappedEstimatedNewPriceWithCurrencySymbolPrefix
     )
     assertEquals(
       sentMessages(0).To.ContactAttributes.SubscriberAttributes.next_payment_date,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -19,8 +19,8 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
   private val expectedSubscriptionName = "Sub-0001"
   private val expectedStartDate = LocalDate.of(2020, 1, 1)
   private val expectedCurrency = "GBP"
-  private val expectedOldPrice = BigDecimal(11.11)
-  private val expectedEstimatedNewPrice = BigDecimal(22.22)
+  private val expectedOldPrice = BigDecimal(10.00)
+  private val expectedEstimatedNewPrice = BigDecimal(15.00)
   private val expectedCurrentTime = Instant.parse("2020-05-21T15:16:37Z")
 
   private def createStubCohortTable(
@@ -131,7 +131,10 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     assertEquals(createdPriceRises(0).SF_Subscription__c, Some(s"SubscritionId-$expectedSubscriptionName"))
     assertEquals(createdPriceRises(0).Buyer__c, Some(s"Buyer-$expectedSubscriptionName"))
     assertEquals(createdPriceRises(0).Current_Price_Today__c, Some(expectedOldPrice))
-    assertEquals(createdPriceRises(0).Guardian_Weekly_New_Price__c, Some(expectedEstimatedNewPrice))
+    assertEquals(
+      createdPriceRises(0).Guardian_Weekly_New_Price__c,
+      Some(List(expectedOldPrice * 1.2, expectedEstimatedNewPrice).min)
+    )
     assertEquals(createdPriceRises(0).Price_Rise_Date__c, Some(expectedStartDate))
 
     assertEquals(updatedResultsWrittenToCohortTable.size, 1)
@@ -191,7 +194,10 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     assertEquals(updatedPriceRises(0).SF_Subscription__c, Some(s"SubscritionId-$expectedSubscriptionName"))
     assertEquals(updatedPriceRises(0).Buyer__c, Some(s"Buyer-$expectedSubscriptionName"))
     assertEquals(updatedPriceRises(0).Current_Price_Today__c, Some(expectedOldPrice))
-    assertEquals(updatedPriceRises(0).Guardian_Weekly_New_Price__c, Some(expectedEstimatedNewPrice))
+    assertEquals(
+      updatedPriceRises(0).Guardian_Weekly_New_Price__c,
+      Some(List(expectedOldPrice * 1.2, expectedEstimatedNewPrice).min)
+    )
     assertEquals(updatedPriceRises(0).Price_Rise_Date__c, Some(expectedStartDate))
 
     assertEquals(updatedResultsWrittenToCohortTable.size, 1)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -133,7 +133,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     assertEquals(createdPriceRises(0).Current_Price_Today__c, Some(expectedOldPrice))
     assertEquals(
       createdPriceRises(0).Guardian_Weekly_New_Price__c,
-      Some(List(expectedOldPrice * 1.2, expectedEstimatedNewPrice).min)
+      Some(PriceCapper.cappedPrice(expectedOldPrice, expectedEstimatedNewPrice))
     )
     assertEquals(createdPriceRises(0).Price_Rise_Date__c, Some(expectedStartDate))
 
@@ -196,7 +196,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     assertEquals(updatedPriceRises(0).Current_Price_Today__c, Some(expectedOldPrice))
     assertEquals(
       updatedPriceRises(0).Guardian_Weekly_New_Price__c,
-      Some(List(expectedOldPrice * 1.2, expectedEstimatedNewPrice).min)
+      Some(PriceCapper.cappedPrice(expectedOldPrice, expectedEstimatedNewPrice))
     )
     assertEquals(updatedPriceRises(0).Price_Rise_Date__c, Some(expectedStartDate))
 

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -30,8 +30,7 @@ class AmendmentDataTest extends munit.FunSuite {
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
-      earliestStartDate = migrationStartDate2022,
-      None
+      earliestStartDate = migrationStartDate2022
     )
     assertEquals(
       priceData,
@@ -52,14 +51,13 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       earliestStartDate = migrationStartDate2022,
-      Some(ChargeCap.builderFromMultiplier(1.2))
     )
     assertEquals(
       priceData,
       Right(
         AmendmentData(
           LocalDate.of(2023, 2, 11),
-          PriceData(currency = "GBP", oldPrice = 60.00, newPrice = 72.00, billingPeriod = "Quarter")
+          PriceData(currency = "GBP", oldPrice = 60.00, newPrice = 74.40, billingPeriod = "Quarter")
         )
       )
     )
@@ -73,7 +71,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       earliestStartDate = migrationStartDate2022,
-      None
     )
     assertEquals(
       priceData,
@@ -96,7 +93,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       earliestStartDate = migrationStartDate2022,
-      None
     )
     assertEquals(
       priceData,
@@ -116,8 +112,7 @@ class AmendmentDataTest extends munit.FunSuite {
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
-      earliestStartDate = migrationStartDate2022,
-      None
+      earliestStartDate = migrationStartDate2022
     )
     assertEquals(
       priceData,
@@ -137,8 +132,7 @@ class AmendmentDataTest extends munit.FunSuite {
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
-      earliestStartDate = migrationStartDate2022,
-      None
+      earliestStartDate = migrationStartDate2022
     )
     assertEquals(
       priceData,
@@ -198,8 +192,7 @@ class AmendmentDataTest extends munit.FunSuite {
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
-      startDate = LocalDate.of(2020, 5, 28),
-      None
+      startDate = LocalDate.of(2020, 5, 28)
     )
     assertEquals(
       priceData,
@@ -214,8 +207,7 @@ class AmendmentDataTest extends munit.FunSuite {
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
-      startDate = LocalDate.of(2020, 6, 15),
-      None
+      startDate = LocalDate.of(2020, 6, 15)
     )
     assertEquals(
       priceData,
@@ -231,7 +223,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2020, 7, 16),
-      None
     )
     assertEquals(
       priceData,
@@ -247,7 +238,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2020, 6, 4),
-      None
     )
     assertEquals(
       priceData,
@@ -263,7 +253,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2020, 6, 4),
-      None
     )
     assertEquals(
       priceData,
@@ -279,7 +268,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2020, 8, 8),
-      None
     )
     assertEquals(
       priceData,
@@ -295,7 +283,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2020, 7, 5),
-      None
     )
     assertEquals(
       priceData,
@@ -311,7 +298,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2020, 7, 28),
-      None
     )
     assertEquals(
       priceData,
@@ -327,7 +313,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2021, 1, 13),
-      None
     )
     assertEquals(
       priceData,
@@ -343,7 +328,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2020, 12, 7),
-      None
     )
     assertEquals(
       priceData,
@@ -368,7 +352,7 @@ class AmendmentDataTest extends munit.FunSuite {
     val subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json")
     val invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json")
     val serviceStartDate = LocalDate.of(2020, 6, 4)
-    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate, None)
+    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate)
     assertEquals(totalChargeAmount, Right(BigDecimal(54.99)))
   }
 
@@ -377,7 +361,7 @@ class AmendmentDataTest extends munit.FunSuite {
     val subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json")
     val invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json")
     val serviceStartDate = LocalDate.of(2022, 2, 19)
-    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate, None)
+    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate)
     assertEquals(totalChargeAmount, Right(BigDecimal(69.99)))
   }
 
@@ -386,7 +370,7 @@ class AmendmentDataTest extends munit.FunSuite {
     val subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json")
     val invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json")
     val serviceStartDate = LocalDate.of(2020, 6, 9)
-    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate, None)
+    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate)
     assertEquals(totalChargeAmount, Right(BigDecimal(25.95)))
   }
 
@@ -395,7 +379,7 @@ class AmendmentDataTest extends munit.FunSuite {
     val subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json")
     val invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json")
     val serviceStartDate = LocalDate.of(2020, 7, 16)
-    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate, None)
+    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate)
     assertEquals(totalChargeAmount, Right(BigDecimal(15.57)))
   }
 
@@ -404,7 +388,7 @@ class AmendmentDataTest extends munit.FunSuite {
     val subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json")
     val invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json")
     val serviceStartDate = LocalDate.of(2022, 6, 26)
-    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate, None)
+    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate)
     assertEquals(totalChargeAmount, Right(BigDecimal(20.99)))
   }
 
@@ -413,7 +397,7 @@ class AmendmentDataTest extends munit.FunSuite {
     val subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json")
     val invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json")
     val serviceStartDate = LocalDate.of(2022, 4, 18)
-    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate, None)
+    val totalChargeAmount = AmendmentData.totalChargeAmount(subscription, invoiceList, serviceStartDate)
     assertEquals(totalChargeAmount, Right(BigDecimal(54.12)))
   }
 
@@ -423,7 +407,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       serviceStartDate = LocalDate.of(2020, 8, 4),
-      None
     )
     assertEquals(
       totalChargeAmount,
@@ -479,7 +462,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 2, 19),
-      None
     )
     assertEquals(
       priceData,
@@ -495,7 +477,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 2, 11),
-      None
     )
     assertEquals(
       priceData,
@@ -511,7 +492,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 2, 28),
-      None
     )
     assertEquals(
       priceData,
@@ -527,7 +507,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 2, 28),
-      None
     )
     assertEquals(
       priceData,
@@ -543,7 +522,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 3, 15),
-      None
     )
     assertEquals(
       priceData,
@@ -559,7 +537,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 2, 19),
-      None
     )
     assertEquals(
       priceData,
@@ -575,7 +552,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 2, 8),
-      None
     )
     assertEquals(
       priceData,
@@ -591,7 +567,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 4, 18),
-      None
     )
     assertEquals(
       priceData,
@@ -607,7 +582,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 4, 5),
-      None
     )
     assertEquals(
       priceData,
@@ -623,7 +597,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2022, 6, 19),
-      None
     )
     assertEquals(
       priceData,
@@ -639,7 +612,6 @@ class AmendmentDataTest extends munit.FunSuite {
       subscription = subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       startDate = LocalDate.of(2023, 1, 26),
-      None
     )
     assertEquals(
       priceData,

--- a/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
@@ -6,7 +6,7 @@ import pricemigrationengine.Fixtures
 
 class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
 
-  test("Zuora amendment correctly creates a charge override from the capped price") {
+  test("Zuora amendment correctly creates a charge") {
     val fixtureSet = "GuardianWeekly/CappedPriceIncrease2"
     val date = LocalDate.of(2022, 12, 30)
     val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
@@ -15,12 +15,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      Some(
-        ChargeCap(
-          None,
-          78 * 1.2
-        ) // ChargeCap here is used to apply the correct rate plan charges
-      )
+      1
     )
     assertEquals(
       update,
@@ -34,7 +29,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
                 ChargeOverride(
                   productRatePlanChargeId = "2c92a0fe6619b4b601661aa8b74e623f",
                   billingPeriod = "Quarter",
-                  price = 93.6
+                  price = 108.0
                 )
               )
             )
@@ -52,7 +47,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
     )
   }
 
-  test("Zuora amendment correctly creates a charge override from the capped price 2") {
+  test("Zuora amendment correctly creates a charge override from a non trivial price correction factor") {
     val fixtureSet = "GuardianWeekly/CappedPriceIncrease3"
     val date = LocalDate.of(2022, 12, 19)
     val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
@@ -61,12 +56,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      Some(
-        ChargeCap(
-          None,
-          60 * 1.2
-        ) // ChargeCap here is used to apply the correct rate plan charges
-      )
+      0.5
     )
     assertEquals(
       update,
@@ -80,7 +70,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
                 ChargeOverride(
                   productRatePlanChargeId = "2c92a0ff6619bf8b01661ab2d0396eb2",
                   billingPeriod = "Quarter",
-                  price = 72
+                  price = 37.20
                 )
               )
             )
@@ -107,12 +97,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      Some(
-        ChargeCap(
-          None,
-          60 * 1.2
-        ) // ChargeCap here is used to apply the correct rate plan charges
-      )
+      1
     )
     assertEquals(
       update,
@@ -126,7 +111,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
                 ChargeOverride(
                   productRatePlanChargeId = "2c92a0ff6619bf8b01661ab2d0396eb2",
                   billingPeriod = "Quarter",
-                  price = 72.0
+                  price = 74.4
                 )
               )
             )
@@ -155,7 +140,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      None
+      1
     )
     assertEquals(
       update,
@@ -165,7 +150,13 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
             AddZuoraRatePlan(
               productRatePlanId = "2c92a0086619bf8901661ab02752722f",
               contractEffectiveDate = date,
-              chargeOverrides = Nil
+              chargeOverrides = List(
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0ff6619bf8b01661ab2d0396eb2",
+                  billingPeriod = "Quarter",
+                  price = 90.0
+                )
+              )
             )
           ),
           remove = List(
@@ -187,14 +178,54 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      None
+      1
     )
     assertEquals(
       update,
       Right(
         ZuoraSubscriptionUpdate(
           add = List(
-            AddZuoraRatePlan(productRatePlanId = "2c92a0fd56fe270b0157040dd79b35da", contractEffectiveDate = date)
+            AddZuoraRatePlan(
+              productRatePlanId = "2c92a0fd56fe270b0157040dd79b35da",
+              contractEffectiveDate = date,
+              chargeOverrides = List(
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0ff56fe33f0015709c182cb7c82",
+                  billingPeriod = "Month",
+                  price = 6.7
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fd56fe26b6015709c0613b44a6",
+                  billingPeriod = "Month",
+                  price = 6.7
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0ff56fe33f0015709c215527db4",
+                  billingPeriod = "Month",
+                  price = 6.7
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fd56fe270b015709c320ee0595",
+                  billingPeriod = "Month",
+                  price = 9.75
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fd56fe26b601570431a5bc5a34",
+                  billingPeriod = "Month",
+                  price = 6.7
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0ff56fe33f5015709c39719783e",
+                  billingPeriod = "Month",
+                  price = 9.74
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0ff56fe33f3015709c110a71630",
+                  billingPeriod = "Month",
+                  price = 6.7
+                )
+              )
+            )
           ),
           remove = List(
             RemoveZuoraRatePlan(ratePlanId = "rp2", contractEffectiveDate = date)
@@ -215,14 +246,29 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      None
+      1
     )
     assertEquals(
       update,
       Right(
         ZuoraSubscriptionUpdate(
           add = List(
-            AddZuoraRatePlan(productRatePlanId = "2c92a0ff56fe33f00157040f9a537f4b", contractEffectiveDate = date)
+            AddZuoraRatePlan(
+              productRatePlanId = "2c92a0ff56fe33f00157040f9a537f4b",
+              contractEffectiveDate = date,
+              chargeOverrides = List(
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0ff56fe33f00157041713362b51",
+                  billingPeriod = "Month",
+                  price = 10.99
+                ),
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fc56fe26ba01570417df6d1b54",
+                  billingPeriod = "Month",
+                  price = 11.0
+                )
+              )
+            )
           ),
           remove = List(
             RemoveZuoraRatePlan(ratePlanId = "rp2", contractEffectiveDate = date)
@@ -243,7 +289,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      None
+      1
     )
     assertEquals(
       update,
@@ -286,14 +332,24 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      None
+      1
     )
     assertEquals(
       update,
       Right(
         ZuoraSubscriptionUpdate(
           add = List(
-            AddZuoraRatePlan(productRatePlanId = "2c92a0fe6619b4b301661aa494392ee2", contractEffectiveDate = date)
+            AddZuoraRatePlan(
+              productRatePlanId = "2c92a0fe6619b4b301661aa494392ee2",
+              contractEffectiveDate = date,
+              chargeOverrides = List(
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fe6619b4b601661aa8b74e623f",
+                  billingPeriod = "Quarter",
+                  price = 42.4
+                )
+              )
+            )
           ),
           remove = List(
             RemoveZuoraRatePlan(ratePlanId = "rp123", contractEffectiveDate = date)
@@ -314,7 +370,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      None
+      1
     )
     assertEquals(
       update,
@@ -377,7 +433,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      None
+      1
     )
     assertEquals(
       update,
@@ -420,7 +476,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
       invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json"),
       date,
-      None
+      1
     )
     assertEquals(
       update,
@@ -432,7 +488,13 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
             AddZuoraRatePlan(
               productRatePlanId = "2c92a0fe5af9a6b9015b0fe1ecc0116c",
               contractEffectiveDate = date,
-              chargeOverrides = Nil
+              chargeOverrides = List(
+                ChargeOverride(
+                  productRatePlanChargeId = "2c92a0fe5af9a6b9015b0fe1ed121177",
+                  billingPeriod = "Month",
+                  price = 11.99
+                )
+              )
             )
           ),
           remove = List(
@@ -443,7 +505,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
     )
   }
 
-  test("CappedPriceIncrease: The standard uncapped price rise is invariant") {
+  test("Estimated price is computed correctly") {
 
     val fixtureSet = "GuardianWeekly/CappedPriceIncrease"
     val catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json")
@@ -458,34 +520,10 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
         subscription,
         invoiceList,
         earliestStartDate,
-        None
       )
     assertEquals(
       estimationResult,
       Right(SuccessfulEstimationResult("subNum", LocalDate.of(2022, 11, 12), "GBP", 30.00, 41.25, "Quarter"))
-    )
-  }
-
-  test("CappedPriceIncrease: Capped price rise is correct") {
-
-    val fixtureSet = "GuardianWeekly/CappedPriceIncrease"
-    val catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json")
-    val subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json")
-    val account = Fixtures.accountFromJson(s"$fixtureSet/Account.json")
-    val earliestStartDate = LocalDate.of(2022, 10, 10)
-    val invoiceList = Fixtures.invoiceListFromJson(s"$fixtureSet/InvoicePreview.json")
-    val estimationResult =
-      EstimationResult(
-        account,
-        catalogue,
-        subscription,
-        invoiceList,
-        earliestStartDate,
-        Some(ChargeCap.builderFromMultiplier(1.2))
-      )
-    assertEquals(
-      estimationResult,
-      Right(SuccessfulEstimationResult("subNum", LocalDate.of(2022, 11, 12), "GBP", 30.00, 36, "Quarter"))
     )
   }
 }


### PR DESCRIPTION
This PR description is in two parts. The short version that just describes the change and the long version that Pascal had originally written with all the details (of the problem and solutions)

# Short Version

In this PR, we reimplement the 20% price capping policy which was introduced here: https://github.com/guardian/price-migration-engine/pull/727 , while also changing the semantics of the `estimatedNewPrice` field of a cohort Item (essentially reverting back to its original meaning). 

In one sentence: we no longer store the capped price in the `estimatedNewPrice` field. We store it uncapped and cap it when we need. The advantage is a much simpler capping logic and a more robust Amendment process (which requires the uncapped version). 

The Amendment handler now has a single `PriceCapper` object. It is not used in the Estimation handler. `PriceCapping.cappedPrice` is used just once in the SalesforcePriceRiseCreation handler and used also just once in the NotificationHandler. Then, at the very end, `PriceCapping.priceCorrectionFactor` is used once in the Amendment Handler (to compute the correct subscription update), and then `PriceCapping.cappedPrice` used one more time to check the price post subscription update (at which point a failure may be issued).

ps: The change looks big because it's actually 3 PRs into one. 

1. Decommissioning the old price capping.
2. Reimplementing price capping in a much simpler way.
3. Adapting the SalesforcePriceRiseCreation and the Notification handlers to the updated semantics of the `estimatedNewPrice` field.