### PR TITLE
Introduce MigrationType

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -122,9 +122,13 @@ object EstimationHandler extends CohortHandler {
       invoicePreview: ZuoraInvoiceList,
       cohortSpec: CohortSpec
   ): Int = {
-    if (isMonthlySubscription(subscription, invoicePreview))
-      if (CohortSpec.isMembershipPriceRise(cohortSpec)) 1 else 3
-    else 1
+    if (isMonthlySubscription(subscription, invoicePreview)) {
+      MigrationType(cohortSpec) match {
+        case Membership2023Monthlies => 1
+        case Membership2023Annuals   => 1
+        case _                       => 3
+      }
+    } else 1
   }
 
   def decideStartDateLowerboundWithRandomAddition(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -19,28 +19,31 @@ object NotificationHandler extends CohortHandler {
   // For general information about the notification period see the docs/notification-periods.md
 
   // The standard notification period for letter products (where the notification is delivered by email)
-  // is -49 (included) to -35 (excluded) days.
-  val guLettersNotificationLeadTime = 49
-  private val engineLettersMinNotificationLeadTime = 35
+  // is -49 (included) to -35 (excluded) days. Legally the min is 30 days, but we set 35 days to alert if a
+  // subscription if exiting the notification window and needs to be investigated and repaired before the deadline
+  // of 30 days.
+
+  val letterMaxNotificationLeadTime = 49
+  private val letterMinNotificationLeadTime = 35
 
   // Membership migration
   // Notification period: -33 (included) to -31 (excluded) days
-  private val membershipPriceRiseNotificationLeadTime = 33
-  private val membershipMinNotificationLeadTime = 31
+  private val emailMaxNotificationLeadTime = 33
+  private val emailMinNotificationLeadTime = 31
 
   def maxLeadTime(cohortSpec: CohortSpec): Int = {
     if (CohortSpec.isMembershipPriceRise(cohortSpec)) {
-      membershipPriceRiseNotificationLeadTime
+      emailMaxNotificationLeadTime
     } else {
-      guLettersNotificationLeadTime
+      letterMaxNotificationLeadTime
     }
   }
 
   def minLeadTime(cohortSpec: CohortSpec): Int = {
     if (CohortSpec.isMembershipPriceRise(cohortSpec)) {
-      membershipMinNotificationLeadTime
+      emailMinNotificationLeadTime
     } else {
-      engineLettersMinNotificationLeadTime
+      letterMinNotificationLeadTime
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -90,10 +90,12 @@ object AmendmentData {
       moment, just a difference between regular price rises and membership (batch 1) will do.
      */
 
-    if (CohortSpec.isMembershipPriceRise(cohortSpec)) {
-      Membership2023.priceData(account, catalogue, subscription, invoiceList, nextServiceStartDate, cohortSpec)
-    } else {
-      priceDataWithRatePlanMatching(account, catalogue, subscription, invoiceList, nextServiceStartDate)
+    MigrationType(cohortSpec) match {
+      case Membership2023Monthlies =>
+        Membership2023.priceData(account, catalogue, subscription, invoiceList, nextServiceStartDate, cohortSpec)
+      case Membership2023Annuals =>
+        Membership2023.priceData(account, catalogue, subscription, invoiceList, nextServiceStartDate, cohortSpec)
+      case _ => priceDataWithRatePlanMatching(account, catalogue, subscription, invoiceList, nextServiceStartDate)
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/Membership2023.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Membership2023.scala
@@ -90,24 +90,24 @@ object Membership2023 {
       }
     }
 
-    if (CohortSpec.isMembershipPriceRiseMonthlies(cohortSpec)) {
-      for {
-        ratePlan <- subscriptionRatePlan(subscription)
-        ratePlanCharge <- subscriptionRatePlanCharge(subscription, ratePlan)
-        currency = ratePlanCharge.currency
-        oldPrice <- getOldPrice(subscription, ratePlanCharge)
-        newPrice <- currencyToNewPriceMonthlies(currency: String)
-      } yield PriceData(currency, oldPrice, newPrice, "Month")
-    } else if (CohortSpec.isMembershipPriceRiseAnnuals(cohortSpec)) {
-      for {
-        ratePlan <- subscriptionRatePlan(subscription)
-        ratePlanCharge <- subscriptionRatePlanCharge(subscription, ratePlan)
-        currency = ratePlanCharge.currency
-        oldPrice <- getOldPrice(subscription, ratePlanCharge)
-        newPrice <- currencyToNewPriceAnnuals(currency: String)
-      } yield PriceData(currency, oldPrice, newPrice, "Annual")
-    } else {
-      Left(AmendmentDataFailure(s"(error: 7ba45f10) Incorrect cohort spec for this function: ${cohortSpec}"))
+    MigrationType(cohortSpec) match {
+      case Membership2023Monthlies =>
+        for {
+          ratePlan <- subscriptionRatePlan(subscription)
+          ratePlanCharge <- subscriptionRatePlanCharge(subscription, ratePlan)
+          currency = ratePlanCharge.currency
+          oldPrice <- getOldPrice(subscription, ratePlanCharge)
+          newPrice <- currencyToNewPriceMonthlies(currency: String)
+        } yield PriceData(currency, oldPrice, newPrice, "Month")
+      case Membership2023Annuals =>
+        for {
+          ratePlan <- subscriptionRatePlan(subscription)
+          ratePlanCharge <- subscriptionRatePlanCharge(subscription, ratePlan)
+          currency = ratePlanCharge.currency
+          oldPrice <- getOldPrice(subscription, ratePlanCharge)
+          newPrice <- currencyToNewPriceAnnuals(currency: String)
+        } yield PriceData(currency, oldPrice, newPrice, "Annual")
+      case _ => Left(AmendmentDataFailure(s"(error: 7ba45f10) Incorrect cohort spec for this function: ${cohortSpec}"))
     }
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -1,8 +1,8 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.handlers.NotificationHandler.thereIsEnoughNotificationLeadTime
-import pricemigrationengine.handlers.NotificationHandler.guLettersNotificationLeadTime
-import pricemigrationengine.{TestLogging}
+import pricemigrationengine.handlers.NotificationHandler.letterMaxNotificationLeadTime
+import pricemigrationengine.TestLogging
 import pricemigrationengine.model.CohortTableFilter._
 import pricemigrationengine.model._
 import pricemigrationengine.model.membershipworkflow.EmailMessage
@@ -199,7 +199,7 @@ class NotificationHandlerTest extends munit.FunSuite {
   test("guLettersNotificationLeadTime should be at least 49 days") {
     // "Should be at least 49 days", but for invariance we test against the
     // usual value of exactly 49
-    assert(guLettersNotificationLeadTime == 49)
+    assert(letterMaxNotificationLeadTime == 49)
   }
 
   test("NotificationHandler should get records from cohort table and SF and send Email with the data") {


### PR DESCRIPTION
When we introduced the 2023 membership price migrations, we introduced the concept of parametrisation of basic functions with `CohortSpec`s. Back then we got away with `if (cohort detections) then  ... else (else if ...)` the existing code, but with more of such customised migrations coming, it was time for a refactoring. 

For this we introduce `sealed trait MigrationType`, leading to a much cleaner and more readable code. 

`MigrationType` does not identity a migration (Sometime several migrations map to a unique migration type, for instance both Membership 2023 Batch 1 and Batch 2 both map to type `Membership2023Monthlies`, whereas Membership 2023 Batch 3 identifies with `Membership2023Annuals`.  It simply helps identify common code used by possibly more than one migration.

All pre 2023 migrations map to type `Legacy`.