### PR TITLE
add cancellation reason to cohort item

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -40,7 +40,11 @@ object AmendmentHandler extends CohortHandler {
           // Although it was given to us as a failure of `doAmendment`, the only effect of the database update, if it
           // is not recorded as a failure of `amend`, is to allow the processing to continue.
           val result = CancelledAmendmentResult(item.subscriptionName)
-          CohortTable.update(CohortItem.fromCancelledAmendmentResult(result)).as(result)
+          CohortTable
+            .update(
+              CohortItem.fromCancelledAmendmentResult(result, "(cause: 99727bf9) subscription was cancelled in Zuora")
+            )
+            .as(result)
         }
         case _: ExpiringSubscriptionFailure => {
           // `ExpiringSubscriptionFailure` happens when the subscription's end of effective period is before the

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -82,7 +82,8 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
           cohortItem.whenAmendmentDone.getOrElse(""),
           cohortItem.whenNotificationSent.getOrElse(""),
           cohortItem.whenNotificationSentWrittenToSalesforce.getOrElse(""),
-          cohortItem.whenAmendmentWrittenToSalesforce.getOrElse("")
+          cohortItem.whenAmendmentWrittenToSalesforce.getOrElse(""),
+          cohortItem.cancellationReason.getOrElse("")
         )
       )
       .mapError(ex => CohortTableDatalakeExportFailure(s"Failed to write CohortItem as CSV to s3: ${ex.getMessage}"))
@@ -107,7 +108,8 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
         "when_amendment_done",
         "when_notification_sent",
         "when_notification_sent_written_to_salesforce",
