### PR TITLE
Add support for membership Batch2

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -1,6 +1,5 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.model.CohortSpec.isMembershipPriceRiseBatch1
 import pricemigrationengine.model.CohortTableFilter.NotificationSendDateWrittenToSalesforce
 import pricemigrationengine.model._
 import pricemigrationengine.services._
@@ -113,7 +112,9 @@ object AmendmentHandler extends CohortHandler {
           )
         )
 
-      _ <- ZIO.fromEither(checkNewPrice(item, oldPrice, newPrice, CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)))
+      _ <- ZIO.fromEither(
+        checkNewPrice(item, oldPrice, newPrice, CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec))
+      )
 
       whenDone <- Clock.instant
     } yield SuccessfulAmendmentResult(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -113,7 +113,7 @@ object AmendmentHandler extends CohortHandler {
           )
         )
 
-      _ <- ZIO.fromEither(checkNewPrice(item, oldPrice, newPrice, CohortSpec.isMembershipPriceRiseBatch1(cohortSpec)))
+      _ <- ZIO.fromEither(checkNewPrice(item, oldPrice, newPrice, CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)))
 
       whenDone <- Clock.instant
     } yield SuccessfulAmendmentResult(
@@ -133,7 +133,7 @@ object AmendmentHandler extends CohortHandler {
       .filterOrFail(_.status != "Cancelled")(CancelledSubscriptionFailure(item.subscriptionName))
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    if (CohortSpec.isMembershipPriceRiseBatch1(input)) {
+    if (CohortSpec.isMembershipPriceRiseMonthlies(input)) {
       ZIO.succeed(HandlerOutput(isComplete = true))
     } else {
       main(input).provideSome[Logging](

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -1,6 +1,5 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.model.CohortSpec.isMembershipPriceRiseBatch1
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.services._

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -116,7 +116,7 @@ object EstimationHandler extends CohortHandler {
         .contains("Month")
 
     // We usually spread the start date over 3 months, but in the case of membership price rise batch 1, we want all to do through within a month
-    val spreadPeriod = if (CohortSpec.isMembershipPriceRiseBatch1(cohortSpec)) 1 else 3
+    val spreadPeriod = if (CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)) 1 else 3
 
     if (isMonthlySubscription) {
       for {

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -56,7 +56,7 @@ object NotificationHandler extends CohortHandler {
 
   // to manage those different values for the max and min lead time, which define notification period, we introduce
   def maxLeadTime(cohortSpec: CohortSpec): Int = {
-    if (CohortSpec.isMembershipPriceRiseBatch1(cohortSpec)) {
+    if (CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)) {
       membershipPriceRiseNotificationLeadTime
     } else {
       guLettersNotificationLeadTime
@@ -64,7 +64,7 @@ object NotificationHandler extends CohortHandler {
   }
 
   def minLeadTime(cohortSpec: CohortSpec): Int = {
-    if (CohortSpec.isMembershipPriceRiseBatch1(cohortSpec)) {
+    if (CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)) {
       membershipMinNotificationLeadTime
     } else {
       engineLettersMinNotificationLeadTime
@@ -160,7 +160,7 @@ object NotificationHandler extends CohortHandler {
       _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
       contact <- SalesforceClient.getContact(sfSubscription.Buyer__c)
       firstName <- requiredField(contact.FirstName, "Contact.FirstName").orElse(
-        if (CohortSpec.isMembershipPriceRiseBatch1(cohortSpec)) {
+        if (CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)) {
           requiredField(contact.Salutation.fold(Some("Member"))(Some(_)), "Contact.Salutation")
         } else {
           requiredField(contact.Salutation, "Contact.Salutation")
@@ -180,7 +180,7 @@ object NotificationHandler extends CohortHandler {
       currencySymbol <- currencyISOtoSymbol(currencyISOCode)
 
       // In the case of membership price rise, we need to not cap the price
-      cappedEstimatedNewPriceWithCurrencySymbol = s"${currencySymbol}${PriceCap.cappedPrice(oldPrice, estimatedNewPrice, CohortSpec.isMembershipPriceRiseBatch1(cohortSpec))}"
+      cappedEstimatedNewPriceWithCurrencySymbol = s"${currencySymbol}${PriceCap.cappedPrice(oldPrice, estimatedNewPrice, CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec))}"
 
       _ <- logMissingEmailAddress(cohortItem, contact)
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -1,6 +1,5 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.model.CohortSpec.isMembershipPriceRiseBatch1
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiceCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.services._

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -86,7 +86,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
       Some(subscription.Buyer__c),
       Some(oldPrice),
       Some(
-        PriceCap.cappedPrice(oldPrice, estimatedNewPrice, CohortSpec.isMembershipPriceRiseBatch1(cohortSpec))
+        PriceCap.cappedPrice(oldPrice, estimatedNewPrice, CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec))
       ), // In case of membership price rise, we override the capping
       Some(priceRiseDate),
       Some(subscription.Id)

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -96,7 +96,7 @@ object AmendmentData {
       moment, just a difference between regular price rises and membership (batch 1) will do.
      */
 
-    if (CohortSpec.isMembershipPriceRiseBatch1(cohortSpec)) {
+    if (CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)) {
       Membership2023.priceData(account, catalogue, subscription, invoiceList, nextServiceStartDate)
     } else {
       priceDataWithRatePlanMatching(account, catalogue, subscription, invoiceList, nextServiceStartDate)

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -1,6 +1,5 @@
 package pricemigrationengine.model
 
-import pricemigrationengine.model.CohortSpec.isMembershipPriceRiseBatch1
 import pricemigrationengine.model.ZuoraProductCatalogue.{homeDeliveryRatePlans, productPricingMap}
 
 import java.time.LocalDate

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -66,6 +66,6 @@ object CohortSpec {
   def isMembershipPriceRiseBatch1(cohortSpec: CohortSpec): Boolean = cohortSpec.cohortName == "Membership2023_Batch1"
   def isMembershipPriceRiseBatch2(cohortSpec: CohortSpec): Boolean = cohortSpec.cohortName == "Membership2023_Batch2"
 
-  def isMembershipPriceRise(cohortSpec: CohortSpec) =
+  def isMembershipPriceRiseMonthlies(cohortSpec: CohortSpec) =
     isMembershipPriceRiseBatch1(cohortSpec) || isMembershipPriceRiseBatch2(cohortSpec)
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -64,4 +64,8 @@ object CohortSpec {
     )).left.map(e => CohortSpecFetchFailure(e))
 
   def isMembershipPriceRiseBatch1(cohortSpec: CohortSpec): Boolean = cohortSpec.cohortName == "Membership2023_Batch1"
+  def isMembershipPriceRiseBatch2(cohortSpec: CohortSpec): Boolean = cohortSpec.cohortName == "Membership2023_Batch2"
+
+  def isMembershipPriceRise(cohortSpec: CohortSpec) =
+    isMembershipPriceRiseBatch1(cohortSpec) || isMembershipPriceRiseBatch2(cohortSpec)
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
@@ -37,7 +37,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
       }
     )
     suite("membership estimations")(
-      test("Estimation uses uncapped price") {
+      test("Estimation uses uncapped price, Membership2023_Batch1") {
 
         // The name of the cohort here is import to trigger the membership2023_Batch1 code path
         val cohortSpec =
@@ -55,6 +55,31 @@ object EstimationHandlerTest extends ZIOSpecDefault {
         assertTrue(
           estimationResult == Right(
             SuccessfulEstimationResult("SUBSCRIPTION-NUMBER", LocalDate.of(2023, 5, 13), "GBP", 5, 7, "Month")
+          )
+        )
+      },
+      test("Estimation uses uncapped price, Membership2023_Batch2") {
+        // Similar to the previous test (and in particular we do reuse Batch1's fixtures as they are structurally
+        // indistinguishable from Batch1), but shifting by a month for Batch2.
+
+        val cohortSpec =
+          CohortSpec("Membership2023_Batch2", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 6, 1))
+        val startDate = cohortSpec.earliestPriceMigrationStartDate
+
+        val account = Fixtures.accountFromJson("Membership2023/Batch1/GBP/account.json")
+        val catalogue = Fixtures.productCatalogueFromJson("Membership2023/Batch1/GBP/catalogue.json")
+        val subscription = Fixtures.subscriptionFromJson("Membership2023/Batch1/GBP/subscription.json")
+        val invoicePreview = Fixtures.invoiceListFromJson("Membership2023/Batch1/GBP/invoice-preview.json")
+
+        // In the test, the actual startDate and the cohort's cohortSpec earliestPriceMigrationStartDate are same (which is fine)
+        val estimationResult = EstimationResult(account, catalogue, subscription, invoicePreview, startDate, cohortSpec)
+
+        // Compared to Membership2023_Batch1, we move the earliest possible start date by a month,
+        // from LocalDate.of(2023, 5, 1) to LocalDate.of(2023, 6, 1) will result in the actual subscription start
+        // date be postponed by a month (from LocalDate.of(2023, 5, 13) to LocalDate.of(2023, 6, 13)).
+        assertTrue(
+          estimationResult == Right(
+            SuccessfulEstimationResult("SUBSCRIPTION-NUMBER", LocalDate.of(2023, 6, 13), "GBP", 5, 7, "Month")
           )
         )
       }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -273,7 +273,7 @@ class NotificationHandlerTest extends munit.FunSuite {
   }
 
   test(
-    "NotificationHandler should get records from cohort table and SF and send Email with the data (membership variation)"
+    "NotificationHandler should get records from cohort table and SF and send Email with the data (membership Batch1)"
   ) {
 
     // The membership variation here uses a similar structure as the legacy NotificationHandler test, but we need
@@ -310,7 +310,97 @@ class NotificationHandlerTest extends munit.FunSuite {
     val cohortSpec =
       CohortSpec("Membership2023_Batch1", brazeCampaignName, LocalDate.of(2000, 1, 1), LocalDate.of(2023, 5, 1))
 
-    assertEquals(1, 1)
+    assertEquals(
+      unsafeRunSync(default)(
+        (for {
+          _ <- TestClock.setTime(dataCurrentTime)
+          program <- NotificationHandler.main(cohortSpec)
+        } yield program).provideLayer(
+          testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
+        )
+      ),
+      Success(HandlerOutput(isComplete = true))
+    )
+
+    assertEquals(sentMessages.size, 1)
+    assertEquals(sentMessages(0).DataExtensionName, dataExtensionName)
+    assertEquals(sentMessages(0).SfContactId, buyerId)
+    assertEquals(sentMessages(0).IdentityUserId, Some(identityId))
+    assertEquals(sentMessages(0).To.Address, Some(emailAddress))
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.billing_address_1, street)
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.billing_address_2, None)
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.billing_city, Some(city))
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.billing_state, Some(state))
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.billing_postal_code, postalCode)
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.billing_country, country)
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.title, Some(salutation))
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.first_name, firstName)
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.last_name, lastName)
+    assertEquals(
+      sentMessages(0).To.ContactAttributes.SubscriberAttributes.payment_amount,
+      unCappedEstimatedNewPriceWithCurrencySymbolPrefix
+    )
+    assertEquals(
+      sentMessages(0).To.ContactAttributes.SubscriberAttributes.next_payment_date,
+      expectedStartDateUserFriendlyFormat
+    )
+    assertEquals(
+      sentMessages(0).To.ContactAttributes.SubscriberAttributes.payment_frequency,
+      billingPeriodInNotification
+    )
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.subscription_id, subscriptionName)
+
+    assertEquals(updatedResultsWrittenToCohortTable.size, 2)
+    assertEquals(
+      updatedResultsWrittenToCohortTable(0),
+      CohortItem(
+        subscriptionName = subscriptionName,
+        processingStage = NotificationSendProcessingOrError,
+        whenNotificationSent = Some(dataCurrentTime)
+      )
+    )
+    assertEquals(
+      updatedResultsWrittenToCohortTable(1),
+      CohortItem(
+        subscriptionName = subscriptionName,
+        processingStage = NotificationSendComplete,
+        whenNotificationSent = Some(dataCurrentTime)
+      )
+    )
+  }
+
+  test(
+    "NotificationHandler should get records from cohort table and SF and send Email with the data (membership Batch2)"
+  ) {
+
+    // This test is identical to the previous one, but specific to Batch2
+
+    val itemStartDate = LocalDate.of(2023, 6, 1)
+
+    val cohortItem =
+      CohortItem(
+        subscriptionName = subscriptionName,
+        processingStage = AmendmentComplete,
+        startDate = Some(itemStartDate),
+        currency = Some(currency),
+        oldPrice = Some(oldPrice),
+        estimatedNewPrice = Some(estimatedNewPrice),
+        billingPeriod = Some(billingPeriod)
+      )
+
+    val dataCurrentTime = Instant.parse("2023-03-29T07:00:00Z")
+    val expectedStartDateUserFriendlyFormat = "1 June 2023"
+
+    val stubSalesforceClient = stubSFClient(List(salesforceSubscription), List(salesforceContact))
+    val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
+    val stubCohortTable = createStubCohortTable(updatedResultsWrittenToCohortTable, cohortItem)
+    val sentMessages = ArrayBuffer[EmailMessage]()
+    val stubEmailSender = createStubEmailSender(sentMessages)
+
+    // Building the cohort spec with the correct campaign name (as during the previous test)
+    // This time we also need to set the correct campaign name to trigger the membership price cap override
+    val cohortSpec =
+      CohortSpec("Membership2023_Batch2", brazeCampaignName, LocalDate.of(2000, 1, 1), LocalDate.of(2023, 6, 1))
 
     assertEquals(
       unsafeRunSync(default)(
@@ -493,7 +583,7 @@ class NotificationHandlerTest extends munit.FunSuite {
   }
 
   test(
-    "NotificationHandler, if membership price rise, in case of missing FirstMame and missing Salutation, should still send an email"
+    "NotificationHandler, if membership price rise (Batch1), in case of missing FirstMame and missing Salutation, should still send an email"
   ) {
     val stubSalesforceClient =
       stubSFClient(List(salesforceSubscription), List(salesforceContact.copy(FirstName = None, Salutation = None)))
@@ -505,6 +595,37 @@ class NotificationHandlerTest extends munit.FunSuite {
     // Building the cohort spec with the correct campaign name
     val cohortSpec =
       CohortSpec("Membership2023_Batch1", brazeCampaignName, LocalDate.of(2000, 1, 1), LocalDate.of(2023, 5, 1))
+
+    assertEquals(
+      unsafeRunSync(default)(
+        (for {
+          _ <- TestClock.setTime(currentTime)
+          program <- NotificationHandler.main(cohortSpec)
+        } yield program).provideLayer(
+          testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
+        )
+      ),
+      Success(HandlerOutput(isComplete = true))
+    )
+
+    assertEquals(sentMessages.size, 1)
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.title, None)
+    assertEquals(sentMessages(0).To.ContactAttributes.SubscriberAttributes.first_name, "Member")
+  }
+
+  test(
+    "NotificationHandler, if membership price rise (Batch2), in case of missing FirstMame and missing Salutation, should still send an email"
+  ) {
+    val stubSalesforceClient =
+      stubSFClient(List(salesforceSubscription), List(salesforceContact.copy(FirstName = None, Salutation = None)))
+    val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
+    val stubCohortTable = createStubCohortTable(updatedResultsWrittenToCohortTable, cohortItem)
+    val sentMessages = ArrayBuffer[EmailMessage]()
+    val stubEmailSender = createStubEmailSender(sentMessages)
+
+    // Building the cohort spec with the correct campaign name
+    val cohortSpec =
+      CohortSpec("Membership2023_Batch2", brazeCampaignName, LocalDate.of(2000, 1, 1), LocalDate.of(2023, 6, 1))
 
     assertEquals(
       unsafeRunSync(default)(
@@ -591,6 +712,7 @@ class NotificationHandlerTest extends munit.FunSuite {
 
   test("thereIsEnoughNotificationLeadTime behaves correctly (legacy case)") {
     // The item startDate will be set for April 4th
+    // (note that the dates of the test, and the subsequent variations, are one month ahead from the actual migration dates)
     // In the legacy case, of 35 days min lead time:
     //     - Feb 1st should be enough lead time (although not yet in the notification window)
     //     - May 1st should be not be enough (there only is 34 days from May 1st to April 4th)
@@ -610,7 +732,7 @@ class NotificationHandlerTest extends munit.FunSuite {
     assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date3, cohortItem), false)
   }
 
-  test("thereIsEnoughNotificationLeadTime behaves correctly (membership case)") {
+  test("thereIsEnoughNotificationLeadTime behaves correctly (membership case, Batch1)") {
     // We are using the same dates as for the previous test (legacy case)
     // Here let's observe the slight shift in notification period due to membership variation.
     // 34 days wasn't enough in the legacy case, but will be in the membership case.
@@ -629,4 +751,24 @@ class NotificationHandlerTest extends munit.FunSuite {
     assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date4, cohortItem), false)
   }
 
+  test("thereIsEnoughNotificationLeadTime behaves correctly (membership case, Batch2)") {
+    // Similar as Batch1, but shifted by a month
+    // (note that the dates of the test, and the subsequent variations, are one month ahead from the actual migration dates)
+
+    val itemStartDate = LocalDate.of(2023, 5, 4)
+
+    val cohortSpec = CohortSpec("Membership2023_Batch2", "BrazeCampaignName", LocalDate.of(2000, 1, 1), itemStartDate)
+    val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate))
+
+    val date2 = LocalDate.of(2023, 3, 1)
+    val date3 = LocalDate.of(2023, 4, 1) // 33 days to target, should true
+    val date4 = LocalDate.of(2023, 4, 2) // 32 days to target, should true
+    val date5 = LocalDate.of(2023, 4, 3) // 31 days to target, should false
+    val date6 = LocalDate.of(2023, 4, 4) // 30 days to target, should false
+    assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date2, cohortItem), true)
+    assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date3, cohortItem), true)
+    assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date4, cohortItem), true)
+    assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date5, cohortItem), false)
+    assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date6, cohortItem), false)
+  }
 }

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -650,7 +650,7 @@ class AmendmentDataTest extends munit.FunSuite {
     )
   }
 
