### PR TITLE
Refactoring Estimation Results

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -81,7 +81,7 @@ object EstimationHandler extends CohortHandler {
       item: CohortItem,
       cohortSpec: CohortSpec,
       today: LocalDate,
-  ): ZIO[Zuora, Failure, SuccessfulEstimationResult] = {
+  ): ZIO[Zuora, Failure, EstimationData] = {
     for {
       subscription <-
         Zuora

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -27,7 +27,7 @@ case class CohortItem(
 
 object CohortItem {
 
-  def fromSuccessfulEstimationResult(result: SuccessfulEstimationResult): UIO[CohortItem] =
+  def fromSuccessfulEstimationResult(result: EstimationData): UIO[CohortItem] =
     for {
       thisInstant <- Clock.instant
     } yield CohortItem(
@@ -41,7 +41,7 @@ object CohortItem {
       whenEstimationDone = Some(thisInstant)
     )
 
-  def fromNoPriceIncreaseEstimationResult(result: SuccessfulEstimationResult): UIO[CohortItem] =
+  def fromNoPriceIncreaseEstimationResult(result: EstimationData): UIO[CohortItem] =
     fromSuccessfulEstimationResult(result).map(_.copy(processingStage = NoPriceIncrease))
 
   def fromFailedEstimationResult(result: FailedEstimationResult): CohortItem =

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 trait EstimationResult
 
-case class SuccessfulEstimationResult(
+case class EstimationData(
     subscriptionName: String,
     startDate: LocalDate,
     currency: Currency,
@@ -12,6 +12,10 @@ case class SuccessfulEstimationResult(
     estimatedNewPrice: BigDecimal,
     billingPeriod: String
 ) extends EstimationResult
+
+case class FailedEstimationResult(subscriptionNumber: String, reason: String) extends EstimationResult
+
+case class CancelledEstimationResult(subscriptionNumber: String) extends EstimationResult
 
 object EstimationResult {
   def apply(
@@ -21,9 +25,9 @@ object EstimationResult {
       invoiceList: ZuoraInvoiceList,
       startDateLowerBound: LocalDate,
       cohortSpec: CohortSpec,
-  ): Either[AmendmentDataFailure, SuccessfulEstimationResult] = {
+  ): Either[AmendmentDataFailure, EstimationData] = {
     AmendmentData(account, catalogue, subscription, invoiceList, startDateLowerBound, cohortSpec) map { amendmentData =>
-      SuccessfulEstimationResult(
+      EstimationData(
         subscription.subscriptionNumber,
         amendmentData.startDate,
         amendmentData.priceData.currency,
@@ -34,7 +38,3 @@ object EstimationResult {
     }
   }
 }
-
-case class FailedEstimationResult(subscriptionNumber: String, reason: String) extends EstimationResult
-
-case class CancelledEstimationResult(subscriptionNumber: String) extends EstimationResult

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerTest.scala
@@ -2,7 +2,7 @@ package pricemigrationengine.handlers
 
 import pricemigrationengine.Fixtures
 import pricemigrationengine.handlers.EstimationHandler.startDateGeneralLowerBound
-import pricemigrationengine.model.{CohortSpec, EstimationResult, SuccessfulEstimationResult}
+import pricemigrationengine.model.{CohortSpec, EstimationResult, EstimationData}
 import zio.test._
 import pricemigrationengine.util.Date
 import java.time.{LocalDate, LocalDateTime, OffsetDateTime, ZoneOffset}
@@ -57,7 +57,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
 
         assertTrue(
           estimationResult == Right(
-            SuccessfulEstimationResult("SUBSCRIPTION-NUMBER", LocalDate.of(2023, 5, 13), "GBP", 5, 7, "Month")
+            EstimationData("SUBSCRIPTION-NUMBER", LocalDate.of(2023, 5, 13), "GBP", 5, 7, "Month")
           )
         )
       },
@@ -82,7 +82,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
         // date be postponed by a month (from LocalDate.of(2023, 5, 13) to LocalDate.of(2023, 6, 13)).
         assertTrue(
           estimationResult == Right(
-            SuccessfulEstimationResult("SUBSCRIPTION-NUMBER", LocalDate.of(2023, 6, 13), "GBP", 5, 7, "Month")
+            EstimationData("SUBSCRIPTION-NUMBER", LocalDate.of(2023, 6, 13), "GBP", 5, 7, "Month")
           )
         )
       },
@@ -102,7 +102,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
 
         assertTrue(
           estimationResult == Right(
-            SuccessfulEstimationResult("SUBSCRIPTION-NUMBER", LocalDate.of(2024, 1, 20), "GBP", 49, 75, "Annual")
+            EstimationData("SUBSCRIPTION-NUMBER", LocalDate.of(2024, 1, 20), "GBP", 49, 75, "Annual")
           )
         )
       },
@@ -122,7 +122,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
 
         assertTrue(
           estimationResult == Right(
-            SuccessfulEstimationResult("SUBSCRIPTION-NUMBER", LocalDate.of(2024, 1, 20), "USD", 69, 120, "Annual")
+            EstimationData("SUBSCRIPTION-NUMBER", LocalDate.of(2024, 1, 20), "USD", 69, 120, "Annual")
           )
         )
       },
@@ -195,7 +195,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
 
         assertTrue(
           estimationResult ==
-            SuccessfulEstimationResult(
+            EstimationData(
               subscriptionName = "SUBSCRIPTION-NUMBER",
               startDate = LocalDate.of(2023, 9, 1),
               currency = "GBP",
@@ -227,7 +227,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
 
         assertTrue(
           estimationResult ==
-            SuccessfulEstimationResult(
+            EstimationData(
               subscriptionName = "SUBSCRIPTION-NUMBER",
               startDate = LocalDate.of(2023, 9, 3),
               currency = "GBP",
@@ -258,7 +258,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
 
         assertTrue(
           estimationResult ==
-            SuccessfulEstimationResult(
+            EstimationData(
               subscriptionName = "SUBSCRIPTION-NUMBER",
               startDate = LocalDate.of(2024, 7, 2),
               currency = "USD",
@@ -290,7 +290,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
 
         assertTrue(
           estimationResult ==
-            SuccessfulEstimationResult(
+            EstimationData(
               subscriptionName = "SUBSCRIPTION-NUMBER",
               startDate = LocalDate.of(2024, 6, 28),
               currency = "GBP",
@@ -325,7 +325,7 @@ object EstimationHandlerTest extends ZIOSpecDefault {
 
         assertTrue(
           estimationResult ==
-            SuccessfulEstimationResult(
+            EstimationData(
               subscriptionName = "SUBSCRIPTION-NUMBER",
               startDate = LocalDate.of(2023, 9, 8),
               currency = "GBP",

--- a/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/ZuoraSubscriptionUpdateTest.scala
@@ -525,7 +525,7 @@ class ZuoraSubscriptionUpdateTest extends munit.FunSuite {
       )
     assertEquals(
       estimationResult,
-      Right(SuccessfulEstimationResult("subNum", LocalDate.of(2022, 11, 12), "GBP", 30.00, 41.25, "Quarter"))
+      Right(EstimationData("subNum", LocalDate.of(2022, 11, 12), "GBP", 30.00, 41.25, "Quarter"))
     )
   }
 }


### PR DESCRIPTION
Perform a little refactoring of  `trait EstimationResult` to make it easier to understand and more friendly to new comers to the code base. Notably: 

1. We rename `SuccessfulEstimationResult` to `EstimationData`
2. We update its `apply function to avoid using a `AmendmentData` as intermediary step for compute a `EstimationData`. 
 
The code now makes more sense. 