### PR TITLE
add originalOrderDate to case class ZuoraRatePlanCharge

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
@@ -54,7 +54,8 @@ case class ZuoraRatePlanCharge(
     billingDay: Option[String] = None,
     triggerEvent: Option[String] = None,
     triggerDate: Option[LocalDate] = None,
-    discountPercentage: Option[Double] = None
+    discountPercentage: Option[Double] = None,
+    originalOrderDate: Option[LocalDate] = None
 )
 
 object ZuoraRatePlanCharge {

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -49,7 +49,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("ContractEffective"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2016, 11, 13))
       )
     )
 
@@ -87,7 +88,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
               billingDay = Some("ChargeTriggerDay"),
               triggerEvent = Some("ContractEffective"),
               triggerDate = None,
-              discountPercentage = None
+              discountPercentage = None,
+              originalOrderDate = Some(LocalDate.of(2016, 11, 13))
             )
           ),
           lastChangeType = None
@@ -155,7 +157,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("ContractEffective"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2017, 1, 20))
       )
     )
 
@@ -193,7 +196,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
               billingDay = Some("ChargeTriggerDay"),
               triggerEvent = Some("ContractEffective"),
               triggerDate = None,
-              discountPercentage = None
+              discountPercentage = None,
+              originalOrderDate = Some(LocalDate.of(2017, 1, 20))
             )
           ),
           lastChangeType = None
@@ -261,7 +265,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("ContractEffective"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2017, 1, 20))
       )
     )
 
@@ -299,7 +304,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
               billingDay = Some("ChargeTriggerDay"),
               triggerEvent = Some("ContractEffective"),
               triggerDate = None,
-              discountPercentage = None
+              discountPercentage = None,
+              originalOrderDate = Some(LocalDate.of(2017, 1, 20))
             )
           ),
           lastChangeType = None
@@ -365,7 +371,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 4, 1))
       )
     )
 
@@ -403,7 +410,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
               billingDay = Some("ChargeTriggerDay"),
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
-              discountPercentage = None
+              discountPercentage = None,
+              originalOrderDate = Some(LocalDate.of(2023, 4, 1))
             )
           ),
           lastChangeType = Some("Add")
@@ -486,7 +494,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 7, 3))
       )
     )
 
@@ -524,7 +533,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
               billingDay = Some("ChargeTriggerDay"),
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
-              discountPercentage = None
+              discountPercentage = None,
+              originalOrderDate = Some(LocalDate.of(2023, 7, 3))
             )
           ),
           lastChangeType = None
@@ -619,7 +629,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 7, 2))
       )
     )
 
@@ -657,7 +668,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
               billingDay = Some("ChargeTriggerDay"),
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
-              discountPercentage = None
+              discountPercentage = None,
+              originalOrderDate = Some(LocalDate.of(2023, 7, 2))
             )
           ),
           lastChangeType = None
@@ -737,7 +749,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 6, 28))
       )
     )
 
@@ -775,7 +788,8 @@ class AmendmentHandlerTest extends munit.FunSuite {
               billingDay = Some("ChargeTriggerDay"),
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
-              discountPercentage = None
+              discountPercentage = None,
+              originalOrderDate = Some(LocalDate.of(2023, 6, 28))
             )
           ),
           lastChangeType = None

--- a/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
@@ -52,7 +52,8 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
             Some("ChargeTriggerDay"),
             Some("CustomerAcceptance"),
             None,
-            None
+            None,
+            originalOrderDate = Some(LocalDate.of(2016, 7, 5))
           )
         ),
         None
@@ -79,7 +80,8 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2016, 7, 5))
       )
     )
 
@@ -154,7 +156,8 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
             Some("ChargeTriggerDay"),
             Some("CustomerAcceptance"),
             None,
-            None
+            None,
+            originalOrderDate = Some(LocalDate.of(2023, 10, 3))
           )
         ),
         None
@@ -181,7 +184,8 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 10, 3))
       )
     )
 
@@ -271,22 +275,23 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         "Digital Pack Quarterly",
         List(
           ZuoraRatePlanCharge(
-            "2c92a0fb4edd70c9014edeaa4fd42186",
-            "Digital Pack Quarterly",
-            "C-00266638",
-            "GBP",
-            Some(35.95),
-            Some("Quarter"),
-            Some(LocalDate.of(2023, 11, 10)),
-            Some(LocalDate.of(2023, 8, 10)),
-            None,
-            Some("Subscription_End"),
-            None,
-            None,
-            Some("ChargeTriggerDay"),
-            Some("CustomerAcceptance"),
-            None,
-            None
+            productRatePlanChargeId = "2c92a0fb4edd70c9014edeaa4fd42186",
+            name = "Digital Pack Quarterly",
+            number = "C-00266638",
+            currency = "GBP",
+            price = Some(35.95),
+            billingPeriod = Some("Quarter"),
+            chargedThroughDate = Some(LocalDate.of(2023, 11, 10)),
+            processedThroughDate = Some(LocalDate.of(2023, 8, 10)),
+            specificBillingPeriod = None,
+            endDateCondition = Some("Subscription_End"),
+            upToPeriodsType = None,
+            upToPeriods = None,
+            billingDay = Some("ChargeTriggerDay"),
+            triggerEvent = Some("CustomerAcceptance"),
+            triggerDate = None,
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2016, 6, 16))
           )
         ),
         None