-  test("priceData: is correct in the case of membership subscriptions [GBP]") {
+  test("priceData: is correct in the case of membership subscriptions [GBP], Batch 1") {
     val cohortSpec =
       CohortSpec("Membership2023_Batch1", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 5, 1))
 
@@ -668,9 +668,47 @@ class AmendmentDataTest extends munit.FunSuite {
     )
   }
 
-  test("priceData: is correct in the case of membership subscriptions [AUD]") {
+  test("priceData: is correct in the case of membership subscriptions [AUD], Batch 1") {
+    // Note: this tests exists to show correctness against a non GBP currency, but there actually won't be any such
+    // currencies in Batch1
     val cohortSpec =
       CohortSpec("Membership2023_Batch1", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 5, 1))
+
+    val account = Fixtures.accountFromJson("Membership2023/Batch1/AUD/account.json")
+    val catalogue = Fixtures.productCatalogueFromJson("Membership2023/Batch1/AUD/catalogue.json")
+    val subscription = Fixtures.subscriptionFromJson("Membership2023/Batch1/AUD/subscription.json")
+    val invoicePreview = Fixtures.invoiceListFromJson("Membership2023/Batch1/AUD/invoice-preview.json")
+
+    val priceData =
+      AmendmentData.priceData(account, catalogue, subscription, invoicePreview, LocalDate.of(2023, 1, 26), cohortSpec)
+
+    assertEquals(
+      priceData,
+      Right(PriceData(currency = "AUD", oldPrice = 10, newPrice = 14, billingPeriod = "Month"))
+    )
+  }
+
+  test("priceData: is correct in the case of membership subscriptions [GBP], Batch2") {
+    val cohortSpec =
+      CohortSpec("Membership2023_Batch2", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 6, 1))
+
+    val account = Fixtures.accountFromJson("Membership2023/Batch1/GBP/account.json")
+    val catalogue = Fixtures.productCatalogueFromJson("Membership2023/Batch1/GBP/catalogue.json")
+    val subscription = Fixtures.subscriptionFromJson("Membership2023/Batch1/GBP/subscription.json")
+    val invoicePreview = Fixtures.invoiceListFromJson("Membership2023/Batch1/GBP/invoice-preview.json")
+
+    val priceData =
+      AmendmentData.priceData(account, catalogue, subscription, invoicePreview, LocalDate.of(2023, 1, 26), cohortSpec)
+
+    assertEquals(
+      priceData,
+      Right(PriceData(currency = "GBP", oldPrice = 5, newPrice = 7, billingPeriod = "Month"))
+    )
+  }
+
+  test("priceData: is correct in the case of membership subscriptions [AUD], Batch2") {
+    val cohortSpec =
+      CohortSpec("Membership2023_Batch2", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 6, 1))
 
     val account = Fixtures.accountFromJson("Membership2023/Batch1/AUD/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("Membership2023/Batch1/AUD/catalogue.json")


### PR DESCRIPTION
We add support for membership Batch2. The two batches are identical in structure with the exception of a month delay. Consequently the code change is trivial, but for symmetry the tests have been mirrored for Batch2, which makes most of the change.