### PR TITLE
set default country for membership

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -142,7 +142,12 @@ object NotificationHandler extends CohortHandler {
           requiredField(address.street, "Contact.OtherAddress.street")
         }
       postalCode = address.postalCode.getOrElse("")
-      country <- requiredField(address.country, "Contact.OtherAddress.country")
+      country <-
+        if (CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)) {
+          requiredField(address.country.fold(Some("United Kingdom"))(Some(_)), "Contact.OtherAddress.country")
+        } else {
+          requiredField(address.country, "Contact.OtherAddress.country")
+        }
       oldPrice <- requiredField(cohortItem.oldPrice, "CohortItem.oldPrice")
       estimatedNewPrice <- requiredField(cohortItem.estimatedNewPrice, "CohortItem.estimatedNewPrice")
       startDate <- requiredField(cohortItem.startDate.map(_.toString()), "CohortItem.startDate")


### PR DESCRIPTION
After noticing that two subscriptions user data were missing it, this sets a default `country` if a user Salesforce record was missing one, but only in the case of membership. 

nb: We do not actually need the country information for sending the notification emails, those requirements are actually inherited from print products migrations. The value might still be used for canvas scheduling in Braze though, hence a well formed default instead of, say, empty string. 