### PR TITLE
Simplify signature of PriceCap.priceCapLegacy

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -81,20 +81,20 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
           .fromOption(cohortItem.startDate)
           .orElseFail(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have a startDate"))
     } yield {
-      val forceEstimated = MigrationType(cohortSpec) match {
-        case Membership2023Monthlies => true
-        case Membership2023Annuals   => true
-        case SupporterPlus2023V1V2MA => true
-        case DigiSubs2023            => true
-        case Newspaper2024           => true
-        case GW2024                  => true
-        case Legacy                  => false
+      val estimatedPriceWithOptionalCapping = MigrationType(cohortSpec) match {
+        case Membership2023Monthlies => estimatedNewPrice
+        case Membership2023Annuals   => estimatedNewPrice
+        case SupporterPlus2023V1V2MA => estimatedNewPrice
+        case DigiSubs2023            => estimatedNewPrice
+        case Newspaper2024           => estimatedNewPrice
+        case GW2024                  => estimatedNewPrice
+        case Legacy                  => PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice)
       }
       SalesforcePriceRise(
         Some(subscription.Name),
         Some(subscription.Buyer__c),
         Some(oldPrice),
-        Some(PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice, forceEstimated)),
+        Some(estimatedPriceWithOptionalCapping),
         Some(priceRiseDate),
         Some(subscription.Id),
         Migration_Name__c = Some(cohortSpec.cohortName),

--- a/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
@@ -43,14 +43,9 @@ object PriceCap {
   private val priceCappingMultiplier = 1.2 // old price + 20%
   def priceCapLegacy(
       oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal,
-      forceEstimated: Boolean = false
+      estimatedNewPrice: BigDecimal
   ): BigDecimal = {
-    if (forceEstimated) {
-      estimatedNewPrice
-    } else {
-      List(estimatedNewPrice, oldPrice * priceCappingMultiplier).min
-    }
+    List(estimatedNewPrice, oldPrice * priceCappingMultiplier).min
   }
 
   // --------------------------------------------------------

--- a/lambda/src/test/scala/pricemigrationengine/model/PriceCap.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/PriceCap.scala
@@ -6,19 +6,12 @@ import java.time.LocalDate
 
 class LegacyMigrationsTest extends munit.FunSuite {
 
-  test("The price legacy capping function works correctly (default)") {
+  test("The price legacy capping function works correctly") {
     val oldPrice = BigDecimal(100)
     val cappedPrice = BigDecimal(120)
     val uncappedPrice = BigDecimal(156)
     // Note the implicit price capping at 20%
     assertEquals(cappedPrice, PriceCap.priceCapLegacy(oldPrice, uncappedPrice))
-  }
-
-  test("The legacy price capping works correctly in case of force estimated") {
-    val oldPrice = BigDecimal(100)
-    val uncappedPrice = BigDecimal(156)
-    // Note the implicit price capping at 20%
-    assertEquals(uncappedPrice, PriceCap.priceCapLegacy(oldPrice, uncappedPrice, true))
   }
 
   test("priceCapNotification (no need to apply)") {


### PR DESCRIPTION
Here we 

1. Simplify the signature of `PriceCap.priceCapLegacy` (which is limited to legacy migrations pending decommissioning), to not provide the `forceEstimated` parameter, which is now redundant (since its value is always `true` for legacy migrations). 

2. Perform a nice refactoring in the SalesforcePriceRiseCreationHandler. This is in anticipation of the GW2024 implementation which moves away from deciding `forceEstimated` and instead will provide the right optional capping function.