### PR TITLE
ZuoraRatePlan: enforce naming convention

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/Membership2023Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Membership2023Migration.scala
@@ -141,7 +141,7 @@ object Membership2023Migration {
       ratePlanCharge <- ZuoraRatePlanCharge.matchingRatePlanCharge(subscription, invoiceItem).toSeq
       price <- ratePlanCharge.price.toSeq
       if price > 0
-      ratePlan <- ZuoraRatePlan.ratePlan(subscription, ratePlanCharge).toSeq
+      ratePlan <- ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharge).toSeq
     } yield ratePlan).distinct
 
     if (activeRatePlans.isEmpty)
@@ -178,7 +178,7 @@ object Membership2023Migration {
       ratePlanCharge <- ZuoraRatePlanCharge.matchingRatePlanCharge(subscription, invoiceItem).toSeq
       price <- ratePlanCharge.price.toSeq
       if price > 0
-      ratePlan <- ZuoraRatePlan.ratePlan(subscription, ratePlanCharge).toSeq
+      ratePlan <- ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharge).toSeq
     } yield ratePlan).distinct
 
     if (activeRatePlans.isEmpty)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
@@ -310,7 +310,7 @@ object SupporterPlus2023V1V2Migration {
       ratePlanCharge <- ZuoraRatePlanCharge.matchingRatePlanCharge(subscription, invoiceItem).toSeq
       price <- ratePlanCharge.price.toSeq
       if price > 0
-      ratePlan <- ZuoraRatePlan.ratePlan(subscription, ratePlanCharge).toSeq
+      ratePlan <- ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharge).toSeq
     } yield ratePlan).distinct
 
     if (activeRatePlans.isEmpty)

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -257,7 +257,7 @@ object AmendmentData {
     for {
       ratePlanCharges <- ratePlanChargesOrFail(subscription, invoiceItems)
       ratePlan <- ZuoraRatePlan
-        .ratePlan(subscription, ratePlanCharges.head)
+        .ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharges.head)
         .toRight(AmendmentDataFailure(s"Failed to get RatePlan for charges: $ratePlanCharges"))
 
       isZoneABC = zoneABCPlanNames contains ratePlan.productName

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlan.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlan.scala
@@ -15,7 +15,10 @@ case class ZuoraRatePlan(
 object ZuoraRatePlan {
   implicit val rw: ReadWriter[ZuoraRatePlan] = macroRW
 
-  def ratePlan(subscription: ZuoraSubscription, ratePlanCharge: ZuoraRatePlanCharge): Option[ZuoraRatePlan] =
+  def ratePlanChargeToMatchingRatePlan(
+      subscription: ZuoraSubscription,
+      ratePlanCharge: ZuoraRatePlanCharge
+  ): Option[ZuoraRatePlan] =
     subscription.ratePlans.find(_.ratePlanCharges.exists(_.number == ratePlanCharge.number))
 
   def ratePlanToCurrency(ratePlan: ZuoraRatePlan): Option[String] = {

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscriptionUpdate.scala
@@ -44,7 +44,7 @@ object ZuoraSubscriptionUpdate {
       ratePlanCharge <- ZuoraRatePlanCharge.matchingRatePlanCharge(subscription, invoiceItem).toSeq
       price <- ratePlanCharge.price.toSeq
       if price > 0
-      ratePlan <- ZuoraRatePlan.ratePlan(subscription, ratePlanCharge).toSeq
+      ratePlan <- ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharge).toSeq
     } yield ratePlan).distinct
 
     if (activeRatePlans.isEmpty)

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -60,7 +60,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
 
     // And now that we have a ZuoraRatePlanCharge, we can use it to find a matching rate plans.
 
-    val ratePlans = ZuoraRatePlan.ratePlan(subscription, ratePlanCharges.head).toSeq
+    val ratePlans = ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharges.head).toSeq
 
     assertEquals(
       ratePlans,
@@ -168,7 +168,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
 
     // And now that we have a ZuoraRatePlanCharge, we can use it to find a matching rate plans.
 
-    val ratePlans = ZuoraRatePlan.ratePlan(subscription, ratePlanCharges.head).toSeq
+    val ratePlans = ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharges.head).toSeq
 
     assertEquals(
       ratePlans,
@@ -276,7 +276,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
 
     // And now that we have a ZuoraRatePlanCharge, we can use it to find a matching rate plans.
 
-    val ratePlans = ZuoraRatePlan.ratePlan(subscription, ratePlanCharges.head).toSeq
+    val ratePlans = ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharges.head).toSeq
 
     assertEquals(
       ratePlans,
@@ -382,7 +382,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
 
     // And now that we have a ZuoraRatePlanCharge, we can use it to find a matching rate plans.
 
-    val ratePlans = ZuoraRatePlan.ratePlan(subscription, ratePlanCharges.head).toSeq
+    val ratePlans = ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharges.head).toSeq
 
     assertEquals(
       ratePlans,
@@ -505,7 +505,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
 
     // And now that we have a ZuoraRatePlanCharge, we can use it to find a matching rate plans.
 
-    val ratePlans = ZuoraRatePlan.ratePlan(subscription, ratePlanCharges.head).toSeq
+    val ratePlans = ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharges.head).toSeq
 
     assertEquals(
       ratePlans,
@@ -640,7 +640,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
 
     // And now that we have a ZuoraRatePlanCharge, we can use it to find a matching rate plans.
 
-    val ratePlans = ZuoraRatePlan.ratePlan(subscription, ratePlanCharges.head).toSeq
+    val ratePlans = ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharges.head).toSeq
 
     assertEquals(
       ratePlans,
@@ -760,7 +760,7 @@ class AmendmentHandlerTest extends munit.FunSuite {
 
     // And now that we have a ZuoraRatePlanCharge, we can use it to find a matching rate plans.
 
-    val ratePlans = ZuoraRatePlan.ratePlan(subscription, ratePlanCharges.head).toSeq
+    val ratePlans = ZuoraRatePlan.ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharges.head).toSeq
 
     assertEquals(
       ratePlans,


### PR DESCRIPTION
We enforce the naming convention that is being used with the other functions on the ZuoraRatePlan object.