### PR TITLE
prevent seeking amendment on subscriptions in version 1

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
@@ -7,6 +7,7 @@ import upickle.default._
 
 case class ZuoraSubscription(
     subscriptionNumber: String,
+    version: Int,
     customerAcceptanceDate: LocalDate,
     contractEffectiveDate: LocalDate,
     ratePlans: List[ZuoraRatePlan],

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
@@ -32,6 +32,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
 
   private val subscription1 = ZuoraSubscription(
     subscriptionNumber = "S1",
+    version = 4,
     accountNumber = "A9107",
     customerAcceptanceDate = LocalDate.of(2022, 1, 1),
     contractEffectiveDate = LocalDate.of(2022, 1, 1),
@@ -69,6 +70,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
 
   private val subscription2 = ZuoraSubscription(
     subscriptionNumber = "S1",
+    version = 4,
     accountNumber = "A9107",
     customerAcceptanceDate = LocalDate.of(2022, 1, 1),
     contractEffectiveDate = LocalDate.of(2022, 1, 1),


### PR DESCRIPTION
The last amendment check that was introduced here: https://github.com/guardian/price-migration-engine/pull/925 , fails when the subscription is in version 1 with the Zuora error message 

```
This is the original subscription and has no amendment
```

In this PR:
1. We expend the datatype of a subscription to specify the version
2. We prevent the {MigrationRelevanceBasedOnLastAmendment} check if the version is still 1
