### PR TITLE
add missing role to CohortTableAccessPolicy

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -101,6 +101,7 @@ Resources:
         - Ref: PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
         - Ref: PriceMigrationEngineSalesforceAmendmentUpdateLambdaRole
         - Ref: PriceMigrationEngineCohortTableDatalakeExportLambdaRole
+        - Ref: PriceMigrationEngineSubscriptionIdUploadLambdaRole
 
   PriceMigrationEngineTableCreateLambdaRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
I am trying to upload the subscriptions numbers of a new cohort. It wasn't working (numbers are not appearing in the cohort table). Interesting the engine was reporting, things like

```
Ignored A-S00612556 as already in table
```

I suspected that something was wrong and did https://github.com/guardian/price-migration-engine/pull/883 , interestingly the extra login revealed 

<img width="787" alt="Screenshot 2023-07-01 at 19 13 41" src="https://github.com/guardian/price-migration-engine/assets/6035518/5d0d2156-9e88-46ed-856b-099a9fe00801">

This change fixes the problem
