### PR TITLE
correct bug in supporter+ charge override for annuals

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
@@ -264,14 +264,14 @@ object SupporterPlus2023V1V2Migration {
     val chargeOverrides = for {
       currency <- item.currency
       price <- currencyToNewPrice("Annual", currency).toOption
-      estimatedPrice <- item.estimatedNewPrice
+      oldPrice <- item.oldPrice
     } yield {
-      if (estimatedPrice > price) {
+      if (oldPrice > price) {
         List(
           ChargeOverride(
             productRatePlanChargeId = "8a12892d85fc6df4018602451322287f", // Annual Contribution
             billingPeriod = "Annual",
-            price = estimatedPrice - price
+            price = oldPrice - price
           )
         )
       } else {

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -789,8 +789,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
         processingStage = NotificationSendDateWrittenToSalesforce,
         startDate = Some(LocalDate.of(2024, 6, 28)),
         currency = Some("GBP"),
-        oldPrice = Some(BigDecimal(120)),
-        estimatedNewPrice = Some(BigDecimal(120)),
+        oldPrice = Some(BigDecimal(120)), // Here we simulate the subscription having a £25 contribution
+        estimatedNewPrice = Some(BigDecimal(95)), // correct rate plan price for annual GBP
         billingPeriod = Some("Annual")
       )
 


### PR DESCRIPTION
When we did the supporter plus migration (https://github.com/guardian/price-migration-engine/pull/896 ), there was a tiny bug in the way the Zuora update object is computed in the case of annual subscriptions with a non trivial contribution, which due to the unusual nature of that migration wasn't even caught in the extensive tests we wrote for it. In this PR we correct it. 

Note that this code is never going to be ran again, we only correct it out of principle. The slight mispricing this caused in Zuora will be fixed separately. 

The problem was caused by comparing the estimated new price and the price from the rate plan. For that migration, and by design, the estimated new price is always equal to the price from the rate plan. Instead, we should be comparing the old price with the rate plan price. The old price can be higher than the rate plan price (the case we wanted to capture), as the old price carries the optional contribution that we want to carry over. 

It is interesting to notice that the code was actually correct for monthlies: https://github.com/guardian/price-migration-engine/blob/11e8372dc7367a1d586616139406121b5dfc9366/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala#L227 , the bug for annuals might just have been a typo that the tests didn't catch.