### PR TITLE
refactor effectful code

### DIFF
--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerSpec.scala
@@ -36,9 +36,8 @@ object NotificationHandlerSpec extends ZIOSpecDefault {
         MailingAddress = Some(mailingAddress)
       )
       val cohortSpec = CohortSpec("cohortName", "BrazeCampaignName", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 1, 1))
-      NotificationHandler.targetAddress(cohortSpec, contact) map { address =>
-        assertTrue(address == mailingAddress)
-      }
+      val salesForceAddress = NotificationHandler.targetAddressE(cohortSpec, contact).toOption.get
+      assertTrue(salesForceAddress == mailingAddress)
     },
     test("should use mailing address if billing address has no city") {
       val contact = SalesforceContact(
@@ -52,9 +51,8 @@ object NotificationHandlerSpec extends ZIOSpecDefault {
         MailingAddress = Some(mailingAddress)
       )
       val cohortSpec = CohortSpec("cohortName", "BrazeCampaignName", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 1, 1))
-      NotificationHandler.targetAddress(cohortSpec, contact) map { address =>
-        assertTrue(address == mailingAddress)
-      }
+      val salesForceAddress = NotificationHandler.targetAddressE(cohortSpec, contact).toOption.get
+      assertTrue(salesForceAddress == mailingAddress)
     }
   )
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerSpec.scala
@@ -36,7 +36,7 @@ object NotificationHandlerSpec extends ZIOSpecDefault {
         MailingAddress = Some(mailingAddress)
       )
       val cohortSpec = CohortSpec("cohortName", "BrazeCampaignName", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 1, 1))
-      val salesForceAddress = NotificationHandler.targetAddressE(cohortSpec, contact).toOption.get
+      val salesForceAddress = NotificationHandler.targetAddress(cohortSpec, contact).toOption.get
       assertTrue(salesForceAddress == mailingAddress)
     },
     test("should use mailing address if billing address has no city") {
@@ -51,7 +51,7 @@ object NotificationHandlerSpec extends ZIOSpecDefault {
         MailingAddress = Some(mailingAddress)
       )
       val cohortSpec = CohortSpec("cohortName", "BrazeCampaignName", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 1, 1))
-      val salesForceAddress = NotificationHandler.targetAddressE(cohortSpec, contact).toOption.get
+      val salesForceAddress = NotificationHandler.targetAddress(cohortSpec, contact).toOption.get
       assertTrue(salesForceAddress == mailingAddress)
     }
   )


### PR DESCRIPTION
In https://github.com/guardian/price-migration-engine/pull/942 , Kelvin was suggesting a small refactoring in the notification handler. In this change, `requiredField`,  `targetAddress` are now both pure functions that return `Either[NotificationHandlerFailure, A]`.