@@ -313,7 +318,8 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2016, 6, 16))
       )
     )
 
@@ -375,22 +381,23 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         "Digital Pack Annual",
         List(
           ZuoraRatePlanCharge(
-            "2c92a0fb4edd70c9014edeaa5001218c",
-            "Digital Pack Annual",
-            "C-04065127",
-            "GBP",
-            Some(119.0),
-            Some("Annual"),
-            Some(LocalDate.of(2023, 11, 17)),
-            Some(LocalDate.of(2022, 11, 17)),
-            None,
-            Some("Subscription_End"),
-            None,
-            None,
-            Some("ChargeTriggerDay"),
-            Some("CustomerAcceptance"),
-            None,
-            None
+            productRatePlanChargeId = "2c92a0fb4edd70c9014edeaa5001218c",
+            name = "Digital Pack Annual",
+            number = "C-04065127",
+            currency = "GBP",
+            price = Some(119.0),
+            billingPeriod = Some("Annual"),
+            chargedThroughDate = Some(LocalDate.of(2023, 11, 17)),
+            processedThroughDate = Some(LocalDate.of(2022, 11, 17)),
+            specificBillingPeriod = None,
+            endDateCondition = Some("Subscription_End"),
+            upToPeriodsType = None,
+            upToPeriods = None,
+            billingDay = Some("ChargeTriggerDay"),
+            triggerEvent = Some("CustomerAcceptance"),
+            triggerDate = None,
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2022, 11, 1))
           )
         ),
         None
@@ -417,7 +424,8 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 11, 1))
       )
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2024MigrationTest.scala
@@ -110,7 +110,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2016, 10, 11))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0ff560d311b0156136ba0523996",
@@ -128,7 +129,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2016, 10, 11))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0ff560d311b0156136b9fac3976",
@@ -146,7 +148,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2016, 10, 11))
       )
     )
     val ratePlan =
@@ -189,7 +192,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 6, 2))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd5614305c01561dc88f8975c8",
@@ -207,7 +211,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 6, 2))
       )
     )
     val ratePlan =
@@ -251,7 +256,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2021, 6, 28))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c6ce2ef1",
@@ -269,7 +275,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2021, 6, 28))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c6872ee9",
@@ -287,7 +294,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2021, 6, 28))
       )
     )
     val ratePlan =
@@ -331,7 +339,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 5, 29))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740d28e3024",
@@ -349,7 +358,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 5, 29))
       )
     )
     val ratePlan =
@@ -393,7 +403,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cd012f90",
@@ -411,7 +422,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cc9b2f88",
@@ -429,7 +441,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cc2c2f80",
@@ -447,7 +460,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cbb32f77",
@@ -465,7 +479,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cb4e2f6b",
@@ -483,7 +498,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
       )
     )
     val ratePlan =
@@ -527,7 +543,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c9802f59",
@@ -545,7 +562,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c91d2f4d",
@@ -563,7 +581,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c8c42f40",
@@ -581,7 +600,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c8652f37",
@@ -599,7 +619,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c80f2f26",
@@ -617,7 +638,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c7b82f1c",
@@ -635,7 +657,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
       )
     )
     val ratePlan =
@@ -679,7 +702,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 7, 19))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fe56fe33ff015709bb986636d8",
@@ -697,7 +721,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 7, 19))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd56fe26b601570432f4e33d17",
@@ -715,7 +740,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 7, 19))
       )
     )
     val ratePlan =
@@ -758,7 +784,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 9, 19))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fe56fe33ff015709bb986636d8",
@@ -776,7 +803,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 9, 19))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd56fe26b601570432f4e33d17",
@@ -794,7 +822,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 9, 19))
       )
     )
     val ratePlan =
@@ -838,7 +867,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 7, 20))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fe56fe33ff015709bb986636d8",
@@ -856,7 +886,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 7, 20))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd56fe26b601570432f4e33d17",
@@ -874,7 +905,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 7, 20))
       )
     )
     val ratePlan =
