### PR TITLE
Bring start of membership Batch2 to -35 days

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -25,7 +25,7 @@ object NotificationHandler extends CohortHandler {
 
   // Membership migration
   // Notification period: -33 (included) to -31 (excluded) days
-  private val membershipPriceRiseNotificationLeadTime = 33
+  private val membershipPriceRiseNotificationLeadTime = 35
   private val membershipMinNotificationLeadTime = 31
 
   def maxLeadTime(cohortSpec: CohortSpec): Int = {


### PR DESCRIPTION
To prevent the start of batch 2 to fall on the Saturday of a long week end, we bring the start of the membership window to -35 days