### PR TITLE
refactoring: rename failure

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -46,7 +46,7 @@ object AmendmentHandler extends CohortHandler {
           val result = ExpiringSubscriptionResult(item.subscriptionName)
           CohortTable.update(CohortItem.fromExpiringSubscriptionResult(result)).as(result)
         }
-        case _: IncompatibleAmendmentHistory => {
+        case _: IncompatibleAmendmentHistoryFailure => {
           // See the preambule of the ZuoraSubscriptionAmendment case class for context about
           // IncompatibleAmendmentHistory
           // Note: At the moment we only have one CancelledAmendmentResult, it would be great one day

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -27,7 +27,7 @@ case class ZuoraRenewalFailure(reason: String) extends Failure
 case class AmendmentDataFailure(reason: String) extends Failure
 case class CancelledSubscriptionFailure(reason: String) extends Failure
 case class ExpiringSubscriptionFailure(reason: String) extends Failure
-case class IncompatibleAmendmentHistory(reason: String) extends Failure
+case class IncompatibleAmendmentHistoryFailure(reason: String) extends Failure
 
 case class SalesforcePriceRiseWriteFailure(reason: String) extends Failure
 case class SalesforceClientFailure(reason: String) extends Failure


### PR DESCRIPTION
Enforce the existing naming convention for failures