-        "when_amendment_written_to_salesforce"
+        "when_amendment_written_to_salesforce",
+        "cancellation_reason"
       )
     )
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -172,7 +172,14 @@ object NotificationHandler extends CohortHandler {
       case ShouldProceed => ZIO.succeed(())
       case ShouldCancel => {
         val result = CancelledAmendmentResult(item.subscriptionName)
-        ZIO.succeed(CohortTable.update(CohortItem.fromCancelledAmendmentResult(result)).as(result))
+        ZIO.succeed(
+          CohortTable
+            .update(
+              CohortItem
+                .fromCancelledAmendmentResult(result, "(cause: f5c291b0) Subscription was cancelled by RateplansProbe")
+            )
+            .as(result)
+        )
       }
       case IndeterminateConclusion =>
         ZIO.fail(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -176,7 +176,7 @@ object NotificationHandler extends CohortHandler {
           CohortTable
             .update(
               CohortItem
-                .fromCancelledAmendmentResult(result, "(cause: f5c291b0) Subscription was cancelled by RateplansProbe")
+                .fromCancelledAmendmentResult(result, "(cause: f5c291b0) Migration cancelled by RateplansProbe")
             )
             .as(result)
         )

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -21,7 +21,8 @@ case class CohortItem(
     whenAmendmentDone: Option[Instant] = None,
     whenNotificationSent: Option[Instant] = None,
     whenNotificationSentWrittenToSalesforce: Option[Instant] = None,
-    whenAmendmentWrittenToSalesforce: Option[Instant] = None
+    whenAmendmentWrittenToSalesforce: Option[Instant] = None,
+    cancellationReason: Option[String] = None
 )
 
 object CohortItem {
@@ -59,8 +60,12 @@ object CohortItem {
       whenAmendmentDone = Some(result.whenDone)
     )
 
-  def fromCancelledAmendmentResult(result: CancelledAmendmentResult): CohortItem =
-    CohortItem(result.subscriptionNumber, Cancelled)
+  def fromCancelledAmendmentResult(result: CancelledAmendmentResult, reason: String): CohortItem =
+    CohortItem(
+      result.subscriptionNumber,
+      processingStage = Cancelled,
+      cancellationReason = Some(reason)
+    )
 
   def fromExpiringSubscriptionResult(result: ExpiringSubscriptionResult): CohortItem =
     CohortItem(result.subscriptionNumber, Cancelled)

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -30,8 +30,9 @@ object CohortTableFilter {
   }
 
   /*
-   * Status of a sub that has been cancelled since the price migration process began,
-   * so is ineligible for further processing.
+   * Status of a sub that has been cancelled since the price migration process began, or has
+   * undergone some amendments in Zuora that are incompatible with the price rise.
+   * We mark it as ineligible for further processing.
    */
   case object Cancelled extends CohortTableFilter { override val value: String = "Cancelled" }
 

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTable.scala
@@ -19,7 +19,7 @@ trait CohortTable {
 
   def create(cohortItem: CohortItem): IO[Failure, Unit]
 
-  def update(result: CohortItem): IO[CohortUpdateFailure, Unit]
+  def update(cohortItem: CohortItem): IO[CohortUpdateFailure, Unit]
 }
 
 object CohortTable {
@@ -36,6 +36,6 @@ object CohortTable {
   def create(subscription: CohortItem): ZIO[CohortTable, Failure, Unit] =
     ZIO.environmentWithZIO(_.get.create(subscription))
 
-  def update(result: CohortItem): ZIO[CohortTable, CohortUpdateFailure, Unit] =
-    ZIO.environmentWithZIO(_.get.update(result))
+  def update(cohortItem: CohortItem): ZIO[CohortTable, CohortUpdateFailure, Unit] =
+    ZIO.environmentWithZIO(_.get.update(cohortItem))
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -86,7 +86,8 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
       whenAmendmentDone = Some(Instant.parse("2020-01-03T01:01:01Z")),
       whenNotificationSent = Some(Instant.parse("2020-01-04T01:01:01Z")),
       whenNotificationSentWrittenToSalesforce = Some(Instant.parse("2020-01-05T01:01:01Z")),
-      whenAmendmentWrittenToSalesforce = Some(Instant.parse("2020-01-06T01:01:01Z"))
+      whenAmendmentWrittenToSalesforce = Some(Instant.parse("2020-01-06T01:01:01Z")),
+      cancellationReason = Some("reason")
     )
 
     val stubCohortTable = createStubCohortTable(List(cohortItem))
@@ -108,8 +109,8 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
     assertEquals(s3ExportBucketName, actualS3Location.bucket)
     assertEquals(s"data/${cohortName}.csv", actualS3Location.key)
     assertEquals(
-      """"cohort_name","subscription_name","processing_stage","start_date","currency","old_price","estimated_new_price","billing_period","when_estimation_done","salesforce_price_rise_id","when_sf_show_estimate","new_price","new_subscription_id","when_amendment_done","when_notification_sent","when_notification_sent_written_to_salesforce","when_amendment_written_to_salesforce"
-        |"expected cohort name","subscription 1","NotificationSendComplete","2020-01-01","USD","1.0","2.0","quarter","2020-01-01T01:01:01Z","salesForcePriceRiseId1","2020-01-02T01:01:01Z","3.0","zuoraSubId1","2020-01-03T01:01:01Z","2020-01-04T01:01:01Z","2020-01-05T01:01:01Z","2020-01-06T01:01:01Z"""".stripMargin,
+      """"cohort_name","subscription_name","processing_stage","start_date","currency","old_price","estimated_new_price","billing_period","when_estimation_done","salesforce_price_rise_id","when_sf_show_estimate","new_price","new_subscription_id","when_amendment_done","when_notification_sent","when_notification_sent_written_to_salesforce","when_amendment_written_to_salesforce","cancellation_reason"
+        |"expected cohort name","subscription 1","NotificationSendComplete","2020-01-01","USD","1.0","2.0","quarter","2020-01-01T01:01:01Z","salesForcePriceRiseId1","2020-01-02T01:01:01Z","3.0","zuoraSubId1","2020-01-03T01:01:01Z","2020-01-04T01:01:01Z","2020-01-05T01:01:01Z","2020-01-06T01:01:01Z","reason"""".stripMargin,
       actualFileContents
     )
   }
@@ -143,8 +144,8 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
     assertEquals(s3ExportBucketName, actualS3Location.bucket)
     assertEquals(s"data/${cohortName}.csv", actualS3Location.key)
     assertEquals(
-      """"cohort_name","subscription_name","processing_stage","start_date","currency","old_price","estimated_new_price","billing_period","when_estimation_done","salesforce_price_rise_id","when_sf_show_estimate","new_price","new_subscription_id","when_amendment_done","when_notification_sent","when_notification_sent_written_to_salesforce","when_amendment_written_to_salesforce"
-        |"expected cohort name","subscription 2","ReadyForEstimation","","","","","","","","","","","","","",""""".stripMargin,
+      """"cohort_name","subscription_name","processing_stage","start_date","currency","old_price","estimated_new_price","billing_period","when_estimation_done","salesforce_price_rise_id","when_sf_show_estimate","new_price","new_subscription_id","when_amendment_done","when_notification_sent","when_notification_sent_written_to_salesforce","when_amendment_written_to_salesforce","cancellation_reason"
+        |"expected cohort name","subscription 2","ReadyForEstimation","","","","","","","","","","","","","","",""""".stripMargin,
       actualFileContents
     )
   }


### PR DESCRIPTION
As a follow up of the work we did to redesign the process by which a cohort item can be removed from price rise (meaning put in `Cancelled` processing stage in the engine's Dynamo table), the next step is now to expand the definition of a Cohort Item by adding the optional `cancellationReason` field.

This is a relatively simple process because of the schema-less nature of Dynamo (things would have required a database table definition update if we were using SQL databases)

Although the field is optional, the function `fromCancelledAmendmentResult` is set with a mandatory `reason` field, this will ensure that future cancellations are always given a reason. 

This has also shown that there are now only two reasons why a cohort item can ever be cancelled in the engine: if the corresponding subscription was cancelled in Zuora or if `RateplansProbe.probe` returns the `ShouldCancel` variant of `RateplansProbeResult`, which is exactly what we want.

Note: The files that are generated and sent to the lake have also been extended. 