### PR TITLE
Allow for price cap override

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
@@ -5,14 +5,31 @@ object PriceCap {
   /*
     This object implements the policy of not increasing subscription prices, and
     therefore what our customers pay, by more then 20% during a single price rise.
+
+    With that said, there are situations where we want the capping not to apply.
+    For instance for very small prices or for certain products, or certain rate plans.
+    In which case we can specify that the estimated price will be the new price, even
+    if it was higher than 20% increase. The decision is not left to the PriceCap but
+    belongs to the caller.
    */
 
   private val priceCappingMultiplier = 1.2 // old price + 20%
-  def cappedPrice(oldPrice: BigDecimal, estimatedNewPrice: BigDecimal): BigDecimal =
-    List(estimatedNewPrice, oldPrice * priceCappingMultiplier).min
+  def cappedPrice(oldPrice: BigDecimal, estimatedNewPrice: BigDecimal, forceEstimated: Boolean = false): BigDecimal = {
+    if (forceEstimated) {
+      estimatedNewPrice
+    } else {
+      List(estimatedNewPrice, oldPrice * priceCappingMultiplier).min
+    }
+  }
 
-  def priceCorrectionFactor(oldPrice: BigDecimal, estimatedNewPrice: BigDecimal): BigDecimal = {
-    if (estimatedNewPrice == 0 || estimatedNewPrice.compareTo(oldPrice * priceCappingMultiplier) <= 0) {
+  def priceCorrectionFactor(
+      oldPrice: BigDecimal,
+      estimatedNewPrice: BigDecimal,
+      forceEstimated: Boolean = false
+  ): BigDecimal = {
+    if (
+      forceEstimated || estimatedNewPrice == 0 || estimatedNewPrice.compareTo(oldPrice * priceCappingMultiplier) <= 0
+    ) {
       1
     } else {
       (oldPrice * priceCappingMultiplier) / estimatedNewPrice

--- a/lambda/src/test/scala/pricemigrationengine/model/PriceCapTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/PriceCapTest.scala
@@ -9,12 +9,27 @@ class PriceCapTest extends munit.FunSuite {
     assertEquals(cappedPrice, PriceCap.cappedPrice(oldPrice, uncappedPrice))
   }
 
+  test("The price capping works correctly in case of force estimated") {
+    val oldPrice = BigDecimal(100)
+    val cappedPrice = BigDecimal(120)
+    val uncappedPrice = BigDecimal(156)
+    assertEquals(uncappedPrice, PriceCap.cappedPrice(oldPrice, uncappedPrice, true))
+  }
+
   test("The price correction factor is computed correctly") {
     val oldPrice = BigDecimal(100)
     val estimatedNewPrice = BigDecimal(240)
     val correctionFactor = BigDecimal(0.5)
     // The capped price is 120, half of the estimated new price, hence a correction factor of 0.5
     assertEquals(correctionFactor, PriceCap.priceCorrectionFactor(oldPrice, estimatedNewPrice))
+  }
+
+  test("The price correction factor is computed correctly in case of force estimated") {
+    val oldPrice = BigDecimal(100)
+    val estimatedNewPrice = BigDecimal(240)
+    val correctionFactor = BigDecimal(1)
+    // The capped price is 120, half of the estimated new price, hence a correction factor of 0.5
+    assertEquals(correctionFactor, PriceCap.priceCorrectionFactor(oldPrice, estimatedNewPrice, true))
   }
 
   test("Correction factor in case of 0 estimated new price") {
@@ -24,4 +39,5 @@ class PriceCapTest extends munit.FunSuite {
     // The correction factor in case of an estimated new price of zero is conventionally set to 1
     assertEquals(correctionFactor, PriceCap.priceCorrectionFactor(oldPrice, estimatedNewPrice))
   }
+
 }


### PR DESCRIPTION
Here we implement an override for the price cap. 

There are cases or circumstances where we would not want the cap to apply, for instance small prices or for exceptional products or rate plans. In which case the caller can decide with a boolean that the cap will not apply.