@@ -918,7 +950,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 12, 28))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fe56fe33ff015709bb986636d8",
@@ -936,7 +969,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 12, 28))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd56fe26b601570432f4e33d17",
@@ -954,7 +988,8 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         billingDay = Some("ChargeTriggerDay"),
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
-        discountPercentage = None
+        discountPercentage = None,
+        originalOrderDate = Some(LocalDate.of(2020, 12, 28))
       )
     )
     val ratePlan =

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -805,7 +805,8 @@ class AmendmentDataTest extends munit.FunSuite {
             billingDay = Some("ChargeTriggerDay"),
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
-            discountPercentage = None
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2023, 4, 1))
           )
         )
       )
@@ -871,7 +872,8 @@ class AmendmentDataTest extends munit.FunSuite {
             billingDay = Some("ChargeTriggerDay"),
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
-            discountPercentage = None
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2023, 7, 3))
           )
         )
       )
@@ -937,7 +939,8 @@ class AmendmentDataTest extends munit.FunSuite {
             billingDay = Some("ChargeTriggerDay"),
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
-            discountPercentage = None
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2023, 7, 2))
           )
         )
       )
@@ -999,7 +1002,8 @@ class AmendmentDataTest extends munit.FunSuite {
             billingDay = Some("ChargeTriggerDay"),
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
-            discountPercentage = None
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2023, 4, 1))
           )
         ),
         lastChangeType = Some("Add")
@@ -1027,7 +1031,8 @@ class AmendmentDataTest extends munit.FunSuite {
           billingDay = Some("ChargeTriggerDay"),
           triggerEvent = Some("CustomerAcceptance"),
           triggerDate = None,
-          discountPercentage = None
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2023, 4, 1))
         )
       )
     )
@@ -1112,7 +1117,8 @@ class AmendmentDataTest extends munit.FunSuite {
             billingDay = Some("ChargeTriggerDay"),
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
-            discountPercentage = None
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2023, 7, 3))
           )
         ),
         lastChangeType = None
@@ -1140,7 +1146,8 @@ class AmendmentDataTest extends munit.FunSuite {
           billingDay = Some("ChargeTriggerDay"),
           triggerEvent = Some("CustomerAcceptance"),
           triggerDate = None,
-          discountPercentage = None
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2023, 7, 3))
         )
       )
     )
@@ -1225,7 +1232,8 @@ class AmendmentDataTest extends munit.FunSuite {
             billingDay = Some("ChargeTriggerDay"),
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
-            discountPercentage = None
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2023, 7, 2))
           )
         ),
         None
@@ -1253,7 +1261,8 @@ class AmendmentDataTest extends munit.FunSuite {
           billingDay = Some("ChargeTriggerDay"),
           triggerEvent = Some("CustomerAcceptance"),
           triggerDate = None,
-          discountPercentage = None
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2023, 7, 2))
         )
       )
     )
@@ -1338,7 +1347,8 @@ class AmendmentDataTest extends munit.FunSuite {
             billingDay = Some("ChargeTriggerDay"),
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
-            discountPercentage = None
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2023, 6, 28))
           )
         ),
         None
@@ -1366,7 +1376,8 @@ class AmendmentDataTest extends munit.FunSuite {
           billingDay = Some("ChargeTriggerDay"),
           triggerEvent = Some("CustomerAcceptance"),
           triggerDate = None,
-          discountPercentage = None
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2023, 6, 28))
         )
       )
     )


### PR DESCRIPTION
Done work in collaboration with @LAKSHMIRPILLAI  and @graham228221 ✨

As part of on going work (refactoring the way the engine decides whether to put a cohort item in cancelled state), we would like a way to attribute an affective date to a rate plan.

The Zuora documentation and our tests show that rate plans themselves to not carry dating information. Moreover the Zuora [documentation](https://developer.zuora.com/api-references/api/operation/GET_SubscriptionsByKey/) is also very unclear about the reponses to the `GET_SubscriptionsByKey` operation and notably the keys of a rate plan charge. In particular they do not mention the key `originalOrderDate` which shows up when we manually query subscriptions. 

To test whether or not we could rely on that key, we tested a large number of subscriptions. We downloaded 1012 subscriptions from Zuora, which yielded 11853 rate plans and 23013 rate plan charges, and 100% of them had a `originalOrderDate` field set.

Considering the above results, the chosen way to attribute a date to a rate plan will be to read the `originalOrderDate` field of any (the first) rate plan charge of the rate plan. (This will be implemented in a coming PR).

This change adds the 

```
originalOrderDate: Option[LocalDate] = None
```

field to the `ZuoraRatePlanCharge` case class.

This caused a lot of tests to have to be updated as we are reading from stored fixtures, causing previously unread `originalOrderDate` to be parsed.
