### PR TITLE
Better implementation of Estimation lead time check

### DIFF
--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
@@ -2,7 +2,6 @@ package pricemigrationengine.handlers
 
 import pricemigrationengine.Fixtures.{invoiceListFromJson, subscriptionFromJson}
 import pricemigrationengine.handlers.EstimationHandler.spreadEarliestStartDate
-import pricemigrationengine.handlers.NotificationHandler.thereIsEnoughNotificationLeadTime
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, NoPriceIncrease, ReadyForEstimation}
 import pricemigrationengine.model._
 import pricemigrationengine.service.{MockCohortTable, MockZuora}
@@ -157,30 +156,33 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
       val invoiceList = invoiceListFromJson("NewspaperDelivery/Sixday+/InvoicePreview.json")
       val subscription = subscriptionFromJson("NewspaperDelivery/Sixday+/Subscription.json")
       val startDate = LocalDate.of(2022, 12, 14)
+      val today = LocalDate.of(2022, 1, 1)
 
       for {
         _ <- TestClock.setTime(testTime1)
-        startDate_ <- spreadEarliestStartDate(subscription, invoiceList, cohortSpec)
+        startDate_ <- spreadEarliestStartDate(subscription, invoiceList, cohortSpec, today)
       } yield assert(startDate_)(equalTo(startDate))
     },
     test("Start date is correct for subscription less than one year old (2)") {
       val invoiceList = invoiceListFromJson("NewspaperDelivery/Waitrose25%Discount/InvoicePreview.json")
       val subscription = subscriptionFromJson("NewspaperDelivery/Waitrose25%Discount/Subscription.json")
       val startDate = LocalDate.of(2023, 3, 14)
+      val today = LocalDate.of(2022, 1, 1)
 
       for {
         _ <- TestClock.setTime(testTime1)
-        startDate_ <- spreadEarliestStartDate(subscription, invoiceList, cohortSpec)
+        startDate_ <- spreadEarliestStartDate(subscription, invoiceList, cohortSpec, today)
       } yield assert(startDate_)(equalTo(startDate))
     },
     test("Start date is correct for subscription less than one year old (3)") {
       val invoiceList = invoiceListFromJson("NewspaperDelivery/Everyday/InvoicePreview.json")
       val subscription = subscriptionFromJson("NewspaperDelivery/Everyday/Subscription.json")
       val startDate = LocalDate.of(2022, 11, 14)
+      val today = LocalDate.of(2022, 1, 1)
 
       for {
         _ <- TestClock.setTime(testTime1)
-        startDate_ <- spreadEarliestStartDate(subscription, invoiceList, cohortSpec)
+        startDate_ <- spreadEarliestStartDate(subscription, invoiceList, cohortSpec, today)
       } yield assert(startDate_)(equalTo(startDate))
     },
     test("updates cohort table with EstimationComplete when data is complete") {


### PR DESCRIPTION
This PR is a refinement and better implementation of the check we installed here: https://github.com/guardian/price-migration-engine/pull/829

The original implementation mostly didn't consider that at cohort creation time the items do not yet have a `startDate`, which would lead the check to fail. 

Here we replace the check with a computation (which is a huge win). We ensure that at Estimation stage the startDate is legal (from a user notification requirement point of view), meaning sufficiently ahead in the future relatively to today, and also after the cohort's earliestPriceMigrationStartDate.

To do this we introduce `decideEarliestStartDate` which adds rationality to `spreadEarliestStartDate`, together with the help of `datesMax`. Those two functions are then what is being tested. 

(In the previous PR we had pointed out that `thereIsEnoughNotificationLeadTime` was then being tested twice. It is back being tested once as part of the Notification handler's tests. In this situation we have better computation during Estimation and the same original check during Notification, which logically makes more sense).

 