### PR TITLE
Activate IncompatibleAmendmentHistoryFailure

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -124,7 +124,7 @@ object AmendmentHandler extends CohortHandler {
         } else {
           ZIO.fail(
             IncompatibleAmendmentHistoryFailure(
-              s"[4f7589ea] Cohort item ${item} is being written for cancellation, during scheduled amendment, due to last amendment check failing"
+              s"[4f7589ea] Cohort item ${item} is being written for cancellation, during scheduled amendment, due to last amendment check failing; amendment: ${amendment}"
             )
           )
         }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -46,7 +46,7 @@ object AmendmentHandler extends CohortHandler {
           val result = ExpiringSubscriptionResult(item.subscriptionName)
           CohortTable.update(CohortItem.fromExpiringSubscriptionResult(result)).as(result)
         }
-        case _: IncompatibleAmendmentHistory => {
+        case _: IncompatibleAmendmentHistoryFailure => {
           // See the preambule of the ZuoraSubscriptionAmendment case class for context about
           // IncompatibleAmendmentHistory
           // Note: At the moment we only have one CancelledAmendmentResult, it would be great one day
@@ -122,13 +122,9 @@ object AmendmentHandler extends CohortHandler {
         if (amendmentIsBeforeInstant(amendment, estimationInstant)) {
           ZIO.succeed(())
         } else {
-          // ZIO.fail(
-          //  IncompatibleAmendmentHistory(
-          //    s"[4f7589ea] Cohort item ${item} is being written for cancellation, during scheduled amendment, due to last amendment check failing"
-          //  )
           ZIO.fail(
-            AmendmentDataFailure(
-              s"[77c13996] Cohort item ${item} is being written for cancellation, during scheduled amendment, due to last amendment check failing; amendment: ${amendment}"
+            IncompatibleAmendmentHistoryFailure(
+              s"[4f7589ea] Cohort item ${item} is being written for cancellation, during scheduled amendment, due to last amendment check failing"
             )
           )
         }

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -27,7 +27,7 @@ case class ZuoraRenewalFailure(reason: String) extends Failure
 case class AmendmentDataFailure(reason: String) extends Failure
 case class CancelledSubscriptionFailure(reason: String) extends Failure
 case class ExpiringSubscriptionFailure(reason: String) extends Failure
-case class IncompatibleAmendmentHistory(reason: String) extends Failure
+case class IncompatibleAmendmentHistoryFailure(reason: String) extends Failure
 
 case class SalesforcePriceRiseWriteFailure(reason: String) extends Failure
 case class SalesforceClientFailure(reason: String) extends Failure


### PR DESCRIPTION
When we introduced https://github.com/guardian/price-migration-engine/pull/925 (last amendment check), we indicated

"""
This version is going to fail noisily when the amendment condition occurs. This is on purpose. Once that happens, we will edit the check to cause the intended IncompatibleAmendmentHistoryFailure.
"""

In this PR we are applying that update.