### PR TITLE
Enforce the Migration suffix naming convention

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -170,7 +170,7 @@ object AmendmentHandler extends CohortHandler {
       update <- MigrationType(cohortSpec) match {
         case Membership2023Monthlies =>
           ZIO.fromEither(
-            Membership2023
+            Membership2023Migration
               .updateOfRatePlansToCurrent_Monthlies(
                 subscriptionBeforeUpdate,
                 invoicePreviewBeforeUpdate,
@@ -179,7 +179,7 @@ object AmendmentHandler extends CohortHandler {
           )
         case Membership2023Annuals =>
           ZIO.fromEither(
-            Membership2023
+            Membership2023Migration
               .updateOfRatePlansToCurrent_Annuals(
                 subscriptionBeforeUpdate,
                 invoicePreviewBeforeUpdate,
@@ -188,7 +188,7 @@ object AmendmentHandler extends CohortHandler {
           )
         case SupporterPlus2023V1V2MA =>
           ZIO.fromEither(
-            SupporterPlus2023V1V2
+            SupporterPlus2023V1V2Migration
               .updateOfRatePlansToCurrent(
                 item,
                 subscriptionBeforeUpdate,

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeeklyMigration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeeklyMigration.scala
@@ -22,8 +22,8 @@ object BillingPeriod extends Enumeration {
 
   We see how many days in the echo-legacy plan are currently being charged, i.e.: has a price over 0, then retrieve the corresponding rate plan for the number of days needed.
  */
-case class GuardianWeekly(productRatePlan: ZuoraProductRatePlan, chargePairs: Seq[RatePlanChargePair])
-object GuardianWeekly {
+case class GuardianWeeklyMigration(productRatePlan: ZuoraProductRatePlan, chargePairs: Seq[RatePlanChargePair])
+object GuardianWeeklyMigration {
   // we need to know:
   // billingPeriod - monthly, quarterly, annually
   // Whether it should change to Domestic or ROW
@@ -33,7 +33,7 @@ object GuardianWeekly {
       account: ZuoraAccount,
       catalogue: ZuoraProductCatalogue,
       ratePlanCharges: Seq[ZuoraRatePlanCharge]
-  ): Either[AmendmentDataFailure, GuardianWeekly] = {
+  ): Either[AmendmentDataFailure, GuardianWeeklyMigration] = {
     val billingPeriod = ratePlanCharges.head.billingPeriod match {
       case Some(value) =>
         value match {
@@ -53,7 +53,7 @@ object GuardianWeekly {
     def fetchPlan(
         currentCharges: Seq[ZuoraRatePlanCharge],
         ratePlanName: String
-    ): Either[AmendmentDataFailure, GuardianWeekly] = {
+    ): Either[AmendmentDataFailure, GuardianWeeklyMigration] = {
       val newRatePlan = guardianWeeklyRatePlans
         .find(_.name == ratePlanName)
         .find(_.productRatePlanCharges.head.billingPeriod == currentCharges.head.billingPeriod)
@@ -64,7 +64,7 @@ object GuardianWeekly {
             for ((chargeFromSub, catalogueCharge) <- currentCharges zip plan.productRatePlanCharges)
               yield RatePlanChargePair(chargeFromSub, catalogueCharge)
 
-          Right(GuardianWeekly(plan, chargePairs))
+          Right(GuardianWeeklyMigration(plan, chargePairs))
         case None =>
           Left(
             AmendmentDataFailure(
@@ -85,7 +85,7 @@ object GuardianWeekly {
     def aaaa(
         currency: Currency,
         ratePlanCharges: Seq[ZuoraRatePlanCharge]
-    ): Either[AmendmentDataFailure, GuardianWeekly] = {
+    ): Either[AmendmentDataFailure, GuardianWeeklyMigration] = {
       if (ratePlanCharges.head.currency == "USD") {
         for {
           ratePlan <-

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Membership2023Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Membership2023Migration.scala
@@ -22,7 +22,7 @@ import pricemigrationengine.model.{
 
 import java.time.LocalDate
 
-object Membership2023 {
+object Membership2023Migration {
 
   val priceMapMonthlies: Map[Currency, BigDecimal] = Map(
     "GBP" -> BigDecimal(7),

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
@@ -4,7 +4,7 @@ import pricemigrationengine.model.ZuoraProductCatalogue.{homeDeliveryRatePlans, 
 import scala.math.BigDecimal.RoundingMode
 import java.time.LocalDate
 
-object SupporterPlus2023V1V2 {
+object SupporterPlus2023V1V2Migration {
 
   val newPriceMapMonthlies: Map[Currency, BigDecimal] = Map(
     "GBP" -> BigDecimal(10),

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.model
 
-import pricemigrationengine.migrations.{GuardianWeekly, Membership2023}
+import pricemigrationengine.migrations.{GuardianWeeklyMigration, Membership2023Migration}
 import pricemigrationengine.model.ZuoraProductCatalogue.{homeDeliveryRatePlans, productPricingMap}
 
 import java.time.LocalDate
@@ -260,7 +260,7 @@ object AmendmentData {
 
       pairs <-
         if (isZoneABC)
-          GuardianWeekly.getNewRatePlanCharges(account, catalogue, ratePlanCharges).map(_.chargePairs)
+          GuardianWeeklyMigration.getNewRatePlanCharges(account, catalogue, ratePlanCharges).map(_.chargePairs)
         else ratePlanChargePairs(catalogue, ratePlanCharges)
 
       currency <- pairs.headOption
@@ -307,11 +307,25 @@ object AmendmentData {
 
     MigrationType(cohortSpec) match {
       case Membership2023Monthlies =>
-        Membership2023.priceData(account, catalogue, subscription, invoiceList, nextServiceStartDate, cohortSpec)
+        Membership2023Migration.priceData(
+          account,
+          catalogue,
+          subscription,
+          invoiceList,
+          nextServiceStartDate,
+          cohortSpec
+        )
       case Membership2023Annuals =>
-        Membership2023.priceData(account, catalogue, subscription, invoiceList, nextServiceStartDate, cohortSpec)
+        Membership2023Migration.priceData(
+          account,
+          catalogue,
+          subscription,
+          invoiceList,
+          nextServiceStartDate,
+          cohortSpec
+        )
       case SupporterPlus2023V1V2MA =>
-        SupporterPlus2023V1V2.priceData(
+        SupporterPlus2023V1V2Migration.priceData(
           account,
           catalogue,
           subscription,

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.model
 
-import pricemigrationengine.migrations.GuardianWeekly
+import pricemigrationengine.migrations.GuardianWeeklyMigration
 import pricemigrationengine.model.ChargeOverride.fromRatePlanCharge
 
 import java.time.LocalDate
@@ -112,7 +112,7 @@ object AddZuoraRatePlan {
       ratePlan: ZuoraRatePlan
   ): Either[AmendmentDataFailure, AddZuoraRatePlan] =
     for {
-      guardianWeekly <- GuardianWeekly.getNewRatePlanCharges(
+      guardianWeekly <- GuardianWeeklyMigration.getNewRatePlanCharges(
         account,
         catalogue,
         ratePlan.ratePlanCharges

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -1,11 +1,11 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.model.{ZuoraRatePlanCharge, ZuoraSubscriptionUpdate, _}
+import pricemigrationengine.model._
 
 import java.time.{LocalDate, ZoneOffset}
 import pricemigrationengine.Fixtures
 import pricemigrationengine.handlers.AmendmentHandler.amendmentIsBeforeInstant
-import pricemigrationengine.migrations.Membership2023
+import pricemigrationengine.migrations.Membership2023Migration
 import pricemigrationengine.model.CohortTableFilter.NotificationSendDateWrittenToSalesforce
 
 class AmendmentHandlerTest extends munit.FunSuite {
@@ -95,7 +95,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
       )
     )
 
-    val update = Membership2023.updateOfRatePlansToCurrent_Monthlies(
+    val update = Membership2023Migration.updateOfRatePlansToCurrent_Monthlies(
       subscription,
       invoicePreview,
       effectiveDate: LocalDate
@@ -201,7 +201,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
       )
     )
 
-    val update = Membership2023.updateOfRatePlansToCurrent_Annuals(
+    val update = Membership2023Migration.updateOfRatePlansToCurrent_Annuals(
       subscription,
       invoicePreview,
       effectiveDate: LocalDate
@@ -307,7 +307,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
       )
     )
 
-    val update = Membership2023.updateOfRatePlansToCurrent_Annuals(
+    val update = Membership2023Migration.updateOfRatePlansToCurrent_Annuals(
       subscription,
       invoicePreview,
       effectiveDate: LocalDate
@@ -422,7 +422,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingPeriod = Some("Annual")
       )
 
-    val update = SupporterPlus2023V1V2.updateOfRatePlansToCurrent(
+    val update = SupporterPlus2023V1V2Migration.updateOfRatePlansToCurrent(
       item,
       subscription,
       invoicePreview,
@@ -548,7 +548,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingPeriod = Some("Month")
       )
 
-    val update = SupporterPlus2023V1V2.updateOfRatePlansToCurrent(
+    val update = SupporterPlus2023V1V2Migration.updateOfRatePlansToCurrent(
       item,
       subscription,
       invoicePreview,
@@ -676,7 +676,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingPeriod = Some("Annual")
       )
 
-    val update = SupporterPlus2023V1V2.updateOfRatePlansToCurrent(
+    val update = SupporterPlus2023V1V2Migration.updateOfRatePlansToCurrent(
       item,
       subscription,
       invoicePreview,
@@ -794,7 +794,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingPeriod = Some("Annual")
       )
 
-    val update = SupporterPlus2023V1V2.updateOfRatePlansToCurrent(
+    val update = SupporterPlus2023V1V2Migration.updateOfRatePlansToCurrent(
       item,
       subscription,
       invoicePreview,

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -784,7 +784,7 @@ class AmendmentDataTest extends munit.FunSuite {
       )
     )
 
-    val rpcof = SupporterPlus2023V1V2.ratePlanChargesOrFail(subscription, invoiceItems)
+    val rpcof = SupporterPlus2023V1V2Migration.ratePlanChargesOrFail(subscription, invoiceItems)
     assertEquals(
       rpcof,
       Right(
@@ -812,7 +812,7 @@ class AmendmentDataTest extends munit.FunSuite {
     )
 
     val billingPeriod =
-      SupporterPlus2023V1V2.billingPeriod(
+      SupporterPlus2023V1V2Migration.billingPeriod(
         account,
         catalogue,
         subscription,
@@ -850,7 +850,7 @@ class AmendmentDataTest extends munit.FunSuite {
       )
     )
 
-    val rpcof = SupporterPlus2023V1V2.ratePlanChargesOrFail(subscription, invoiceItems)
+    val rpcof = SupporterPlus2023V1V2Migration.ratePlanChargesOrFail(subscription, invoiceItems)
     assertEquals(
       rpcof,
       Right(
@@ -878,7 +878,7 @@ class AmendmentDataTest extends munit.FunSuite {
     )
 
     val billingPeriod =
-      SupporterPlus2023V1V2.billingPeriod(
+      SupporterPlus2023V1V2Migration.billingPeriod(
         account,
         catalogue,
         subscription,
@@ -916,7 +916,7 @@ class AmendmentDataTest extends munit.FunSuite {
       )
     )
 
-    val rpcof = SupporterPlus2023V1V2.ratePlanChargesOrFail(subscription, invoiceItems)
+    val rpcof = SupporterPlus2023V1V2Migration.ratePlanChargesOrFail(subscription, invoiceItems)
     assertEquals(
       rpcof,
       Right(
@@ -944,7 +944,7 @@ class AmendmentDataTest extends munit.FunSuite {
     )
 
     val billingPeriod =
-      SupporterPlus2023V1V2.billingPeriod(
+      SupporterPlus2023V1V2Migration.billingPeriod(
         account,
         catalogue,
         subscription,
@@ -974,7 +974,7 @@ class AmendmentDataTest extends munit.FunSuite {
     // By doing so we could get a runtime error while running the tests instead of a test framework error.
     // In either case it's an error :)
 
-    val ratePlan = SupporterPlus2023V1V2.subscriptionRatePlan(subscription: ZuoraSubscription).toOption.get
+    val ratePlan = SupporterPlus2023V1V2Migration.subscriptionRatePlan(subscription: ZuoraSubscription).toOption.get
     assertEquals(
       ratePlan,
       ZuoraRatePlan(
@@ -1006,7 +1006,8 @@ class AmendmentDataTest extends munit.FunSuite {
       )
     )
 
-    val ratePlanCharges = SupporterPlus2023V1V2.subscriptionRatePlanCharges(subscription, ratePlan).toOption.get
+    val ratePlanCharges =
+      SupporterPlus2023V1V2Migration.subscriptionRatePlanCharges(subscription, ratePlan).toOption.get
     assertEquals(
       ratePlanCharges,
       List(
@@ -1037,14 +1038,14 @@ class AmendmentDataTest extends munit.FunSuite {
       "GBP"
     )
 
-    val oldPrice = SupporterPlus2023V1V2.getOldPrice(subscription, ratePlanCharges).toOption.get
+    val oldPrice = SupporterPlus2023V1V2Migration.getOldPrice(subscription, ratePlanCharges).toOption.get
     assertEquals(
       oldPrice,
       BigDecimal(10)
     )
 
     val billingP =
-      SupporterPlus2023V1V2
+      SupporterPlus2023V1V2Migration
         .billingPeriod(account, catalogue, subscription, invoicePreview, LocalDate.of(2024, 4, 1))
         .toOption
         .get
@@ -1053,7 +1054,7 @@ class AmendmentDataTest extends munit.FunSuite {
       "Month"
     )
 
-    val newPrice = SupporterPlus2023V1V2.currencyToNewPrice(billingP, currency).toOption.get
+    val newPrice = SupporterPlus2023V1V2Migration.currencyToNewPrice(billingP, currency).toOption.get
     assertEquals(
       newPrice,
       BigDecimal(10)
@@ -1086,7 +1087,7 @@ class AmendmentDataTest extends munit.FunSuite {
     // By doing so we could get a runtime error while running the tests instead of a test framework error.
     // In either case it's an error :)
 
-    val ratePlan = SupporterPlus2023V1V2.subscriptionRatePlan(subscription: ZuoraSubscription).toOption.get
+    val ratePlan = SupporterPlus2023V1V2Migration.subscriptionRatePlan(subscription: ZuoraSubscription).toOption.get
     assertEquals(
       ratePlan,
       ZuoraRatePlan(
@@ -1118,7 +1119,8 @@ class AmendmentDataTest extends munit.FunSuite {
       )
     )
 
-    val ratePlanCharges = SupporterPlus2023V1V2.subscriptionRatePlanCharges(subscription, ratePlan).toOption.get
+    val ratePlanCharges =
+      SupporterPlus2023V1V2Migration.subscriptionRatePlanCharges(subscription, ratePlan).toOption.get
     assertEquals(
       ratePlanCharges,
       List(
@@ -1149,14 +1151,14 @@ class AmendmentDataTest extends munit.FunSuite {
       "GBP"
     )
 
-    val oldPrice = SupporterPlus2023V1V2.getOldPrice(subscription, ratePlanCharges).toOption.get
+    val oldPrice = SupporterPlus2023V1V2Migration.getOldPrice(subscription, ratePlanCharges).toOption.get
     assertEquals(
       oldPrice,
       BigDecimal(25.0)
     )
 
     val billingP =
-      SupporterPlus2023V1V2
+      SupporterPlus2023V1V2Migration
         .billingPeriod(account, catalogue, subscription, invoicePreview, LocalDate.of(2023, 8, 3))
         .toOption
         .get
@@ -1165,7 +1167,7 @@ class AmendmentDataTest extends munit.FunSuite {
       "Month"
     )
 
-    val newPrice = SupporterPlus2023V1V2.currencyToNewPrice(billingP, currency).toOption.get
+    val newPrice = SupporterPlus2023V1V2Migration.currencyToNewPrice(billingP, currency).toOption.get
     assertEquals(
       newPrice,
       BigDecimal(10)
@@ -1198,7 +1200,7 @@ class AmendmentDataTest extends munit.FunSuite {
     // By doing so we could get a runtime error while running the tests instead of a test framework error.
     // In either case it's an error :)
 
-    val ratePlan = SupporterPlus2023V1V2.subscriptionRatePlan(subscription: ZuoraSubscription).toOption.get
+    val ratePlan = SupporterPlus2023V1V2Migration.subscriptionRatePlan(subscription: ZuoraSubscription).toOption.get
     assertEquals(
       ratePlan,
       ZuoraRatePlan(
@@ -1230,7 +1232,8 @@ class AmendmentDataTest extends munit.FunSuite {
       )
     )
 
-    val ratePlanCharges = SupporterPlus2023V1V2.subscriptionRatePlanCharges(subscription, ratePlan).toOption.get
+    val ratePlanCharges =
+      SupporterPlus2023V1V2Migration.subscriptionRatePlanCharges(subscription, ratePlan).toOption.get
     assertEquals(
       ratePlanCharges,
       List(
@@ -1261,14 +1264,14 @@ class AmendmentDataTest extends munit.FunSuite {
       "USD"
     )
 
-    val oldPrice = SupporterPlus2023V1V2.getOldPrice(subscription, ratePlanCharges).toOption.get
+    val oldPrice = SupporterPlus2023V1V2Migration.getOldPrice(subscription, ratePlanCharges).toOption.get
     assertEquals(
       oldPrice,
       BigDecimal(120)
     )
 
     val billingP =
-      SupporterPlus2023V1V2
+      SupporterPlus2023V1V2Migration
         .billingPeriod(account, catalogue, subscription, invoicePreview, LocalDate.of(2024, 7, 2))
         .toOption
         .get
@@ -1277,7 +1280,7 @@ class AmendmentDataTest extends munit.FunSuite {
       "Annual"
     )
 
-    val newPrice = SupporterPlus2023V1V2.currencyToNewPrice(billingP, currency).toOption.get
+    val newPrice = SupporterPlus2023V1V2Migration.currencyToNewPrice(billingP, currency).toOption.get
     assertEquals(
       newPrice,
       BigDecimal(120)
@@ -1310,7 +1313,7 @@ class AmendmentDataTest extends munit.FunSuite {
     // By doing so we could get a runtime error while running the tests instead of a test framework error.
     // In either case it's an error :)
 
-    val ratePlan = SupporterPlus2023V1V2.subscriptionRatePlan(subscription: ZuoraSubscription).toOption.get
+    val ratePlan = SupporterPlus2023V1V2Migration.subscriptionRatePlan(subscription: ZuoraSubscription).toOption.get
     assertEquals(
       ratePlan,
       ZuoraRatePlan(
@@ -1342,7 +1345,8 @@ class AmendmentDataTest extends munit.FunSuite {
       )
     )
 
-    val ratePlanCharges = SupporterPlus2023V1V2.subscriptionRatePlanCharges(subscription, ratePlan).toOption.get
+    val ratePlanCharges =
+      SupporterPlus2023V1V2Migration.subscriptionRatePlanCharges(subscription, ratePlan).toOption.get
     assertEquals(
       ratePlanCharges,
       List(
@@ -1373,14 +1377,14 @@ class AmendmentDataTest extends munit.FunSuite {
       "GBP"
     )
 
-    val oldPrice = SupporterPlus2023V1V2.getOldPrice(subscription, ratePlanCharges).toOption.get
+    val oldPrice = SupporterPlus2023V1V2Migration.getOldPrice(subscription, ratePlanCharges).toOption.get
     assertEquals(
       oldPrice,
       BigDecimal(120)
     )
 
     val billingP =
-      SupporterPlus2023V1V2
+      SupporterPlus2023V1V2Migration
         .billingPeriod(account, catalogue, subscription, invoicePreview, LocalDate.of(2024, 6, 28))
         .toOption
         .get
@@ -1389,7 +1393,7 @@ class AmendmentDataTest extends munit.FunSuite {
       "Annual"
     )
 
-    val newPrice = SupporterPlus2023V1V2.currencyToNewPrice(billingP, currency).toOption.get
+    val newPrice = SupporterPlus2023V1V2Migration.currencyToNewPrice(billingP, currency).toOption.get
     assertEquals(
       newPrice,
       BigDecimal(95)


### PR DESCRIPTION
This is the second of two preliminary refactorings as part of background work for the DigiSubs migration (first PR is here: https://github.com/guardian/price-migration-engine/pull/936)

In this case we are now enforcing the convention that Migration specific utility files/models should be suffixed with "Migration" (like we do with handlers that are all suffixed "Handler"). Will will avoid conflicting naming with elements of the `MigrationType` trait