### PR TITLE
Align with Zuora period descriptions

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -273,16 +273,9 @@ object NotificationHandler extends CohortHandler {
       .unit
   }
 
-  val paymentFrequencyMapping = Map(
-    "Month" -> "Monthly",
-    "Quarter" -> "Quarterly",
-    "Semi_Annual" -> "Semiannually",
-    "Annual" -> "Annually"
-  )
-
   private def paymentFrequency(billingPeriod: String) =
     ZIO
-      .fromOption(paymentFrequencyMapping.get(billingPeriod))
+      .fromOption(BillingPeriod.notificationPaymentFrequencyMapping.get(billingPeriod))
       .orElseFail(EmailSenderFailure(s"No payment frequency mapping found for billing period: $billingPeriod"))
 
   private def updateCohortItemStatus(subscriptionNumber: String, processingStage: CohortTableFilter) = {

--- a/lambda/src/main/scala/pricemigrationengine/migrations/DigiSubs2023Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/DigiSubs2023Migration.scala
@@ -236,7 +236,11 @@ object DigiSubs2023Migration {
           targetRatePlanDetails.ratePlanId,
           effectiveDate,
           List(
-            ChargeOverride(targetRatePlanDetails.ratePlanChargeId, BillingPeriod.toString(billingPeriod), newPrice)
+            ChargeOverride(
+              targetRatePlanDetails.ratePlanChargeId,
+              BillingPeriod.toString(billingPeriod),
+              newPrice
+            )
           )
         )
       ),

--- a/lambda/src/main/scala/pricemigrationengine/model/BillingPeriod.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/BillingPeriod.scala
@@ -9,13 +9,24 @@ object Annual extends BillingPeriod
 
 object BillingPeriod {
 
-  // Note that `toString . fromString` is not the identity function
-  // on the set { "Month", "Quarterly", "Quarter", "Annual" }
+  val notificationPaymentFrequencyMapping = Map(
+    // This map is used to convert a CohortItem's billingPeriod in to the user friendly representation in letters
+    // and emails.
+    "Month" -> "Monthly",
+    "Quarter" -> "Quarterly",
+    "Quarterly" -> "Quarterly",
+    "Semi_Annual" -> "Semiannually",
+    "Annual" -> "Annually"
+  )
 
   def toString(period: BillingPeriod): String = {
+    // For Zuora, the billingPeriod should be one of: Month, Quarter, Semi_Annual, Annual, Eighteen_Months,
+    // Two_Years, Three_Years, Five_Years, Specific_Months, Subscription_Term, Week, Specific_Weeks, Specific_Days
+
+    // We are only using Month, Quarter and Annual
     period match {
       case Monthly   => "Month"
-      case Quarterly => "Quarterly"
+      case Quarterly => "Quarter"
       case Annual    => "Annual"
     }
   }
@@ -24,6 +35,8 @@ object BillingPeriod {
     if (period == "Month") {
       Monthly
     } else if (period == "Quarterly" || period == "Quarter") {
+      // This function is used when reading a BillingPeriod from a CohortItem, and we have both
+      // strings, Quarterly and Quarter in the cohort tables.
       Quarterly
     } else if (period == "Annual") {
       Annual

--- a/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
@@ -323,7 +323,7 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
 
     assertEquals(
       priceData(subscription).toOption.get,
-      PriceData("GBP", BigDecimal(35.95), BigDecimal(44.94), "Quarterly")
+      PriceData("GBP", BigDecimal(35.95), BigDecimal(44.94), "Quarter")
     )
 
     assertEquals(
@@ -336,7 +336,7 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
             chargeOverrides = List(
               ChargeOverride(
                 productRatePlanChargeId = "2c92a0fb4edd70c9014edeaa4fd42186",
-                billingPeriod = "Quarterly",
+                billingPeriod = "Quarter",
                 price = BigDecimal(44.94)
               )
             )


### PR DESCRIPTION
This PR resolves a tiny confusion in the naming of billing periods (discovered when a Quarterly sub needed to be notified and amended this morning). In particular:

1. We move the `toString` function of `BillingPeriod` to generate the string Zuora expects (and in particular they will be the values used in cohort items)

2. Keep `fromString` to parse both "Quarterly" and "Quarter", as we have both variants across migrations, cohort tables

3. Refactor the notification payment frequency mapping to be in `BillingPeriod` for consistency. 