### PR TITLE
Allow for effective cap a bit higher than 20% on some Vouchers and GW

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -1,13 +1,11 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.handlers.NotificationHandler.minLeadTime
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model.{CohortSpec, _}
 import pricemigrationengine.services._
-import zio.{Clock, IO, Random, UIO, ZIO}
+import zio.{Clock, IO, Random, ZIO}
 
 import java.time.LocalDate
-import java.time.temporal._
 
 /** Calculates start date and new price for a set of CohortItems.
   *

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -36,8 +36,6 @@ object AmendmentData {
       startDateLowerBound: LocalDate,
       cohortSpec: CohortSpec,
   ): Either[AmendmentDataFailure, AmendmentData] = {
-    // Note: Here we are given the earliestStartDate and the cohortSpec. The earliestStartDate comes from
-    // `spreadEarliestStartDate` and now overrides the cohort's earliestPriceMigrationStartDate
     for {
       startDate <- nextServiceStartDate(invoiceList, subscription, startDateLowerBound)
       price <- priceData(account, catalogue, subscription, invoiceList, startDate, cohortSpec)
@@ -74,9 +72,6 @@ object AmendmentData {
       nextServiceStartDate: LocalDate,
       cohortSpec: CohortSpec,
   ): Either[AmendmentDataFailure, PriceData] = {
-
-    // Note: The nextServiceDate has gone through:
-    // cohortSpec.earliestPriceMigrationStartDate >> `spreadEarliestStartDate` >> `nextServiceStartDate`
 
     /*
       Date: March 2023

--- a/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
@@ -22,7 +22,7 @@ object PriceCap {
     }
   }
 
-  def priceCorrectionFactor(
+  def priceCorrectionFactorForPriceCap(
       oldPrice: BigDecimal,
       estimatedNewPrice: BigDecimal,
       forceEstimated: Boolean = false

--- a/lambda/src/test/scala/pricemigrationengine/model/PriceCapTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/PriceCapTest.scala
@@ -21,7 +21,7 @@ class PriceCapTest extends munit.FunSuite {
     val estimatedNewPrice = BigDecimal(240)
     val correctionFactor = BigDecimal(0.5)
     // The capped price is 120, half of the estimated new price, hence a correction factor of 0.5
-    assertEquals(correctionFactor, PriceCap.priceCorrectionFactor(oldPrice, estimatedNewPrice))
+    assertEquals(correctionFactor, PriceCap.priceCorrectionFactorForPriceCap(oldPrice, estimatedNewPrice))
   }
 
   test("The price correction factor is computed correctly in case of force estimated") {
@@ -29,7 +29,7 @@ class PriceCapTest extends munit.FunSuite {
     val estimatedNewPrice = BigDecimal(240)
     val correctionFactor = BigDecimal(1)
     // The capped price is 120, half of the estimated new price, hence a correction factor of 0.5
-    assertEquals(correctionFactor, PriceCap.priceCorrectionFactor(oldPrice, estimatedNewPrice, true))
+    assertEquals(correctionFactor, PriceCap.priceCorrectionFactorForPriceCap(oldPrice, estimatedNewPrice, true))
   }
 
   test("Correction factor in case of 0 estimated new price") {
@@ -37,7 +37,7 @@ class PriceCapTest extends munit.FunSuite {
     val estimatedNewPrice = BigDecimal(1)
     val correctionFactor = BigDecimal(1)
     // The correction factor in case of an estimated new price of zero is conventionally set to 1
-    assertEquals(correctionFactor, PriceCap.priceCorrectionFactor(oldPrice, estimatedNewPrice))
+    assertEquals(correctionFactor, PriceCap.priceCorrectionFactorForPriceCap(oldPrice, estimatedNewPrice))
   }
 
 }


### PR DESCRIPTION
This removes the post amendment price check which was introduced here: https://github.com/guardian/price-migration-engine/pull/781

The correction factor will still apply but starting from the estimated price that was recorded [1], and not the price we would have found if we had performed the estimation as part of the amendment step. For those items, the effective cap will be a bit higher than 20%.

This will prevent alarm fatigue and the time spent trying to manually repair those (few) Vouchers and GW subscriptions.

[1] It was the capped price for a few months, between the original implementation of capping https://github.com/guardian/price-migration-engine/pull/727 and the recent refactoring https://github.com/guardian/price-migration-engine/pull/781

### Future work

We can recover the strict 20% cap by performing an estimation as part of the amendment step.