### PR TITLE
Encode GW2024 prices

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/GW2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GW2024Migration.scala
@@ -1,0 +1,32 @@
+package pricemigrationengine.migrations
+
+object GW2024Migration {
+
+  val priceMapMonthlies: Map[String, BigDecimal] = Map(
+    "GBP" -> BigDecimal(15),
+    "USD" -> BigDecimal(30),
+    "CAD" -> BigDecimal(33),
+    "AUD" -> BigDecimal(40),
+    "NZD" -> BigDecimal(50),
+    "EUR" -> BigDecimal(26.5),
+  )
+
+  val priceMapQuarterlies: Map[String, BigDecimal] = Map(
+    "GBP" -> BigDecimal(45),
+    "USD" -> BigDecimal(90),
+    "CAD" -> BigDecimal(99),
+    "AUD" -> BigDecimal(120),
+    "NZD" -> BigDecimal(150),
+    "EUR" -> BigDecimal(79.5),
+  )
+
+  val priceMapAnnuals: Map[String, BigDecimal] = Map(
+    "GBP" -> BigDecimal(180),
+    "USD" -> BigDecimal(360),
+    "CAD" -> BigDecimal(396),
+    "AUD" -> BigDecimal(480),
+    "NZD" -> BigDecimal(600),
+    "EUR" -> BigDecimal(318),
+  )
+
+}


### PR DESCRIPTION
This is the first PR as part of the Guardian Weekly 2024 price migration. Here we simply encode the target prices as per the price grid from the marketing Gantt chart.

![02 PR Picture](https://github.com/guardian/price-migration-engine/assets/6035518/0d21c92b-7093-41b3-bc60-11d4e79743c0)
