### PR TITLE
correct cohort name for supporter plus

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -105,7 +105,7 @@ object AmendmentData {
     else
       Left(
         AmendmentDataFailure(
-          s"Failed to find matching product rate plan charges for rate plan charges: ${failures.mkString(", ")}"
+          s"[AmendmentData] Failed to find matching product rate plan charges for rate plan charges: ${failures.mkString(", ")}"
         )
       )
   }

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -53,11 +53,11 @@ object SupporterPlus2023V1V2MA extends MigrationType
 
 object MigrationType {
   def apply(cohortSpec: CohortSpec): MigrationType = cohortSpec.cohortName match {
-    case "Membership2023_Batch1"    => Membership2023Monthlies
-    case "Membership2023_Batch2"    => Membership2023Monthlies
-    case "Membership2023_Batch3"    => Membership2023Annuals
-    case "SupporterRevenue2023V1V2" => SupporterPlus2023V1V2MA
-    case _                          => Legacy
+    case "Membership2023_Batch1" => Membership2023Monthlies
+    case "Membership2023_Batch2" => Membership2023Monthlies
+    case "Membership2023_Batch3" => Membership2023Annuals
+    case "SupporterPlus2023V1V2" => SupporterPlus2023V1V2MA
+    case _                       => Legacy
   }
 }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/SupporterPlus2023V1V2.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SupporterPlus2023V1V2.scala
@@ -145,7 +145,7 @@ object SupporterPlus2023V1V2 {
     else
       Left(
         AmendmentDataFailure(
-          s"Failed to find matching product rate plan charges for rate plan charges: ${failures.mkString(", ")}"
+          s"[SupporterPlus2023V1V2] Failed to find matching product rate plan charges for rate plan charges: ${failures.mkString(", ")}"
         )
       )
   }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -558,7 +558,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
     )
 
     val cohortSpec =
-      CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+      CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
     // The details of the item must match that of the estimation results in the corresponding EstimationHandlerTest
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
@@ -174,10 +174,10 @@ object EstimationHandlerTest extends ZIOSpecDefault {
 
         assertTrue(startDateGeneralLowerbound(cohortSpec, today) == LocalDate.of(2023, 5, 3))
       },
-      test("EstimationResult is correct for SupporterRevenue2023V1V2 (monthly standard)") {
+      test("EstimationResult is correct for SupporterPlus2023V1V2 (monthly standard)") {
 
         val cohortSpec =
-          CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+          CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
         val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/monthly-standard/account.json")
         val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/monthly-standard/catalogue.json")
@@ -205,10 +205,10 @@ object EstimationHandlerTest extends ZIOSpecDefault {
             )
         )
       },
-      test("EstimationResult is correct for SupporterRevenue2023V1V2 (monthly contribution)") {
+      test("EstimationResult is correct for SupporterPlus2023V1V2 (monthly contribution)") {
 
         val cohortSpec =
-          CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+          CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
         val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/monthly-contribution/account.json")
         val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/monthly-contribution/catalogue.json")
@@ -237,10 +237,10 @@ object EstimationHandlerTest extends ZIOSpecDefault {
             )
         )
       },
-      test("EstimationResult is correct for SupporterRevenue2023V1V2 (annual standard)") {
+      test("EstimationResult is correct for SupporterPlus2023V1V2 (annual standard)") {
 
         val cohortSpec =
-          CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+          CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
         val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/annual-standard/account.json")
         val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/annual-standard/catalogue.json")
@@ -268,10 +268,10 @@ object EstimationHandlerTest extends ZIOSpecDefault {
             )
         )
       },
-      test("EstimationResult is correct for SupporterRevenue2023V1V2 (annual contribution)") {
+      test("EstimationResult is correct for SupporterPlus2023V1V2 (annual contribution)") {
 
         val cohortSpec =
-          CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+          CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
         val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/annual-contribution/account.json")
         val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/annual-contribution/catalogue.json")

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -760,9 +760,9 @@ class AmendmentDataTest extends munit.FunSuite {
     )
   }
 
-  test("billing period is correct for SupporterRevenue2023V1V2 (monthly standard)") {
+  test("billing period is correct for SupporterPlus2023V1V2 (monthly standard)") {
     val cohortSpec =
-      CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+      CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
     val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/monthly-standard/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/monthly-standard/catalogue.json")
@@ -826,9 +826,9 @@ class AmendmentDataTest extends munit.FunSuite {
     )
   }
 
-  test("billing period is correct for SupporterRevenue2023V1V2 (monthly contribution)") {
+  test("billing period is correct for SupporterPlus2023V1V2 (monthly contribution)") {
     val cohortSpec =
-      CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+      CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
     val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/monthly-contribution/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/monthly-contribution/catalogue.json")
@@ -892,9 +892,9 @@ class AmendmentDataTest extends munit.FunSuite {
     )
   }
 
-  test("billing period is correct for SupporterRevenue2023V1V2 (annual standard)") {
+  test("billing period is correct for SupporterPlus2023V1V2 (annual standard)") {
     val cohortSpec =
-      CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+      CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
     val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/annual-standard/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/annual-standard/catalogue.json")
@@ -958,10 +958,10 @@ class AmendmentDataTest extends munit.FunSuite {
     )
   }
 
-  test("priceData: is correct for SupporterRevenue2023V1V2 (monthly standard)") {
+  test("priceData: is correct for SupporterPlus2023V1V2 (monthly standard)") {
 
     val cohortSpec =
-      CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+      CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
     val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/monthly-standard/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/monthly-standard/catalogue.json")
@@ -1070,10 +1070,10 @@ class AmendmentDataTest extends munit.FunSuite {
     )
   }
 
-  test("priceData: is correct for SupporterRevenue2023V1V2 (monthly contribution)") {
+  test("priceData: is correct for SupporterPlus2023V1V2 (monthly contribution)") {
 
     val cohortSpec =
-      CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+      CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
     val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/monthly-contribution/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/monthly-contribution/catalogue.json")
@@ -1182,10 +1182,10 @@ class AmendmentDataTest extends munit.FunSuite {
     )
   }
 
-  test("priceData: is correct for SupporterRevenue2023V1V2 (annual standard)") {
+  test("priceData: is correct for SupporterPlus2023V1V2 (annual standard)") {
 
     val cohortSpec =
-      CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+      CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
     val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/annual-standard/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/annual-standard/catalogue.json")
@@ -1294,10 +1294,10 @@ class AmendmentDataTest extends munit.FunSuite {
     )
   }
 
-  test("priceData: is correct for SupporterRevenue2023V1V2 (annual contribution)") {
+  test("priceData: is correct for SupporterPlus2023V1V2 (annual contribution)") {
 
     val cohortSpec =
-      CohortSpec("SupporterRevenue2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+      CohortSpec("SupporterPlus2023V1V2", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
 
     val account = Fixtures.accountFromJson("SupporterPlus2023V1V2/annual-contribution/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("SupporterPlus2023V1V2/annual-contribution/catalogue.json")


### PR DESCRIPTION
This corrects the cohort name for the supporter plus migration. It didn't show up in tests because the (wrong) cohort name in the tests matched what the MigrationType was expecting, but caused a problem when setting up with state machine with the right name  