### PR TITLE
Handle missing first name and salutation for print products

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -21,7 +21,7 @@ object NotificationHandler extends CohortHandler {
   // The standard notification period for letter products (where the notification is delivered by email)
   // is -49 (included) to -35 (excluded) days.
   val guLettersNotificationLeadTime = 49
-  private val engineLettersMinNotificationLeadTime = 35
+  private val engineLettersMinNotificationLeadTime = 30
 
   // Membership migration
   // Notification period: -33 (included) to -31 (excluded) days

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -21,7 +21,7 @@ object NotificationHandler extends CohortHandler {
   // The standard notification period for letter products (where the notification is delivered by email)
   // is -49 (included) to -35 (excluded) days.
   val guLettersNotificationLeadTime = 49
-  private val engineLettersMinNotificationLeadTime = 30
+  private val engineLettersMinNotificationLeadTime = 35
 
   // Membership migration
   // Notification period: -33 (included) to -31 (excluded) days

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -131,11 +131,7 @@ object NotificationHandler extends CohortHandler {
       _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
       contact <- SalesforceClient.getContact(sfSubscription.Buyer__c)
       firstName <- requiredField(contact.FirstName, "Contact.FirstName").orElse(
-        if (CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)) {
-          requiredField(contact.Salutation.fold(Some("Member"))(Some(_)), "Contact.Salutation")
-        } else {
-          requiredField(contact.Salutation, "Contact.Salutation")
-        }
+        requiredField(contact.Salutation.fold(Some("Member"))(Some(_)), "Contact.Salutation")
       )
       lastName <- requiredField(contact.LastName, "Contact.LastName")
       address <- targetAddress(contact)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
@@ -98,16 +98,15 @@ object EstimationHandlerTest extends ZIOSpecDefault {
       },
       test("decideEarliestStartDate (legacy case, part 1)") {
 
-        // val today = LocalDate.of(2023, 4, 1)
-        // val cohortSpec = CohortSpec("Cohort1", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2022, 5, 1))
+        val today = LocalDate.of(2023, 4, 1)
+        val cohortSpec = CohortSpec("Cohort1", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2022, 5, 1))
 
         // today is: 2023-04-01
         // The Cohort's earliestPriceMigrationStartDate is 2022-05-01
         // (Today + 36 days) is after earliestPriceMigrationStartDate
         // The earliest start date needs to be 36 days ahead of today (35 days min time + 1) -> 2023-05-07
 
-        // assertTrue(startDateGeneralLowerbound(cohortSpec, today) == LocalDate.of(2023, 5, 7))
-        assertTrue(true)
+        assertTrue(startDateGeneralLowerbound(cohortSpec, today) == LocalDate.of(2023, 5, 7))
       },
       test("decideEarliestStartDate (legacy case, part 2)") {
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
@@ -98,15 +98,16 @@ object EstimationHandlerTest extends ZIOSpecDefault {
       },
       test("decideEarliestStartDate (legacy case, part 1)") {
 
-        val today = LocalDate.of(2023, 4, 1)
-        val cohortSpec = CohortSpec("Cohort1", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2022, 5, 1))
+        // val today = LocalDate.of(2023, 4, 1)
+        // val cohortSpec = CohortSpec("Cohort1", "Campaign1", LocalDate.of(2000, 1, 1), LocalDate.of(2022, 5, 1))
 
         // today is: 2023-04-01
         // The Cohort's earliestPriceMigrationStartDate is 2022-05-01
         // (Today + 36 days) is after earliestPriceMigrationStartDate
         // The earliest start date needs to be 36 days ahead of today (35 days min time + 1) -> 2023-05-07
 
-        assertTrue(startDateGeneralLowerbound(cohortSpec, today) == LocalDate.of(2023, 5, 7))
+        // assertTrue(startDateGeneralLowerbound(cohortSpec, today) == LocalDate.of(2023, 5, 7))
+        assertTrue(true)
       },
       test("decideEarliestStartDate (legacy case, part 2)") {
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -690,17 +690,16 @@ class NotificationHandlerTest extends munit.FunSuite {
     // (We are going to use the same values for the membership migration, where we will observing that May
     // 1st will be enough, but May 5th won't)
 
-    // val itemStartDate = LocalDate.of(2023, 5, 4)
+    val itemStartDate = LocalDate.of(2023, 5, 4)
 
-    // val cohortSpec = CohortSpec("CohortName", "BrazeCampaignName", LocalDate.of(2000, 1, 1), itemStartDate)
-    // val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate))
+    val cohortSpec = CohortSpec("CohortName", "BrazeCampaignName", LocalDate.of(2000, 1, 1), itemStartDate)
+    val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate))
 
     // The two following dates are chosen to be after 1st Dec 2022, to hit the non trivial case of the check
-    // val date2 = LocalDate.of(2023, 3, 1)
-    // val date3 = LocalDate.of(2023, 4, 1)
-    // assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date2, cohortItem), true)
-    // assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date3, cohortItem), false)
-    assertEquals(true, true)
+    val date2 = LocalDate.of(2023, 3, 1)
+    val date3 = LocalDate.of(2023, 4, 1)
+    assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date2, cohortItem), true)
+    assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date3, cohortItem), false)
   }
 
   test("thereIsEnoughNotificationLeadTime behaves correctly (membership case, Batch1)") {

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -718,16 +718,17 @@ class NotificationHandlerTest extends munit.FunSuite {
     // (We are going to use the same values for the membership migration, where we will observing that May
     // 1st will be enough, but May 5th won't)
 
-    val itemStartDate = LocalDate.of(2023, 5, 4)
+    // val itemStartDate = LocalDate.of(2023, 5, 4)
 
-    val cohortSpec = CohortSpec("CohortName", "BrazeCampaignName", LocalDate.of(2000, 1, 1), itemStartDate)
-    val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate))
+    // val cohortSpec = CohortSpec("CohortName", "BrazeCampaignName", LocalDate.of(2000, 1, 1), itemStartDate)
+    // val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate))
 
     // The two following dates are chosen to be after 1st Dec 2022, to hit the non trivial case of the check
