### PR TITLE
Implement notification lead time for membership

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -33,7 +33,7 @@ object NotificationHandler extends CohortHandler {
   // Note that technically, meaning legally, the end of the notification period is { May 3rd - 30 days }
   // There is a 5 days period between the engineLettersMinNotificationLeadTime and what is legally required.
 
-  // When the membership subscription was defined, the requirement was to send letters exactly 33 days before
+  // When the membership migration was defined, the requirement was to send letters exactly 33 days before
   // the price rise date (the cohortItem startDate). The idea was to send on March 29th, the emails corresponding
   // to price rise scheduled for May 1st, and keep the same exact lead time.
   // To achieve this let's introduce...


### PR DESCRIPTION
Here we implement the notification lead time requirements for membership. We want the first notification to be sent on March 29th, for price rises happening on May 1st, and then to keep with that schedule. The change is essentially in 3 parts

1. We  better explain at the top of the Notification Handler what the situation is with the notification periods.

2. Introduce the `maxLeadTime` and `minLeadTime` functions which unsurprisingly consume a `CohortSpec`

3. Update the tests. Two points of interest: 
    i. The `createStubCohortTable` function is losing its hard coded 49 days lead time (there was the possibility to refactor it to force a `CohortSpec` in there, but we have redundant tests that check the number of items that have been processed and they essentially perform the same check) 
    ii. We have a more thorough test for `thereIsEnoughNotificationLeadTime`.