### PR TITLE
rename updateOfRatePlansToCurrent to zuoraUpdate

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -131,7 +131,7 @@ object AmendmentHandler extends CohortHandler {
         case Membership2023Monthlies =>
           ZIO.fromEither(
             Membership2023Migration
-              .updateOfRatePlansToCurrent_Monthlies(
+              .zuoraUpdate_Monthlies(
                 subscriptionBeforeUpdate,
                 invoicePreviewBeforeUpdate,
                 startDate
@@ -140,7 +140,7 @@ object AmendmentHandler extends CohortHandler {
         case Membership2023Annuals =>
           ZIO.fromEither(
             Membership2023Migration
-              .updateOfRatePlansToCurrent_Annuals(
+              .zuoraUpdate_Annuals(
                 subscriptionBeforeUpdate,
                 invoicePreviewBeforeUpdate,
                 startDate
@@ -149,7 +149,7 @@ object AmendmentHandler extends CohortHandler {
         case SupporterPlus2023V1V2MA =>
           ZIO.fromEither(
             SupporterPlus2023V1V2Migration
-              .updateOfRatePlansToCurrent(
+              .zuoraUpdate(
                 item,
                 subscriptionBeforeUpdate,
                 invoicePreviewBeforeUpdate,
@@ -158,14 +158,14 @@ object AmendmentHandler extends CohortHandler {
           )
         case DigiSubs2023 =>
           ZIO.fromEither(
-            DigiSubs2023Migration.updateOfRatePlansToCurrent(
+            DigiSubs2023Migration.zuoraUpdate(
               subscriptionBeforeUpdate,
               startDate,
             )
           )
         case Newspaper2024 =>
           ZIO.fromEither(
-            newspaper2024Migration.Amendment.subscriptionToZuoraSubscriptionUpdate(
+            newspaper2024Migration.Amendment.zuoraUpdate(
               subscriptionBeforeUpdate,
               startDate,
             )
@@ -173,7 +173,7 @@ object AmendmentHandler extends CohortHandler {
         case Legacy =>
           ZIO.fromEither(
             ZuoraSubscriptionUpdate
-              .updateOfRatePlansToCurrent(
+              .zuoraUpdate(
                 account,
                 catalogue,
                 subscriptionBeforeUpdate,

--- a/lambda/src/main/scala/pricemigrationengine/migrations/DigiSubs2023Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/DigiSubs2023Migration.scala
@@ -185,7 +185,7 @@ object DigiSubs2023Migration {
     } yield PriceData(currency, oldPrice, newPrice, BillingPeriod.toString(billingPeriod))
   }
 
-  def updateOfRatePlansToCurrent(
+  def zuoraUpdate(
       subscription: ZuoraSubscription,
       effectiveDate: LocalDate,
   ): Either[AmendmentDataFailure, ZuoraSubscriptionUpdate] = {

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Membership2023Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Membership2023Migration.scala
@@ -128,7 +128,7 @@ object Membership2023Migration {
     }
   }
 
-  def updateOfRatePlansToCurrent_Monthlies(
+  def zuoraUpdate_Monthlies(
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,
       effectiveDate: LocalDate,
@@ -165,7 +165,7 @@ object Membership2023Migration {
     }
   }
 
-  def updateOfRatePlansToCurrent_Annuals(
+  def zuoraUpdate_Annuals(
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,
       effectiveDate: LocalDate,

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2024Migration/Amendment.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2024Migration/Amendment.scala
@@ -43,7 +43,7 @@ object Amendment {
     }
   }
 
-  def subscriptionToZuoraSubscriptionUpdate(
+  def zuoraUpdate(
       subscription: ZuoraSubscription,
       effectiveDate: LocalDate,
   ): Either[AmendmentDataFailure, ZuoraSubscriptionUpdate] = {

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
@@ -298,7 +298,7 @@ object SupporterPlus2023V1V2Migration {
     }
   }
 
-  def updateOfRatePlansToCurrent(
+  def zuoraUpdate(
       item: CohortItem,
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
@@ -30,7 +30,7 @@ object ZuoraSubscriptionUpdate {
     * billing period.
     */
 
-  def updateOfRatePlansToCurrent(
+  def zuoraUpdate(
       account: ZuoraAccount,
       catalogue: ZuoraProductCatalogue,
       subscription: ZuoraSubscription,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -96,7 +96,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
       )
     )
 
-    val update = Membership2023Migration.updateOfRatePlansToCurrent_Monthlies(
+    val update = Membership2023Migration.zuoraUpdate_Monthlies(
       subscription,
       invoicePreview,
       effectiveDate: LocalDate
@@ -204,7 +204,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
       )
     )
 
-    val update = Membership2023Migration.updateOfRatePlansToCurrent_Annuals(
+    val update = Membership2023Migration.zuoraUpdate_Annuals(
       subscription,
       invoicePreview,
       effectiveDate: LocalDate
@@ -312,7 +312,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
       )
     )
 
-    val update = Membership2023Migration.updateOfRatePlansToCurrent_Annuals(
+    val update = Membership2023Migration.zuoraUpdate_Annuals(
       subscription,
       invoicePreview,
       effectiveDate: LocalDate
@@ -429,7 +429,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingPeriod = Some("Annual")
       )
 
-    val update = SupporterPlus2023V1V2Migration.updateOfRatePlansToCurrent(
+    val update = SupporterPlus2023V1V2Migration.zuoraUpdate(
       item,
       subscription,
       invoicePreview,
@@ -557,7 +557,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingPeriod = Some("Month")
       )
 
-    val update = SupporterPlus2023V1V2Migration.updateOfRatePlansToCurrent(
+    val update = SupporterPlus2023V1V2Migration.zuoraUpdate(
       item,
       subscription,
       invoicePreview,
@@ -687,7 +687,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingPeriod = Some("Annual")
       )
 
-    val update = SupporterPlus2023V1V2Migration.updateOfRatePlansToCurrent(
+    val update = SupporterPlus2023V1V2Migration.zuoraUpdate(
       item,
       subscription,
       invoicePreview,
@@ -807,7 +807,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
         billingPeriod = Some("Annual")
       )
 
-    val update = SupporterPlus2023V1V2Migration.updateOfRatePlansToCurrent(
+    val update = SupporterPlus2023V1V2Migration.zuoraUpdate(
       item,
       subscription,
       invoicePreview,

--- a/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
@@ -11,7 +11,7 @@ import pricemigrationengine.migrations.DigiSubs2023Migration.{
   priceData,
   subscriptionRatePlan,
   subscriptionRatePlanCharge,
-  updateOfRatePlansToCurrent
+  zuoraUpdate
 }
 import pricemigrationengine.model.CohortTableFilter.SalesforcePriceRiceCreationComplete
 class DigiSubs2023MigrationTest extends munit.FunSuite {
@@ -92,7 +92,7 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
     assertEquals(priceData(subscription).toOption.get, PriceData("GBP", BigDecimal(11.99), BigDecimal(14.99), "Month"))
 
     assertEquals(
-      updateOfRatePlansToCurrent(subscription, LocalDate.of(2024, 1, 1)).toOption.get,
+      zuoraUpdate(subscription, LocalDate.of(2024, 1, 1)).toOption.get,
       ZuoraSubscriptionUpdate(
         add = List(
           AddZuoraRatePlan(
@@ -196,7 +196,7 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
     assertEquals(priceData(subscription).toOption.get, PriceData("GBP", BigDecimal(149.0), BigDecimal(149), "Annual"))
 
     assertEquals(
-      updateOfRatePlansToCurrent(subscription, LocalDate.of(2024, 1, 1)).toOption.get,
+      zuoraUpdate(subscription, LocalDate.of(2024, 1, 1)).toOption.get,
       ZuoraSubscriptionUpdate(
         add = List(
           AddZuoraRatePlan(
@@ -333,7 +333,7 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
     )
 
     assertEquals(
-      updateOfRatePlansToCurrent(subscription, LocalDate.of(2024, 1, 1)).toOption.get,
+      zuoraUpdate(subscription, LocalDate.of(2024, 1, 1)).toOption.get,
       ZuoraSubscriptionUpdate(
         add = List(
           AddZuoraRatePlan(
@@ -439,7 +439,7 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
     )
 
     assertEquals(
-      updateOfRatePlansToCurrent(subscription, LocalDate.of(2024, 1, 1)).toOption.get,
+      zuoraUpdate(subscription, LocalDate.of(2024, 1, 1)).toOption.get,
       ZuoraSubscriptionUpdate(
         add = List(
           AddZuoraRatePlan(

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2024MigrationTest.scala
@@ -1513,7 +1513,7 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
     // val account = Fixtures.accountFromJson("Newspaper2024/NewspaperHomeDelivery-Monthly/account.json")
     // val catalogue = Fixtures.productCatalogueFromJson("Newspaper2024/NewspaperHomeDelivery-Monthly/catalogue.json")
     assertEquals(
-      subscriptionToZuoraSubscriptionUpdate(subscription, LocalDate.of(2024, 3, 1)),
+      zuoraUpdate(subscription, LocalDate.of(2024, 3, 1)),
       Right(
         ZuoraSubscriptionUpdate(
           add = List(
@@ -1555,7 +1555,7 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
   test("Newspaper2024Migration | subscriptionToZuoraSubscriptionUpdate | NewspaperSubscriptionCard-Annual") {
     val subscription = Fixtures.subscriptionFromJson("Newspaper2024/NewspaperSubscriptionCard-Annual/subscription.json")
     assertEquals(
-      subscriptionToZuoraSubscriptionUpdate(subscription, LocalDate.of(2024, 3, 1)),
+      zuoraUpdate(subscription, LocalDate.of(2024, 3, 1)),
       Right(
         ZuoraSubscriptionUpdate(
           add = List(
@@ -1617,7 +1617,7 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
   test("Newspaper2024Migration | subscriptionToZuoraSubscriptionUpdate | NewspaperVoucherBook-Annual") {
     val subscription = Fixtures.subscriptionFromJson("Newspaper2024/NewspaperVoucherBook-Annual/subscription.json")
     assertEquals(
-      subscriptionToZuoraSubscriptionUpdate(subscription, LocalDate.of(2024, 3, 1)),
+      zuoraUpdate(subscription, LocalDate.of(2024, 3, 1)),
       Right(
         ZuoraSubscriptionUpdate(
           add = List(

--- a/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
@@ -10,7 +10,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
     val fixtureSet = "GuardianWeekly/CappedPriceIncrease2"
     val date = LocalDate.of(2022, 12, 30)
 
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -51,7 +51,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   test("Zuora amendment correctly creates a charge override from an enforced priced") {
     val fixtureSet = "GuardianWeekly/CappedPriceIncrease3"
     val date = LocalDate.of(2022, 12, 19)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -92,7 +92,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   test("updateOfRatePlansToCurrent: is correct for a GW ROW subscription with a past Zone ABC rate plan") {
     val fixtureSet = "GuardianWeekly/CappedPriceIncrease4"
     val date = LocalDate.of(2023, 2, 11)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -135,7 +135,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   ) {
     val fixtureSet = "GuardianWeekly/ZoneABC/ZoneC_USD"
     val date = LocalDate.of(2022, 10, 13)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -173,7 +173,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   test("updateOfRatePlansToCurrent: updates correct rate plans on a standard monthly voucher sub") {
     val fixtureSet = "NewspaperVoucher/Monthly"
     val date = LocalDate.of(2020, 5, 28)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -241,7 +241,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   test("updateOfRatePlansToCurrent: updates correct rate plans on a discounted monthly voucher sub") {
     val fixtureSet = "NewspaperVoucher/MonthlyDiscounted"
     val date = LocalDate.of(2020, 6, 15)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -284,7 +284,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   test("updateOfRatePlansToCurrent: updates correct rate plans on a quarterly voucher sub") {
     val fixtureSet = "NewspaperVoucher/QuarterlyVoucher"
     val date = LocalDate.of(2020, 7, 5)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -327,7 +327,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   test("updateOfRatePlansToCurrent: updates correct rate plans on a quarterly GW sub") {
     val fixtureSet = "QuarterlyGW"
     val date = LocalDate.of(2020, 7, 28)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -365,7 +365,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   test("updateOfRatePlansToCurrent: updates correct rate plans on a semi-annual voucher sub") {
     val fixtureSet = "NewspaperVoucher/SemiAnnualVoucher"
     val date = LocalDate.of(2020, 7, 13)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -428,7 +428,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   test("updateOfRatePlansToCurrent: updates correct rate plans on an annual voucher sub") {
     val fixtureSet = "NewspaperVoucher/AnnualVoucher"
     val date = LocalDate.of(2020, 12, 7)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),
@@ -471,7 +471,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
   test("updateOfRatePlansToCurrent: extends term when term ends before effective date of update") {
     val fixtureSet = "NewspaperVoucher/TermEndsEarly"
     val date = LocalDate.of(2020, 8, 5)
-    val update = ZuoraSubscriptionUpdate.updateOfRatePlansToCurrent(
+    val update = ZuoraSubscriptionUpdate.zuoraUpdate(
       account = accountFromJson(s"$fixtureSet/Account.json"),
       catalogue = productCatalogueFromJson(s"$fixtureSet/Catalogue.json"),
       subscription = Fixtures.subscriptionFromJson(s"$fixtureSet/Subscription.json"),


### PR DESCRIPTION
Performs the renaming of `updateOfRatePlansToCurrent` to `zuoraUpdate`. The new name is more friendly to people trying to make sense of the code the first time, and also not all price migration consist in a rate plan change. 