### PR TITLE
Run notification in batches

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -13,7 +13,6 @@ import pricemigrationengine.migrations.newspaper2024Migration
   */
 object AmendmentHandler extends CohortHandler {
 
-  // TODO: move to config
   private val batchSize = 50
 
   private def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora, Failure, HandlerOutput] = {

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -16,7 +16,6 @@ import java.time.LocalDate
   */
 object EstimationHandler extends CohortHandler {
 
-  // TODO: move to config
   private val batchSize = 150
 
   def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora, Failure, HandlerOutput] =

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -291,7 +291,7 @@ Resources:
                 "Resource": "${NotifyingSubscribersLambdaArn}",
                 "InputPath": "$.cohortSpec",
                 "ResultPath": "$.result",
-                "Next": "UpdatingSalesforceWithNotifications",
+                "Next": "IsNotifyingSubscribersComplete",
                 "Retry": [
                   {
                     "ErrorEquals": [
@@ -304,6 +304,18 @@ Resources:
                     "BackoffRate": 2
                   }
                 ]
+              },
+              "IsNotifyingSubscribersComplete": {
+                "Type": "Choice",
+                "Comment": "Is the notification step complete?",
+                "Choices": [
+                  {
+                    "Variable": "$.result.isComplete",
+                    "BooleanEquals": false,
+                    "Next": "NotifyingSubscribers"
+                  }
+                ],
+                "Default": "UpdatingSalesforceWithNotifications"
               },
               "UpdatingSalesforceWithNotifications": {
                 "Type": "Task",


### PR DESCRIPTION
The ongoing Newspaper2024 migrates a large number of subscriptions. This, compounded with the change in the notification handler we implemented recently ( https://github.com/guardian/price-migration-engine/pull/976 ), causes the lambda to overrun the 15 mins limit imposed by AWS. Here, we upgrade the state machine and the Notification handler to run on small batches, following the same pattern we are already using for the Estimation and Amendment handlers.