### PR TITLE
Allow amendment for membership batch 3

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -59,14 +59,12 @@ object AmendmentHandler extends CohortHandler {
       .filterOrFail(_.status != "Cancelled")(CancelledSubscriptionFailure(item.subscriptionName))
 
   def checkExpirationTiming(
+      cohortSpec: CohortSpec,
       item: CohortItem,
       subscription: ZuoraSubscription
   ): Either[Failure, Unit] = {
-    // We check that the subscription's end of effective period is after the startDate, to avoid Zuora's error:
-    // ```
-    // The Contract effective date should not be later than the term end date of the basic subscription
-    // ```
-    // Note that this check will be duplicated in the estimation handler (this check in the Amendment handler came first)
+    // We check that the subscription's end of effective period is after the startDate, to avoid a Zuora's error
+    // Note that we do not make that check for digital products (notably: Membership2023Annuals and SupporterPlus2023V1V2MA)
 
     item.startDate match {
       case None =>
@@ -76,14 +74,21 @@ object AmendmentHandler extends CohortHandler {
           )
         ) // This case won't really happen in practice, but item.startDate is an option
       case Some(startDate) => {
-        if (subscription.termEndDate.isAfter(startDate)) {
-          Right(())
-        } else {
-          Left(
-            ExpiringSubscriptionFailure(
-              s"Cohort item: ${item.subscriptionName}. The item startDate (price increase date), ${item.startDate}, is after the subscription's end of effective period (${subscription.termEndDate.toString})"
-            )
-          )
+        MigrationType(cohortSpec) match {
+          case Membership2023Annuals =>
+            Right(())
+          case SupporterPlus2023V1V2MA =>
+            Right(())
+          case _ =>
+            if (subscription.termEndDate.isAfter(startDate)) {
+              Right(())
+            } else {
+              Left(
+                ExpiringSubscriptionFailure(
+                  s"Cohort item: ${item.subscriptionName}. The item startDate (price increase date), ${item.startDate}, is after the subscription's end of effective period (${subscription.termEndDate.toString})"
+                )
+              )
+            }
         }
       }
     }
@@ -109,7 +114,7 @@ object AmendmentHandler extends CohortHandler {
 
       subscriptionBeforeUpdate <- fetchSubscription(item)
 
-      _ <- ZIO.fromEither(checkExpirationTiming(item, subscriptionBeforeUpdate))
+      _ <- ZIO.fromEither(checkExpirationTiming(cohortSpec, item, subscriptionBeforeUpdate))
 
       account <- Zuora.fetchAccount(subscriptionBeforeUpdate.accountNumber, subscriptionBeforeUpdate.subscriptionNumber)
 
@@ -188,18 +193,14 @@ object AmendmentHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    MigrationType(input) match {
-      case Membership2023Annuals => ZIO.succeed(HandlerOutput(isComplete = true))
-      case _ =>
-        main(input).provideSome[Logging](
-          EnvConfig.cohortTable.layer,
-          EnvConfig.zuora.layer,
-          EnvConfig.stage.layer,
-          DynamoDBZIOLive.impl,
-          DynamoDBClientLive.impl,
-          CohortTableLive.impl(input),
-          ZuoraLive.impl
-        )
-    }
+    main(input).provideSome[Logging](
+      EnvConfig.cohortTable.layer,
+      EnvConfig.zuora.layer,
+      EnvConfig.stage.layer,
+      DynamoDBZIOLive.impl,
+      DynamoDBClientLive.impl,
+      CohortTableLive.impl(input),
+      ZuoraLive.impl
+    )
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -326,6 +326,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
   }
 
   test("Check subscription's end date versus the cohort item's start (price increase) date") {
+    val cohortSpec =
+      CohortSpec("NAME", "Campaign1", LocalDate.of(2023, 7, 14), LocalDate.of(2023, 8, 21))
+
     // Stage 1
     val subscription1 = Fixtures.subscriptionFromJson("Membership2023/Batch1/GBP/subscription.json")
     val item1 =
@@ -333,13 +336,13 @@ class AmendmentHandlerTest extends munit.FunSuite {
     // subscription1.termEndDate is 2023-11-09
     // item's startDate is LocalDate.of(2023, 4, 10)
     // This is the good case
-    assertEquals(checkExpirationTiming(item1, subscription1), Right(()))
+    assertEquals(checkExpirationTiming(cohortSpec, item1, subscription1), Right(()))
 
     // Stage 2
     val subscription2 = Fixtures.subscriptionFromJson("Membership2023/Batch1/GBP/subscription.json")
     val item2 = CohortItem("SUBSCRIPTION-NUMBER", NotificationSendDateWrittenToSalesforce, None)
     // item's startDate is None, this triggers the AmendmentDataFailure
-    assertEquals(checkExpirationTiming(item2, subscription2).isLeft, true)
+    assertEquals(checkExpirationTiming(cohortSpec, item2, subscription2).isLeft, true)
 
     // Stage 3
     val subscription3 = Fixtures.subscriptionFromJson("Membership2023/Batch1/GBP/subscription.json")
@@ -348,7 +351,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
     // subscription3.termEndDate is 2023-11-09
     // item's startDate is LocalDate.of(2024, 1, 1)
     // This triggers the ExpiringSubscriptionFailure case
-    assertEquals(checkExpirationTiming(item3, subscription3).isLeft, true)
+    assertEquals(checkExpirationTiming(cohortSpec, item3, subscription3).isLeft, true)
   }
 
   test("SupporterPlus2023V1V2 Amendment (monthly standard)") {


### PR DESCRIPTION
Here we allow amendment for membership batch 3 (annuals) after thorough checking that the amendment behaves correctly in prod. Note the update of `checkExpirationTiming` which no longer applies to the  two ongoing migrations to avoid subscriptions being incorrectly put in `Cancelled` state on the engine cohort table. 