### PR TITLE
Update BillingPeriod

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/BillingPeriod.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/BillingPeriod.scala
@@ -19,7 +19,7 @@ object BillingPeriod {
   def fromString(period: String): BillingPeriod = {
     if (period == "Month") {
       Monthly
-    } else if (period == "Quarterly") {
+    } else if (period == "Quarterly" || period == "Quarter") {
       Quarterly
     } else if (period == "Annual") {
       Annual

--- a/lambda/src/main/scala/pricemigrationengine/model/BillingPeriod.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/BillingPeriod.scala
@@ -8,6 +8,10 @@ object Annual extends BillingPeriod
 // SemiAnnual will be added when the needs for it arises
 
 object BillingPeriod {
+
+  // Note that `toString . fromString` is not the identity function
+  // on the set { "Month", "Quarterly", "Quarter", "Annual" }
+
   def toString(period: BillingPeriod): String = {
     period match {
       case Monthly   => "Month"


### PR DESCRIPTION
The new `BillingPeriod` was introduced here: https://github.com/guardian/price-migration-engine/pull/941 , and updated here: https://github.com/guardian/price-migration-engine/pull/938/files#diff-c39a139863daeb6a47d3a42b2c6a5a3c30152f9f0c5d543861904e43d0835719, and inherited the "Quarterly" serialisation from the original code. 

Having just discovered that it also appears as "Quarter" in Zuora subscriptions

```
"billingPeriod" : "Quarter"
```

we update the `fromString` function.  Note that with this change `toString . fromString` is no longer the Identity function, on the set `{ "Month", "Quarterly", "Quarter", "Annual" }`.

This PR is preliminary of: https://github.com/guardian/price-migration-engine/pull/948 ``