### PR TITLE
Capture Zuora cancellations in the Estimation Handler

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -47,7 +47,7 @@ object EstimationHandler extends CohortHandler {
           CohortTable.update(CohortItem.fromFailedEstimationResult(result)).as(result)
         case _: CancelledSubscriptionFailure =>
           val result = CancelledEstimationResult(item.subscriptionName)
-          CohortTable.update(CohortItem.fromCancelledEstimationResult(result)).as(result)
+          CohortTable.update(CohortItem.fromCancelledEstimationResult(result,s"(reason: b6829dd30) subscription ${item.subscriptionName} has been cancelled in Zuora")).as(result)
         case e => ZIO.fail(e)
       },
       success = { result =>

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -47,7 +47,14 @@ object EstimationHandler extends CohortHandler {
           CohortTable.update(CohortItem.fromFailedEstimationResult(result)).as(result)
         case _: CancelledSubscriptionFailure =>
           val result = CancelledEstimationResult(item.subscriptionName)
-          CohortTable.update(CohortItem.fromCancelledEstimationResult(result,s"(reason: b6829dd30) subscription ${item.subscriptionName} has been cancelled in Zuora")).as(result)
+          CohortTable
+            .update(
+              CohortItem.fromCancelledEstimationResult(
+                result,
+                s"(reason: b6829dd30) subscription ${item.subscriptionName} has been cancelled in Zuora"
+              )
+            )
+            .as(result)
         case e => ZIO.fail(e)
       },
       success = { result =>

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -47,7 +47,7 @@ object CohortItem {
   def fromFailedEstimationResult(result: FailedEstimationResult): CohortItem =
     CohortItem(result.subscriptionNumber, EstimationFailed)
 
-  def fromCancelledEstimationResult(result: CancelledEstimationResult , reason:String): CohortItem =
+  def fromCancelledEstimationResult(result: CancelledEstimationResult, reason: String): CohortItem =
     CohortItem(result.subscriptionNumber, processingStage = Cancelled, cancellationReason = Some(reason))
 
   def fromSuccessfulAmendmentResult(result: SuccessfulAmendmentResult): CohortItem =

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -47,8 +47,8 @@ object CohortItem {
   def fromFailedEstimationResult(result: FailedEstimationResult): CohortItem =
     CohortItem(result.subscriptionNumber, EstimationFailed)
 
-  def fromCancelledEstimationResult(result: CancelledEstimationResult): CohortItem =
-    CohortItem(result.subscriptionNumber, Cancelled)
+  def fromCancelledEstimationResult(result: CancelledEstimationResult , reason:String): CohortItem =
+    CohortItem(result.subscriptionNumber, processingStage = Cancelled, cancellationReason = Some(reason))
 
   def fromSuccessfulAmendmentResult(result: SuccessfulAmendmentResult): CohortItem =
     CohortItem(


### PR DESCRIPTION
Update the Estimation Handler to provide a reason when it cancels a cohort item, corresponding to subscription cancelled in Zuora