### PR TITLE
Bring run time back to 7am

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -20,8 +20,7 @@ object NotificationHandler extends CohortHandler {
 
   // The standard notification period for letter products (where the notification is delivered by email)
   // is -49 (included) to -35 (excluded) days.
-  // During membership migration the max time has (temporarily) been set to 50.
-  val guLettersNotificationLeadTime = 50
+  val guLettersNotificationLeadTime = 49
   private val engineLettersMinNotificationLeadTime = 35
 
   // Membership migration

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -197,10 +197,9 @@ class NotificationHandlerTest extends munit.FunSuite {
     )
 
   test("guLettersNotificationLeadTime should be at least 49 days") {
-    // There is a comment at the top of the Notification handler which explains why the value 49 was chosen
-    // Here we are simply checking that it's at least 49 days (it was temporarily set to 50 day during
-    // membership migration)
-    assert(guLettersNotificationLeadTime >= 49)
+    // "Should be at least 49 days", but for invariance we test against the
+    // usual value of exactly 49
+    assert(guLettersNotificationLeadTime == 49)
   }
 
   test("NotificationHandler should get records from cohort table and SF and send Email with the data") {

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -139,8 +139,8 @@ Resources:
       - PriceMigrationLambda
     Condition: IsProd
     Properties:
-      Description: Trigger daily 10 am (UTC) kick-off of state machines for active cohorts.
-      ScheduleExpression: "cron(0 10 ? * * *)"
+      Description: Trigger daily 7 am (UTC) kick-off of state machines for active cohorts.
+      ScheduleExpression: "cron(0 7 ? * * *)"
       State: ENABLED
       Targets:
         - Arn: !GetAtt PriceMigrationLambda.Arn


### PR DESCRIPTION
### Context

When we started the membership migration, we moved the engine daily run time to 10 UTC (https://github.com/guardian/price-migration-engine/pull/820). This was to help with user engagement. 

We have recently enabled canvas email sending in membership-workflow (https://github.com/guardian/membership-workflow/pull/415 and https://github.com/guardian/membership-workflow/pull/417), and Marketing has set the region specific scheduling.

### Change

This brings the engine daily run time (all instances and all migration) back to 7am UTC.

