### PR TITLE
Update the start of the state machine to 10 UTC, 11 BST

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -21,8 +21,13 @@ object NotificationHandler extends CohortHandler {
 
   // The NotificationHandler acts on any item for which today is within the notification period for this item
 
-  private val guLettersNotificationLeadTime = 49
+  val guLettersNotificationLeadTime = 50
   private val engineLettersMinNotificationLeadTime = 35
+
+  // (The following description refers to a lead time of 49 days, which was the original
+  // lead time before updating it to 50 day as a side effect of moving the state machine morning
+  // start time to 11 BST for the membership migration. When the need for that change goes, then we will
+  // move the value back to 49 with no update in the below comment.)
 
   // Historically, for print subscriptions, we have used guLettersNotificationLeadTime and
   // engineLettersMinNotificationLeadTime to define the notification window. For instance,
@@ -30,8 +35,12 @@ object NotificationHandler extends CohortHandler {
   // { May 3rd - 49 days, guLettersNotificationLeadTime } and the end of the notification period
   // is { May 3rd - 35 days, engineLettersMinNotificationLeadTime }
 
+  // The value of 49 days itself was chosen so that overseas subscribers get their letters at least 30 days before
+  // price rise, so we plan for a 2 weeks mail delivery.
+
   // Note that technically, meaning legally, the end of the notification period is { May 3rd - 30 days }
-  // There is a 5 days period between the engineLettersMinNotificationLeadTime and what is legally required.
+  // There is a 5 days period between the engineLettersMinNotificationLeadTime and what is legally required, again to
+  // help with delivery periods. Below 35 days, it's better to postpone the price rise.
 
   // When the membership migration was defined, the requirement was to send letters exactly 33 days before
   // the price rise date (the cohortItem startDate). The idea was to send on March 29th, the emails corresponding

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -1,6 +1,7 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.handlers.NotificationHandler.thereIsEnoughNotificationLeadTime
+import pricemigrationengine.handlers.NotificationHandler.guLettersNotificationLeadTime
 import pricemigrationengine.{TestLogging}
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
@@ -13,8 +14,7 @@ import zio.stream.ZStream
 import zio.test.{TestClock, testEnvironment}
 import zio.{IO, ZIO, ZLayer}
 
-import java.time.temporal.ChronoUnit
-import java.time.{Instant, LocalDate, ZoneOffset}
+import java.time.{Instant, LocalDate}
 import scala.collection.mutable.ArrayBuffer
 
 class NotificationHandlerTest extends munit.FunSuite {
@@ -195,6 +195,13 @@ class NotificationHandlerTest extends munit.FunSuite {
       estimatedNewPrice = Some(estimatedNewPrice),
       billingPeriod = Some(billingPeriod)
     )
+
+  test("guLettersNotificationLeadTime should be at least 49 days") {
+    // There is a comment at the top of the Notification handler which explains why the value 49 was chosen
+    // Here we are simply checking that it's at least 49 days (it was temporarily set to 50 day during
+    // membership migration)
+    assert(guLettersNotificationLeadTime >= 49)
+  }
 
   test("NotificationHandler should get records from cohort table and SF and send Email with the data") {
     val stubSalesforceClient = stubSFClient(List(salesforceSubscription), List(salesforceContact))

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -139,8 +139,8 @@ Resources:
       - PriceMigrationLambda
     Condition: IsProd
     Properties:
-      Description: Trigger daily 7 am (UTC) kick-off of state machines for active cohorts.
-      ScheduleExpression: "cron(0 7 ? * * *)"
+      Description: Trigger daily 10 am (UTC) kick-off of state machines for active cohorts.
+      ScheduleExpression: "cron(0 10 ? * * *)"
       State: ENABLED
       Targets:
         - Arn: !GetAtt PriceMigrationLambda.Arn


### PR DESCRIPTION
### 1. Morning runtime

The Engine's state machine has traditionally ran at 07:00 UTC (currently 08:00 BST). This change brings that start time to 10:00 UTC (11:00 BST) to satisfy membership migration requirements. 

When will this time be updated again ?

- If we only care about maintaining that timing for the UK, then when we move to winter time in 6 months, we should update it to 11 UTC.

- If/when we implement the canvas integration, then we can bring it back to 7 UTC, knowing that a canvas will handle the timing management.

- When the membership migration ends, if there are no other concurrent migrations with that requirement (hopefully by then canvas will be standard), then we can bring it back to 7 UTC.

### 2. GU letters lead print time increase

Moving the run time to 11am (UK) might cause up to a day delay in print letters in Latcham. We temporality increase the lead time from 49 to 50 days. 