### PR TITLE
repair the notification handler's ability to count

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -50,15 +50,14 @@ object NotificationHandler extends CohortHandler {
         .fetch(SalesforcePriceRiceCreationComplete, Some(today.plusDays(maxLeadTime(cohortSpec))))
         .take(batchSize)
         .mapZIO(item => sendNotification(cohortSpec)(item, today))
-        .runFold(0) { (sum, count) => sum + count }
-      _ <- Logging.info(s"Successfully sent $count price rise notifications")
+        .runCount
     } yield HandlerOutput(isComplete = count < batchSize)
   }
 
   def sendNotification(cohortSpec: CohortSpec)(
       cohortItem: CohortItem,
       today: LocalDate
-  ): ZIO[EmailSender with SalesforceClient with CohortTable with Logging with Zuora, Failure, Int] = {
+  ): ZIO[EmailSender with SalesforceClient with CohortTable with Logging with Zuora, Failure, Unit] = {
     for {
       _ <-
         if (thereIsEnoughNotificationLeadTime(cohortSpec, today, cohortItem)) {
@@ -74,20 +73,20 @@ object NotificationHandler extends CohortHandler {
       sfSubscription <-
         SalesforceClient
           .getSubscriptionByName(cohortItem.subscriptionName)
-      count <-
+      _ <-
         if (sfSubscription.Status__c != Cancelled_Status) {
           sendNotification(cohortSpec, cohortItem, sfSubscription)
         } else {
           putSubIntoCancelledStatus(cohortItem.subscriptionName)
         }
-    } yield count
+    } yield ()
   }
 
   def sendNotification(
       cohortSpec: CohortSpec,
       cohortItem: CohortItem,
       sfSubscription: SalesforceSubscription
-  ): ZIO[EmailSender with SalesforceClient with CohortTable with Logging, Failure, Int] =
+  ): ZIO[EmailSender with SalesforceClient with CohortTable with Logging, Failure, Unit] =
     for {
       _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
       contact <- SalesforceClient.getContact(sfSubscription.Buyer__c)
@@ -144,7 +143,7 @@ object NotificationHandler extends CohortHandler {
       )
 
       _ <- updateCohortItemStatus(cohortItem.subscriptionName, NotificationSendComplete)
-    } yield Successful
+    } yield ()
 
   // -------------------------------------------------------------------
   // Subscription Rate Plan Checks


### PR DESCRIPTION
### Context

In the PR we made yesterday ( https://github.com/guardian/price-migration-engine/pull/994 ), I wrote "We actually had the frustrating situation of having a `thereIsEnoughNotificationLeadTime` induced alarm, then turning it off and then see the notifications being sent, which is very very strange 🤔"

### More context

When the Estimation handler runs in batches, it asks for 150 items from the database. If it gets 150 items, it process them and then returns 

```
{
  "isComplete": false
}
```

so that the state machine knows to run that same step again. If at some point it gets less than 150 items, then it process them and then return 

```
{
  "isComplete": true
}
```

### The problem

The Notification handler has a bug by which it almost always returns

```
{
  "isComplete": true
}
```

preventing the state machine from running it again. 

Then, in periods when a lot of subs needs to be notified, the engine will perform the logical equivalent of a integer overflow and cause perfectly fine subs to exit their notification windows un-notified. This explains why we could not find anything wrong with the subs we have been rescuing earlier in the week. They exited their notification window because the engine wasn't processing them when it should have been, because the loop wasn't working 🙄

That problem was introduced when we refactored the Notification handler.

Also, now that we understand what the problem was, it also makes perfect sense that it would happen more often (as we observed) on migrations with very small notification windows, like the 2023 digital ones (the smaller the space, the easier to overflow it) 🙂

### This change

We are not interested in the log line where the Notification handler displays how many notifications it sent, that was mostly useful at the time the engine was trying to talk directly to Braze. We then update the signature of a few functions and just use `.runCount` to get an accurate count of how many results were returned from the database, that decides if the lambda should be run again or not. 