### PR TITLE
notification lead time check during estimation step

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -101,7 +101,7 @@ object NotificationHandler extends CohortHandler {
     } else {
       ZIO.fail(
         NotificationNotEnoughLeadTimeFailure(
-          s"The start date of item ${cohortItem.subscriptionName} (startDate: ${cohortItem.startDate}) is too close to today ${today}"
+          s"[notification] The start date of item ${cohortItem.subscriptionName} (startDate: ${cohortItem.startDate}) is too close to today ${today}"
         )
       )
     }

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -19,6 +19,8 @@ case class CohortCreateFailure(reason: String) extends Failure
 case class CohortItemAlreadyPresentFailure(reason: String) extends Failure
 case class CohortUpdateFailure(reason: String) extends Failure
 
+case class EstimationNotEnoughLeadTimeFailure(reason: String) extends Failure
+
 case class ZuoraFailure(reason: String) extends Failure
 case class ZuoraFetchFailure(reason: String) extends Failure
 case class ZuoraUpdateFailure(reason: String) extends Failure

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
@@ -2,6 +2,7 @@ package pricemigrationengine.handlers
 
 import pricemigrationengine.Fixtures.{invoiceListFromJson, subscriptionFromJson}
 import pricemigrationengine.handlers.EstimationHandler.spreadEarliestStartDate
+import pricemigrationengine.handlers.NotificationHandler.thereIsEnoughNotificationLeadTime
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, NoPriceIncrease, ReadyForEstimation}
 import pricemigrationengine.model._
 import pricemigrationengine.service.{MockCohortTable, MockZuora}
@@ -211,7 +212,8 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
       )
       val cohortItemRead = CohortItem(
         subscriptionName = "S1",
-        processingStage = ReadyForEstimation
+        processingStage = ReadyForEstimation,
+        startDate = Some(LocalDate.of(2022, 6, 1))
       )
       val cohortItemExpectedToWrite = CohortItem(
         subscriptionName = "S1",
@@ -242,10 +244,12 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         result = unit
       )
       val cohortSpec = CohortSpec("Cohort1", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2022, 5, 1))
+      val today = LocalDate.of(2022, 4, 1)
       for {
         _ <- TestClock.setTime(time)
         _ <- EstimationHandler
           .estimate(productCatalogue, cohortSpec)(
+            today,
             cohortItemRead
           )
           .provide(expectedZuoraUse, expectedCohortTableUpdate)
@@ -280,7 +284,8 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
       )
       val cohortItemRead = CohortItem(
         subscriptionName = "S1",
-        processingStage = ReadyForEstimation
+        processingStage = ReadyForEstimation,
+        startDate = Some(LocalDate.of(2022, 6, 1))
       )
       val expectedSubscriptionFetch = MockZuora.FetchSubscription(
         assertion = equalTo("S1"),
@@ -310,10 +315,12 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
         result = unit
       )
       val cohortSpec = CohortSpec("Cohort1", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2022, 5, 1))
+      val today = LocalDate.of(2022, 4, 1)
       for {
         _ <- TestClock.setTime(time)
         _ <- EstimationHandler
           .estimate(productCatalogue, cohortSpec)(
+            today,
             cohortItemRead
           )
           .provide(expectedZuoraUse, expectedCohortTableUpdate)


### PR DESCRIPTION
We update the signature of the `doEstimation` function in the Estimation step to check for enough notification lead time. 

We already have a check of a sufficient notification lead time in the Notification step, but as @kelvin-chappell once observed, it is possible to set a cohort `earliestPriceMigrationStartDate` in such a way that the Estimation step will proceed fine but then the Notification step would immediately fail because the `startDate` decided during the Estimation step did not respect a sufficient lead time. 

nb 0: Note the introduction of `EstimationNotEnoughLeadTimeFailure` which duplicates `NotificationNotEnoughLeadTimeFailure`.

This problem would not happen in practice, because engine operators would be careful of setting a sufficiently large lead time at the beginning of a migration, but this PR will cause the engine to immediately fail at Estimation instead of waiting the Notification step to fail there. 

nb 1: The `thereIsEnoughNotificationLeadTime` is still defined in the Notification handler. We didn't see a need to refactor it somewhere else, although there always possibility to do that later.

nb 2: Interestingly `thereIsEnoughNotificationLeadTime` is now tested twice in the Estimation handler test suite and the Notification handler test suite. 

This was made while pairing with @SarahJessica 👏