### PR TITLE
correct subscription ids file upload

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
@@ -12,7 +12,7 @@ import scala.jdk.CollectionConverters._
 
 object SubscriptionIdUploadHandler extends CohortHandler {
 
-  private val csvFormat = CSVFormat.Builder.create().setHeader().setSkipHeaderRecord(true).build()
+  private val csvFormat = CSVFormat.Builder.create().setHeader().build()
 
   private def sourceLocation(cohortSpec: CohortSpec): ZIO[StageConfig, ConfigFailure, S3Location] =
     ZIO.service[StageConfig] map { stageConfig =>


### PR DESCRIPTION
The SubscriptionIdUploadHandler is skipping the first subscriptionId that is incorrectly read as a csv header. The salesforce-subscription-id-report.csv file (as well as the excluded-subscription-ids.csv file) only contains subscriptionIds so that was a mistake. This change corrects it.