-    val date2 = LocalDate.of(2023, 3, 1)
-    val date3 = LocalDate.of(2023, 4, 1)
-    assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date2, cohortItem), true)
-    assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date3, cohortItem), false)
+    // val date2 = LocalDate.of(2023, 3, 1)
+    // val date3 = LocalDate.of(2023, 4, 1)
+    // assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date2, cohortItem), true)
+    // assertEquals(thereIsEnoughNotificationLeadTime(cohortSpec, date3, cohortItem), false)
+    assertEquals(true, true)
   }
 
   test("thereIsEnoughNotificationLeadTime behaves correctly (membership case, Batch1)") {

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -554,34 +554,6 @@ class NotificationHandlerTest extends munit.FunSuite {
   }
 
   test(
-    "NotificationHandler, in case of missing FirstName and missing Salutation, should not send an email"
-  ) {
-    val stubSalesforceClient =
-      stubSFClient(List(salesforceSubscription), List(salesforceContact.copy(FirstName = None, Salutation = None)))
-    val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
-    val stubCohortTable = createStubCohortTable(updatedResultsWrittenToCohortTable, cohortItem)
-    val sentMessages = ArrayBuffer[EmailMessage]()
-    val stubEmailSender = createStubEmailSender(sentMessages)
-
-    // Building the cohort spec with the correct campaign name
-    val cohortSpec = CohortSpec("Name", brazeCampaignName, LocalDate.of(2000, 1, 1), LocalDate.of(2023, 5, 1))
-
-    assertEquals(
-      unsafeRunSync(default)(
-        (for {
-          _ <- TestClock.setTime(currentTime)
-          program <- NotificationHandler.main(cohortSpec)
-        } yield program).provideLayer(
-          testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient ++ stubEmailSender
-        )
-      ),
-      Success(HandlerOutput(isComplete = true))
-    )
-
-    assertEquals(sentMessages.size, 0)
-  }
-
-  test(
     "NotificationHandler, if membership price rise (Batch1), in case of missing FirstMame and missing Salutation, should still send an email"
   ) {
     val stubSalesforceClient =


### PR DESCRIPTION
This brings to print products the same handling of missing first name and missing salutation (in Salesforce data) we used for membership emails. This was after noticing that an annual Guardian Weekly subscription was suffering of the same problem. 

(Interestingly that problem wasn't noticed early and only came to attention as the subscription was exiting its notification window 🤷‍♀️)