### PR TITLE
better implementation of subscription start date with random choice

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -33,13 +33,13 @@ object AmendmentData {
       catalogue: ZuoraProductCatalogue,
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,
-      earliestStartDate: LocalDate,
+      startDateLowerBound: LocalDate,
       cohortSpec: CohortSpec,
   ): Either[AmendmentDataFailure, AmendmentData] = {
     // Note: Here we are given the earliestStartDate and the cohortSpec. The earliestStartDate comes from
     // `spreadEarliestStartDate` and now overrides the cohort's earliestPriceMigrationStartDate
     for {
-      startDate <- nextServiceStartDate(invoiceList, subscription, earliestStartDate)
+      startDate <- nextServiceStartDate(invoiceList, subscription, startDateLowerBound)
       price <- priceData(account, catalogue, subscription, invoiceList, startDate, cohortSpec)
     } yield AmendmentData(startDate, priceData = price)
   }

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -19,12 +19,10 @@ object EstimationResult {
       catalogue: ZuoraProductCatalogue,
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,
-      earliestStartDate: LocalDate,
+      startDateLowerBound: LocalDate,
       cohortSpec: CohortSpec,
   ): Either[AmendmentDataFailure, SuccessfulEstimationResult] = {
-    // Note: Here we are given the earliestStartDate and the cohortSpec. The earliestStartDate comes from
-    // `spreadEarliestStartDate` and now overrides the cohort's earliestPriceMigrationStartDate
-    AmendmentData(account, catalogue, subscription, invoiceList, earliestStartDate, cohortSpec) map { amendmentData =>
+    AmendmentData(account, catalogue, subscription, invoiceList, startDateLowerBound, cohortSpec) map { amendmentData =>
       SuccessfulEstimationResult(
         subscription.subscriptionNumber,
         amendmentData.startDate,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.Fixtures
-import pricemigrationengine.handlers.EstimationHandler.{datesMax, decideEarliestStartDate}
+import pricemigrationengine.handlers.EstimationHandler.{datesMax, startDateGeneralLowerbound}
 import pricemigrationengine.model.{CohortSpec, EstimationResult, SuccessfulEstimationResult}
 import zio.test._
 
@@ -19,7 +19,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
         for {
           _ <- TestClock.setTime(testTime1)
           _ <- TestRandom.feedInts(1)
-          earliestStartDate <- EstimationHandler.spreadEarliestStartDate(
+          earliestStartDate <- EstimationHandler.decideStartDateLowerboundWithRandomAddition(
             subscription = Fixtures.subscriptionFromJson("NewspaperVoucher/QuarterlyVoucher/Subscription.json"),
             invoicePreview = Fixtures.invoiceListFromJson("NewspaperVoucher/QuarterlyVoucher/InvoicePreview.json"),
             CohortSpec("Cohort1", "Campaign1", LocalDate.of(2000, 1, 1), absoluteEarliestStartDate),
@@ -32,7 +32,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
         for {
           _ <- TestClock.setTime(testTime1)
           _ <- TestRandom.feedInts(1)
-          earliestStartDate <- EstimationHandler.spreadEarliestStartDate(
+          earliestStartDate <- EstimationHandler.decideStartDateLowerboundWithRandomAddition(
             subscription = Fixtures.subscriptionFromJson("NewspaperVoucher/Monthly/Subscription.json"),
             invoicePreview = Fixtures.invoiceListFromJson("NewspaperVoucher/Monthly/InvoicePreview.json"),
             CohortSpec("Cohort1", "Campaign1", LocalDate.of(2000, 1, 1), absoluteEarliestStartDate),
@@ -106,7 +106,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
         // (Today + 36 days) is after earliestPriceMigrationStartDate
         // The earliest start date needs to be 36 days ahead of today (35 days min time + 1) -> 2023-05-07
 
-        assertTrue(decideEarliestStartDate(cohortSpec, today) == LocalDate.of(2023, 5, 7))
+        assertTrue(startDateGeneralLowerbound(cohortSpec, today) == LocalDate.of(2023, 5, 7))
       },
       test("decideEarliestStartDate (legacy case, part 2)") {
 
@@ -118,7 +118,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
         // earliestPriceMigrationStartDate is after (today + 36 days)
         // The earliest start date can be earliestPriceMigrationStartDate
 
-        assertTrue(decideEarliestStartDate(cohortSpec, today) == cohortSpec.earliestPriceMigrationStartDate)
+        assertTrue(startDateGeneralLowerbound(cohortSpec, today) == cohortSpec.earliestPriceMigrationStartDate)
       },
       test("decideEarliestStartDate (membership)") {
 
@@ -131,7 +131,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
         // (Today + 32 days) is after earliestPriceMigrationStartDate
         // The earliest start date needs to be 32 days ahead of today -> 2023-05-05
 
-        assertTrue(decideEarliestStartDate(cohortSpec, today) == LocalDate.of(2023, 5, 3))
+        assertTrue(startDateGeneralLowerbound(cohortSpec, today) == LocalDate.of(2023, 5, 3))
       }
     )
   }


### PR DESCRIPTION
In this change we reimplement the function that was once known as `spreadEarliestStartDate`. 

First, we introduce the (mathematical) notion of *lower bound* to rename variables that were once called "earliestStartDate". The naming was confusing because it suggested that the start date had already been computed when it fact we only want to say that it needs to be after a given date. (Interestingly it was called `onOrAfter` in `nextServiceStartDate` which was the only place where it had a non confusing name).

Then the components of `spreadEarliestStartDate` have been extracted and refactored leading to the following logic. 

We start with `today` and the cohorts's `earliestPriceMigrationStartDate`. We then compute a first lower bound using 

```
startDateGeneralLowerbound
```

Which ensures that we are after `( today + min notification period)` and after the cohorts's `earliestPriceMigrationStartDate`. 

Then we use 

```
oneYearPolicy
```

to ensure that we are not price rising subscription within their first year. 

Then we compute the spread period, within which a random number will be chosen (Note that with the introduction of the membership migration, that spread period is migration, and even cohort, specific).

Having separated the application of policies from the random choice leads to a much better logic, not to mention policy components that can be individually tested. 

