### PR TITLE
Introduce new SalesforcePriceRise fields

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -14,7 +14,7 @@ import pricemigrationengine.migrations.newspaper2024Migration
 object AmendmentHandler extends CohortHandler {
 
   // TODO: move to config
-  private val batchSize = 100
+  private val batchSize = 50
 
   private def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora, Failure, HandlerOutput] = {
     for {

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -11,14 +11,15 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
 
   // TODO: move to config
   private val batchSize = 2000
-
-  private val main: ZIO[CohortTable with SalesforceClient with Logging, Failure, HandlerOutput] =
+  private def main(
+      cohortSpec: CohortSpec
+  ): ZIO[CohortTable with SalesforceClient with Logging, Failure, HandlerOutput] =
     for {
       count <- CohortTable
         .fetch(AmendmentComplete, None)
         .take(batchSize)
         .mapZIO(item =>
-          updateSfWithNewSubscriptionId(item).tapBoth(
+          updateSfWithNewSubscriptionId(cohortSpec, item).tapBoth(
             e => Logging.error(s"Failed to update price rise record for ${item.subscriptionName}: $e"),
             _ => Logging.info(s"Amendment of ${item.subscriptionName} recorded in Salesforce")
           )
@@ -27,10 +28,11 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
     } yield HandlerOutput(isComplete = count < batchSize)
 
   private def updateSfWithNewSubscriptionId(
+      cohortSpec: CohortSpec,
       item: CohortItem
   ): ZIO[CohortTable with SalesforceClient with Logging, Failure, Unit] =
     for {
-      priceRise <- ZIO.fromEither(buildPriceRise(item))
+      priceRise <- ZIO.fromEither(buildPriceRise(cohortSpec, item))
       salesforcePriceRiseId <-
         ZIO
           .fromOption(item.salesforcePriceRiseId)
@@ -49,14 +51,22 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
     } yield ()
 
   private def buildPriceRise(
+      cohortSpec: CohortSpec,
       cohortItem: CohortItem
   ): Either[SalesforcePriceRiseWriteFailure, SalesforcePriceRise] =
     cohortItem.newSubscriptionId
-      .map(newSubscriptionId => SalesforcePriceRise(Amended_Zuora_Subscription_Id__c = Some(newSubscriptionId)))
+      .map(newSubscriptionId =>
+        SalesforcePriceRise(
+          Amended_Zuora_Subscription_Id__c = Some(newSubscriptionId),
+          Migration_Name__c = Some(cohortSpec.cohortName),
+          Migration_Status__c = Some("AmendmentComplete"),
+          Cancellation_Reason__c = None
+        )
+      )
       .toRight(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have a newSubscriptionId field"))
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
-    main.provideSome[Logging](
+    main(input).provideSome[Logging](
       EnvConfig.cohortTable.layer,
       EnvConfig.salesforce.layer,
       EnvConfig.stage.layer,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -95,7 +95,10 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
         Some(oldPrice),
         Some(PriceCap(oldPrice, estimatedNewPrice, forceEstimated)),
         Some(priceRiseDate),
-        Some(subscription.Id)
+        Some(subscription.Id),
+        Migration_Name__c = Some(cohortSpec.cohortName),
+        Migration_Status__c = Some("EstimationComplete"),
+        Cancellation_Reason__c = None
       )
     }
   }

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
@@ -10,5 +10,10 @@ case class SalesforcePriceRise(
     Price_Rise_Date__c: Option[LocalDate] = None,
     SF_Subscription__c: Option[String] = None,
     Date_Letter_Sent__c: Option[LocalDate] = None,
-    Amended_Zuora_Subscription_Id__c: Option[ZuoraSubscriptionId] = None
+    Amended_Zuora_Subscription_Id__c: Option[ZuoraSubscriptionId] = None,
+    Migration_Name__c: Option[String],
+    Migration_Status__c: Option[
+      String
+    ], // The processing state of the cohort item at time of salesforce notification, including Cancellation
+    Cancellation_Reason__c: Option[String]
 )

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
@@ -12,8 +12,13 @@ case class SalesforcePriceRise(
     Date_Letter_Sent__c: Option[LocalDate] = None,
     Amended_Zuora_Subscription_Id__c: Option[ZuoraSubscriptionId] = None,
     Migration_Name__c: Option[String],
-    Migration_Status__c: Option[
-      String
-    ], // The processing state of the cohort item at time of salesforce notification, including Cancellation
+    Migration_Status__c: Option[String], // [1]
     Cancellation_Reason__c: Option[String]
 )
+
+// [1] The processing state of the cohort item at time of salesforce notification
+//     and "Cancellation", if the item is bout to or has been cancelled.
+
+// Note that Cancellation_Reason__c should remain withing 255 chars. This is a limitation
+// imposed by Salesforce which came during the initial
+// integration: https://github.com/guardian/salesforce/pull/976

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -81,6 +81,9 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
     val stubSalesforceClient = stubSFClient(updatedPriceRises)
     val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
 
+    val cohortSpec: CohortSpec =
+      CohortSpec("cohortName", "brazeCampaignName", LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 1), None)
+
     val cohortItem = CohortItem(
       subscriptionName = subscriptionName,
       processingStage = NotificationSendComplete,
@@ -94,7 +97,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
       unsafeRunSync(default)(
         (for {
           _ <- TestClock.setTime(currentTime)
-          program <- SalesforceNotificationDateUpdateHandler.main
+          program <- SalesforceNotificationDateUpdateHandler.main(cohortSpec)
         } yield program).provideLayer(
           testEnvironment ++ TestLogging.logging ++ stubCohortTable ++ stubSalesforceClient
         )

--- a/lambda/src/test/scala/pricemigrationengine/service/SalesforceClientLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/SalesforceClientLiveTest.scala
@@ -16,7 +16,10 @@ class SalesforceClientLiveTest extends munit.FunSuite {
           Guardian_Weekly_New_Price__c = Some(1.99),
           Price_Rise_Date__c = Some(LocalDate.of(2020, 1, 1)),
           SF_Subscription__c = Some("subscriptionId"),
-          Date_Letter_Sent__c = Some(LocalDate.of(2020, 1, 2))
+          Date_Letter_Sent__c = Some(LocalDate.of(2020, 1, 2)),
+          Migration_Name__c = Some("cohortName"),
+          Migration_Status__c = Some("EstimationComplete"),
+          Cancellation_Reason__c = None
         )
       ),
       """{
@@ -26,7 +29,10 @@ class SalesforceClientLiveTest extends munit.FunSuite {
         |  "Guardian_Weekly_New_Price__c": "1.99",
         |  "Price_Rise_Date__c": "2020-01-01",
         |  "SF_Subscription__c": "subscriptionId",
-        |  "Date_Letter_Sent__c": "2020-01-02"
+        |  "Date_Letter_Sent__c": "2020-01-02",
+        |  "Migration_Name__c": "cohortName",
+        |  "Migration_Status__c": "EstimationComplete",
+        |  "Cancellation_Reason__c": null
         |}""".stripMargin
     )
   }
@@ -34,11 +40,17 @@ class SalesforceClientLiveTest extends munit.FunSuite {
     assertEquals(
       SalesforceClientLive.serialisePriceRise(
         SalesforcePriceRise(
-          Date_Letter_Sent__c = Some(LocalDate.of(2020, 1, 2))
+          Date_Letter_Sent__c = Some(LocalDate.of(2020, 1, 2)),
+          Migration_Name__c = Some("cohortName"),
+          Migration_Status__c = Some("EstimationComplete"),
+          Cancellation_Reason__c = Some("Error 1")
         )
       ),
       """{
-        |  "Date_Letter_Sent__c": "2020-01-02"
+        |  "Date_Letter_Sent__c": "2020-01-02",
+        |  "Migration_Name__c": "cohortName",
+        |  "Migration_Status__c": "EstimationComplete",
+        |  "Cancellation_Reason__c": "Error 1"
         |}""".stripMargin
     )
   }


### PR DESCRIPTION
A few days ago, Salesforce has been updated ( https://github.com/guardian/salesforce/pull/976 ) to handle a set of (optional) new fields in the object it gets from the price migration engine as part of the engine's updates about a subscription under going a migration. 

In this PR we add and populate those fields to the engine's SalesforcePriceRise case class.  

This is the first of two PRs. In the next PR we will specifically add code to also update Salesforce in the even of a migration Cancellation (with a reason provided by the engine).

ps: We also bring the amendment handler batch size from 100 to 50. To avoid being too close to the 15 mins time limit for aws lambda runs.
 