### PR TITLE
Update estimated prices for Batch 2

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/Membership2023.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Membership2023.scala
@@ -13,10 +13,10 @@ object Membership2023 {
 
   val priceMap: Map[Currency, BigDecimal] = Map(
     "GBP" -> BigDecimal(7),
-    "AUD" -> BigDecimal(14),
-    "CAD" -> BigDecimal(9.79),
-    "EUR" -> BigDecimal(6.99),
-    "USD" -> BigDecimal(9.79),
+    "AUD" -> BigDecimal(14.99),
+    "CAD" -> BigDecimal(12.99),
+    "EUR" -> BigDecimal(9.99),
+    "USD" -> BigDecimal(9.99),
   )
 
   def priceData(

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -684,7 +684,7 @@ class AmendmentDataTest extends munit.FunSuite {
 
     assertEquals(
       priceData,
-      Right(PriceData(currency = "AUD", oldPrice = 10, newPrice = 14, billingPeriod = "Month"))
+      Right(PriceData(currency = "AUD", oldPrice = 10, newPrice = 14.99, billingPeriod = "Month"))
     )
   }
 
@@ -720,7 +720,7 @@ class AmendmentDataTest extends munit.FunSuite {
 
     assertEquals(
       priceData,
-      Right(PriceData(currency = "AUD", oldPrice = 10, newPrice = 14, billingPeriod = "Month"))
+      Right(PriceData(currency = "AUD", oldPrice = 10, newPrice = 14.99, billingPeriod = "Month"))
     )
   }
 


### PR DESCRIPTION
This brings the prices used in the estimation step in line with Zuora's updated values. 