### PR TITLE
GW2024 migration prices update

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/GW2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GW2024Migration.scala
@@ -9,6 +9,7 @@ object GW2024Migration {
     "AUD" -> BigDecimal(40),
     "NZD" -> BigDecimal(50),
     "EUR" -> BigDecimal(26.5),
+    "ROW (USD)" -> BigDecimal(33)
   )
 
   val priceMapQuarterlies: Map[String, BigDecimal] = Map(
@@ -18,6 +19,7 @@ object GW2024Migration {
     "AUD" -> BigDecimal(120),
     "NZD" -> BigDecimal(150),
     "EUR" -> BigDecimal(79.5),
+    "ROW (USD)" -> BigDecimal(99)
   )
 
   val priceMapAnnuals: Map[String, BigDecimal] = Map(
@@ -27,6 +29,7 @@ object GW2024Migration {
     "AUD" -> BigDecimal(480),
     "NZD" -> BigDecimal(600),
     "EUR" -> BigDecimal(318),
+    "ROW (USD)" -> BigDecimal(396)
   )
 
 }


### PR DESCRIPTION
This is an update of https://github.com/guardian/price-migration-engine/pull/999 

After talking with marketing we are going to use the `ROW (USD)` prices.

![Screenshot 2024-03-08 at 11 18 13](https://github.com/guardian/price-migration-engine/assets/6035518/9b7c358f-7af0-4e5f-b50d-a3de8990ad93)
