### PR TITLE
GW2024 Part 1: GW2024 extends MigrationType

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -170,6 +170,13 @@ object AmendmentHandler extends CohortHandler {
               startDate,
             )
           )
+        case GW2024 =>
+          ZIO.fromEither(
+            GW2024Migration.zuoraUpdate(
+              subscriptionBeforeUpdate,
+              startDate,
+            )
+          )
         case Legacy =>
           ZIO.fromEither(
             ZuoraSubscriptionUpdate

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -103,14 +103,18 @@ object EstimationHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    main(input).provideSome[Logging](
-      EnvConfig.cohortTable.layer,
-      EnvConfig.zuora.layer,
-      EnvConfig.stage.layer,
-      DynamoDBZIOLive.impl,
-      DynamoDBClientLive.impl,
-      CohortTableLive.impl(input),
-      ZuoraLive.impl
-    )
+    MigrationType(input) match {
+      case GW2024 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ =>
+        main(input).provideSome[Logging](
+          EnvConfig.cohortTable.layer,
+          EnvConfig.zuora.layer,
+          EnvConfig.stage.layer,
+          DynamoDBZIOLive.impl,
+          DynamoDBClientLive.impl,
+          CohortTableLive.impl(input),
+          ZuoraLive.impl
+        )
+    }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -6,7 +6,12 @@ import pricemigrationengine.model.membershipworkflow._
 import pricemigrationengine.services._
 import zio.{Clock, ZIO}
 import com.gu.i18n
-import pricemigrationengine.migrations.{DigiSubs2023Migration, Membership2023Migration, newspaper2024Migration}
+import pricemigrationengine.migrations.{
+  DigiSubs2023Migration,
+  GW2024Migration,
+  Membership2023Migration,
+  newspaper2024Migration
+}
 import pricemigrationengine.model.RateplansProbe
 
 import java.time.{LocalDate, ZoneId}
@@ -205,6 +210,7 @@ object NotificationHandler extends CohortHandler {
       case SupporterPlus2023V1V2MA => SupporterPlus2023V1V2Migration.maxLeadTime
       case DigiSubs2023            => DigiSubs2023Migration.maxLeadTime
       case Newspaper2024           => newspaper2024Migration.StaticData.maxLeadTime
+      case GW2024                  => GW2024Migration.maxLeadTime
       case Legacy                  => 49
     }
   }
@@ -216,6 +222,7 @@ object NotificationHandler extends CohortHandler {
       case SupporterPlus2023V1V2MA => SupporterPlus2023V1V2Migration.minLeadTime
       case DigiSubs2023            => DigiSubs2023Migration.minLeadTime
       case Newspaper2024           => newspaper2024Migration.StaticData.minLeadTime
+      case GW2024                  => GW2024Migration.minLeadTime
       case Legacy                  => 35
     }
   }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -87,6 +87,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
         case SupporterPlus2023V1V2MA => true
         case DigiSubs2023            => true
         case Newspaper2024           => true
+        case GW2024                  => true
         case Legacy                  => false
       }
       SalesforcePriceRise(

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GW2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GW2024Migration.scala
@@ -1,6 +1,12 @@
 package pricemigrationengine.migrations
 
+import pricemigrationengine.model._
+import java.time.LocalDate
+
 object GW2024Migration {
+
+  val maxLeadTime = 49
+  val minLeadTime = 36
 
   val priceMapMonthlies: Map[String, BigDecimal] = Map(
     "GBP" -> BigDecimal(15),
@@ -32,4 +38,17 @@ object GW2024Migration {
     "ROW (USD)" -> BigDecimal(396)
   )
 
+  def priceData(
+      subscription: ZuoraSubscription,
+      account: ZuoraAccount
+  ): Either[AmendmentDataFailure, PriceData] = {
+    ???
+  }
+
+  def zuoraUpdate(
+      subscription: ZuoraSubscription,
+      effectiveDate: LocalDate,
+  ): Either[AmendmentDataFailure, ZuoraSubscriptionUpdate] = {
+    ???
+  }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -1,7 +1,12 @@
 package pricemigrationengine.model
 
-import pricemigrationengine.migrations.newspaper2024Migration
-import pricemigrationengine.migrations.{DigiSubs2023Migration, GuardianWeeklyMigration, Membership2023Migration}
+import pricemigrationengine.migrations.{
+  DigiSubs2023Migration,
+  GW2024Migration,
+  GuardianWeeklyMigration,
+  Membership2023Migration,
+  newspaper2024Migration
+}
 import pricemigrationengine.model.ZuoraProductCatalogue.{homeDeliveryRatePlans, productPricingMap}
 
 import java.time.LocalDate
@@ -339,6 +344,11 @@ object AmendmentData {
       case Newspaper2024 =>
         newspaper2024Migration.Estimation.priceData(
           subscription
+        )
+      case GW2024 =>
+        GW2024Migration.priceData(
+          subscription: ZuoraSubscription,
+          account: ZuoraAccount
         )
       case Legacy => priceDataWithRatePlanMatching(account, catalogue, subscription, invoiceList, nextServiceStartDate)
     }

--- a/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
@@ -18,6 +18,7 @@ object Membership2023Annuals extends MigrationType
 object SupporterPlus2023V1V2MA extends MigrationType
 object DigiSubs2023 extends MigrationType
 object Newspaper2024 extends MigrationType
+object GW2024 extends MigrationType
 
 object MigrationType {
   def apply(cohortSpec: CohortSpec): MigrationType = cohortSpec.cohortName match {
@@ -28,6 +29,7 @@ object MigrationType {
     case "DigiSubs2023_Batch1"   => DigiSubs2023
     case "DigiSubs2023_Batch2"   => DigiSubs2023
     case "Newspaper2024"         => Newspaper2024
+    case "GW2024"                => GW2024
     case _                       => Legacy
   }
 }


### PR DESCRIPTION
This is the first of a series of changes in which we are going to implement the Guardian Weekly 2024 migration. 

Unlike previous migrations implemented in essentially a single pull request, see for instance the example of Newspaper2024  ( https://github.com/guardian/price-migration-engine/pull/964 ), because GW2024 is also a teaching opportunity with various documentation having already been written and new ones coming soon, the question of how to present the migration code update in the engine was posed. 

This PR is the first PR in the series. A migration ultimately starts with the `MigrationType` trait being extended. The change is the least amount of code that needed to be written to make it compile and pass the tests (note that no tests actually needed to be changed). Moreover we make a small change in the `handle` function of the Estimation handler to prevent it to run. This is in case somebody wants to run the state machine. 

Note that a PR to introduce the `GW2024Migration` object/name space had actually already been made https://github.com/guardian/price-migration-engine/pull/999.

It's interesting to notice that two functions have been introduced, but not implemented: `GW2024Migration.priceData` and `GW2024Migration.zuoraUpdate`. They are the main function used in the Estimation step and the Amendment step. The engine no longer makes the assumption that there is a default implementation for them. We are purposely leaving them un implemented because they are not going to be called (even if somebody runs the GW2024 state machine).

The next PRs of this series will show the modifications required to activate the lambdas one by one.
