### PR TITLE
Upgrade the Notification handler (No more silent fails and decommission NotificationSendProcessingOrError)

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -65,7 +65,7 @@ object NotificationHandler extends CohortHandler {
     // previously computed start dates, which can happen if, for argument sake, the engine is down for a few days.
 
     if (thereIsEnoughNotificationLeadTime(cohortSpec, today, cohortItem)) {
-      val result = for {
+      for {
         _ <- cohortItemRatePlansChecks(cohortItem)
         sfSubscription <-
           SalesforceClient
@@ -77,13 +77,6 @@ object NotificationHandler extends CohortHandler {
             putSubIntoCancelledStatus(cohortItem.subscriptionName)
           }
       } yield count
-      result.catchAll { failure =>
-        for {
-          _ <- Logging.error(
-            s"Subscription ${cohortItem.subscriptionName}: Failed to send price rise notification: $failure"
-          )
-        } yield Unsuccessful
-      }
     } else {
       ZIO.fail(
         NotificationNotEnoughLeadTimeFailure(
@@ -121,8 +114,6 @@ object NotificationHandler extends CohortHandler {
       }
 
       _ <- logMissingEmailAddress(cohortItem, contact)
-
-      _ <- updateCohortItemStatus(cohortItem.subscriptionName, NotificationSendProcessingOrError)
 
       _ <- EmailSender.sendEmail(
         message = EmailMessage(

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -54,10 +54,6 @@ object CohortTableFilter {
 
   case object EstimationFailed extends CohortTableFilter { override val value: String = "EstimationFailed" }
 
-  case object NotificationSendProcessingOrError extends CohortTableFilter {
-    override val value: String = "NotificationSendProcessingOrError"
-  }
-
   case object AmendmentFailed extends CohortTableFilter { override val value: String = "AmendmentFailed" }
 
   // Set of all states.  Remember to update when adding a state.
@@ -72,7 +68,6 @@ object CohortTableFilter {
     NoPriceIncrease,
     NotificationSendComplete,
     NotificationSendDateWrittenToSalesforce,
-    NotificationSendProcessingOrError,
     ReadyForEstimation,
     SalesforcePriceRiceCreationComplete
   )


### PR DESCRIPTION
### What is the problem ?

At the moment, when a cohort item fails the `sendNotification` function, this does not translate in an alarm, but is silently recovered from (using `.catchAll`) with just a simple mention in a log. Unfortunately, a cohort items will then be silently failing during its entire notification window (meaning the time between `-maxLeadTime` days before price rise and `-minLeadTime` days before price rise), and then on the day it has exited that window will fail the `thereIsEnoughNotificationLeadTime` check, leading to an alarm, but by then, the cause of the sending failures would have been lost.

We actually had the frustrating situation of having a `thereIsEnoughNotificationLeadTime` induced alarm, then turning it off and then see the notifications being sent, which is very very strange 🤔

### Why is the Notification handler like this ?
 
This is just a theory, result of archeological investigations in the code and github commits and the way the tests are written, but we suspect that this pattern is a very old one from when the engine was trying to talk to Braze directly for sending emails, a relatively long time ago. That patten was introduced to help the engine perform as many notifications as it could but we should now move away from it, because it's much more valuable for the engine to alarm as early as possible instead of silently fail for a while and then to give us little time to investigate and repair things.

### What is the change ?

The change is simply to remove the silent handling of the notification send function. Note that this basic change also comes with two further modifications: (1) Two old tests needed to be removed and a few more slightly amended. They were essentially checking that the failing cohort items were correctly put in `NotificationSendProcessingOrError`. (2) We actually decommission `NotificationSendProcessingOrError`. With this change a cohort item either move from `SalesforcePriceRiceCreationComplete` to `NotificationSendComplete` or remain in the former if there is a problem (and that comes with an alarm). 


Co-authored-by: @LAKSHMIRPILLAI 