### PR TITLE
Refactor BillingPeriod

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeeklyMigration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeeklyMigration.scala
@@ -11,11 +11,6 @@ import pricemigrationengine.model.{
   Currency
 }
 
-object BillingPeriod extends Enumeration {
-  type BillingPeriod = Value
-  val Month, Quarterly, Annual = Value
-}
-
 /*
   Echo Legacy rate plans have to be migrated to use newer rate plans such as Weekend, Everyday, Sixday, Saturday and Sunday.
   Migrating these is not as easy as mapping the current rateplan Id with the new one in the catalogue, so we are taking a separate approach here.

--- a/lambda/src/main/scala/pricemigrationengine/model/BillingPeriod.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/BillingPeriod.scala
@@ -1,0 +1,8 @@
+package pricemigrationengine.model
+
+trait BillingPeriod
+object Monthly extends BillingPeriod
+object Quarterly extends BillingPeriod
+object Annual extends BillingPeriod
+
+// SemiAnnual will be added when the needs for it arises


### PR DESCRIPTION
`BillingPeriod` was originally introduced during the GW migration as a utility enumeration. Here we promote it to a trait. This is done as part of the preparations for DigiSubs2023: https://github.com/guardian/price-migration-engine/pull/938 