### PR TITLE
Renewal before amendment when needed

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -12,7 +12,7 @@ import java.time.LocalDate
 object AmendmentHandler extends CohortHandler {
 
   // TODO: move to config
-  private val batchSize = 150
+  private val batchSize = 100
 
   private def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora, Failure, HandlerOutput] =
     for {

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -94,6 +94,17 @@ object AmendmentHandler extends CohortHandler {
     }
   }
 
+  private def renewSubscriptionIfNeeded(
+      subscription: ZuoraSubscription,
+      startDate: LocalDate
+  ): ZIO[Zuora, Failure, Unit] = {
+    if (subscription.termEndDate.isBefore(startDate)) {
+      Zuora.renewSubscription(subscription.subscriptionNumber)
+    } else {
+      ZIO.succeed(())
+    }
+  }
+
   private def doAmendment(
       cohortSpec: CohortSpec,
       catalogue: ZuoraProductCatalogue,
@@ -115,6 +126,8 @@ object AmendmentHandler extends CohortHandler {
       subscriptionBeforeUpdate <- fetchSubscription(item)
 
       _ <- ZIO.fromEither(checkExpirationTiming(cohortSpec, item, subscriptionBeforeUpdate))
+
+      _ <- renewSubscriptionIfNeeded(subscriptionBeforeUpdate, startDate)
 
       account <- Zuora.fetchAccount(subscriptionBeforeUpdate.accountNumber, subscriptionBeforeUpdate.subscriptionNumber)
 

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -22,6 +22,7 @@ case class CohortUpdateFailure(reason: String) extends Failure
 case class ZuoraFailure(reason: String) extends Failure
 case class ZuoraFetchFailure(reason: String) extends Failure
 case class ZuoraUpdateFailure(reason: String) extends Failure
+case class ZuoraRenewalFailure(reason: String) extends Failure
 
 case class AmendmentDataFailure(reason: String) extends Failure
 case class CancelledSubscriptionFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
@@ -19,6 +19,8 @@ trait Zuora {
       subscription: ZuoraSubscription,
       update: ZuoraSubscriptionUpdate
   ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId]
+
+  def renewSubscription(subscriptionNumber: String): ZIO[Any, ZuoraRenewalFailure, Unit]
 }
 
 object Zuora {
@@ -40,4 +42,7 @@ object Zuora {
       update: ZuoraSubscriptionUpdate
   ): ZIO[Zuora, ZuoraUpdateFailure, ZuoraSubscriptionId] =
     ZIO.environmentWithZIO(_.get.updateSubscription(subscription, update))
+
+  def renewSubscription(subscriptionNumber: String): ZIO[Zuora, ZuoraRenewalFailure, Unit] =
+    ZIO.environmentWithZIO(_.get.renewSubscription(subscriptionNumber))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -207,6 +207,18 @@ object ZuoraLive {
               response => response.subscriptionId
             )
           ) <* logging.info(s"Updated subscription ${subscription.subscriptionNumber} with: $update")
+
+        override def renewSubscription(subscriptionNumber: String): ZIO[Any, ZuoraRenewalFailure, Unit] =
+          retry(
+            put[Unit](
+              path = s"subscriptions/${subscriptionNumber}/renew",
+              body = "{}"
+            ).mapBoth(
+              e => ZuoraRenewalFailure(s"Failed to renew subscription number ${subscriptionNumber}"),
+              response => ()
+            )
+          ) <* logging.info(s"renewed subscription ${subscriptionNumber}")
+
       }
     )
 }

--- a/lambda/src/test/scala/pricemigrationengine/service/MockZuora.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/MockZuora.scala
@@ -16,6 +16,8 @@ object MockZuora extends Mock[Zuora] {
   object UpdateSubscription
       extends Effect[(ZuoraSubscription, ZuoraSubscriptionUpdate), ZuoraUpdateFailure, ZuoraSubscriptionId]
 
+  object RenewSubscription extends Effect[String, ZuoraRenewalFailure, Unit]
+
   val compose: URLayer[Proxy, Zuora] = ZLayer.fromZIO(ZIO.service[Proxy].map { proxy =>
     new Zuora {
 
@@ -35,6 +37,9 @@ object MockZuora extends Mock[Zuora] {
       override def updateSubscription(subscription: ZuoraSubscription, update: ZuoraSubscriptionUpdate)
           : ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId] =
         proxy(UpdateSubscription, subscription, update)
+
+      override def renewSubscription(subscriptionNumber: String): ZIO[Any, ZuoraRenewalFailure, Unit] =
+        proxy(RenewSubscription, subscriptionNumber)
     }
   })
 }


### PR DESCRIPTION
When performing the amendment step, it can happen that the startDate of the new rate plan (which is meant to coincide with the next billing operation), falls after the subscription end of term date, in which case Zuora fails the amendment with error message:

```
The Contract effective date should not be later than the term end date of the basic subscription
``` 

The solution is simply to renew the subscription before performing the amendment, which can be done using the Zuora API. 

```
curl -i -X PUT \
  'https://rest.zuora.com/v1/subscriptions/A-S00885464/renew' \
  -H 'Authorization: Bearer [removed]' \
  -H 'Content-Type: application/json' \
  -d '{}'
```

Note: I have set the batch size to 100 (from 150), after noticing that at 150 the updated lambda ran for 12 minutes, too close for comfort to the AWS 15 mins limit. 