### PR TITLE
checkExpirationTiming in Amendment handler

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -73,7 +73,7 @@ object AmendmentHandler extends CohortHandler {
         )
       )
 
-  private def checkExpirationTiming(
+  def checkExpirationTiming(
       item: CohortItem,
       subscription: ZuoraSubscription
   ): Either[Failure, Unit] = {

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
@@ -17,3 +17,7 @@ case class SuccessfulAmendmentResult(
 case class CancelledAmendmentResult(
     subscriptionNumber: String
 ) extends AmendmentResult
+
+case class ExpiringSubscriptionResult(
+    subscriptionNumber: String
+) extends AmendmentResult

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -43,9 +43,6 @@ object CohortItem {
   def fromNoPriceIncreaseEstimationResult(result: SuccessfulEstimationResult): UIO[CohortItem] =
     fromSuccessfulEstimationResult(result).map(_.copy(processingStage = NoPriceIncrease))
 
-  def fromCappedPriceIncreaseEstimationResult(result: SuccessfulEstimationResult): UIO[CohortItem] =
-    fromSuccessfulEstimationResult(result).map(_.copy(processingStage = CappedPriceIncrease))
-
   def fromFailedEstimationResult(result: FailedEstimationResult): CohortItem =
     CohortItem(result.subscriptionNumber, EstimationFailed)
 
@@ -63,5 +60,8 @@ object CohortItem {
     )
 
   def fromCancelledAmendmentResult(result: CancelledAmendmentResult): CohortItem =
+    CohortItem(result.subscriptionNumber, Cancelled)
+
+  def fromExpiringSubscriptionResult(result: ExpiringSubscriptionResult): CohortItem =
     CohortItem(result.subscriptionNumber, Cancelled)
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -19,16 +19,14 @@ case class CohortCreateFailure(reason: String) extends Failure
 case class CohortItemAlreadyPresentFailure(reason: String) extends Failure
 case class CohortUpdateFailure(reason: String) extends Failure
 
-case class EstimationNotEnoughLeadTimeFailure(reason: String) extends Failure
-
 case class ZuoraFailure(reason: String) extends Failure
 case class ZuoraFetchFailure(reason: String) extends Failure
 case class ZuoraUpdateFailure(reason: String) extends Failure
 
 case class AmendmentDataFailure(reason: String) extends Failure
 case class CancelledSubscriptionFailure(reason: String) extends Failure
+case class ExpiringSubscriptionFailure(reason: String) extends Failure
 
-case class SalesforceFailure(reason: String) extends Failure
 case class SalesforcePriceRiseWriteFailure(reason: String) extends Failure
 case class SalesforceClientFailure(reason: String) extends Failure
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -4,6 +4,8 @@ import pricemigrationengine.model.{ZuoraRatePlanCharge, ZuoraSubscriptionUpdate,
 
 import java.time.LocalDate
 import pricemigrationengine.Fixtures
+import pricemigrationengine.handlers.AmendmentHandler.checkExpirationTiming
+import pricemigrationengine.model.CohortTableFilter.NotificationSendDateWrittenToSalesforce
 
 class AmendmentHandlerTest extends munit.FunSuite {
   test("Membership2023 Amendment") {
@@ -110,5 +112,30 @@ class AmendmentHandlerTest extends munit.FunSuite {
         )
       )
     )
+  }
+  test("Check subscription's end date versus the cohort item's start (price increase) date") {
+    // Stage 1
+    val subscription1 = Fixtures.subscriptionFromJson("Membership2023/Batch1/GBP/subscription.json")
+    val item1 =
+      CohortItem("SUBSCRIPTION-NUMBER", NotificationSendDateWrittenToSalesforce, Some(LocalDate.of(2023, 4, 10)))
+    // subscription1.termEndDate is 2023-11-09
+    // item's startDate is LocalDate.of(2023, 4, 10)
+    // This is the good case
+    assertEquals(checkExpirationTiming(item1, subscription1), Right(()))
+
+    // Stage 2
+    val subscription2 = Fixtures.subscriptionFromJson("Membership2023/Batch1/GBP/subscription.json")
+    val item2 = CohortItem("SUBSCRIPTION-NUMBER", NotificationSendDateWrittenToSalesforce, None)
+    // item's startDate is None, this triggers the AmendmentDataFailure
+    assertEquals(checkExpirationTiming(item2, subscription2).isLeft, true)
+
+    // Stage 3
+    val subscription3 = Fixtures.subscriptionFromJson("Membership2023/Batch1/GBP/subscription.json")
+    val item3 =
+      CohortItem("SUBSCRIPTION-NUMBER", NotificationSendDateWrittenToSalesforce, Some(LocalDate.of(2024, 4, 1)))
+    // subscription3.termEndDate is 2023-11-09
+    // item's startDate is LocalDate.of(2024, 1, 1)
+    // This triggers the ExpiringSubscriptionFailure case
+    assertEquals(checkExpirationTiming(item3, subscription3).isLeft, true)
   }
 }


### PR DESCRIPTION
We have a subscription with an effective end date of `2023-04-10`, corresponding to a cohort item with a startDate of `2023-05-10`. 

<img width="1195" alt="04 Screenshot 2023-04-07 at 19 57 08" src="https://user-images.githubusercontent.com/6035518/230675272-f5746362-e35d-45c5-94a1-7b4a195f98dc.png">

<img width="597" alt="Screenshot 2023-04-07 at 21 34 11" src="https://user-images.githubusercontent.com/6035518/230675358-90281328-dfb5-4f09-868d-afe36f8126f8.png">

This caused the following error in Zuora: 

```
The Contract effective date should not be later than the term end date of the basic subscription
```

This is the result of the relevant check not having been performed during the Estimation step.

This change is the first of two changes. Here we add a check to the Amendment handler to move that item to `Cancelled` state. The next change will add that check to the Estimation handler. (We should indeed do this during Estimation to avoid unnecessarily notify the corresponding customers).

 The offending item has been put to `Cancelled` state.
  
<img width="927" alt="11 Screenshot 2023-04-07 at 21 18 36" src="https://user-images.githubusercontent.com/6035518/230675290-d1245e72-1a9c-4b80-bb5b-ef796d3c9d6a.png">

 