### PR TITLE
GW2024 Part 5: SalesforcePriceRiseCreation Step

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -87,7 +87,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
         case SupporterPlus2023V1V2MA => estimatedNewPrice
         case DigiSubs2023            => estimatedNewPrice
         case Newspaper2024           => estimatedNewPrice
-        case GW2024                  => estimatedNewPrice
+        case GW2024                  => PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, 1.25)
         case Legacy                  => PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice)
       }
       SalesforcePriceRise(
@@ -105,18 +105,14 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    MigrationType(input) match {
-      case GW2024 => ZIO.succeed(HandlerOutput(isComplete = true))
-      case _ =>
-        main(input).provideSome[Logging](
-          EnvConfig.cohortTable.layer,
-          EnvConfig.salesforce.layer,
-          EnvConfig.stage.layer,
-          DynamoDBZIOLive.impl,
-          DynamoDBClientLive.impl,
-          CohortTableLive.impl(input),
-          SalesforceClientLive.impl
-        )
-    }
+    main(input).provideSome[Logging](
+      EnvConfig.cohortTable.layer,
+      EnvConfig.salesforce.layer,
+      EnvConfig.stage.layer,
+      DynamoDBZIOLive.impl,
+      DynamoDBClientLive.impl,
+      CohortTableLive.impl(input),
+      SalesforceClientLive.impl
+    )
   }
 }


### PR DESCRIPTION
Previously:
- Part 1: https://github.com/guardian/price-migration-engine/pull/1012
- Part 2: https://github.com/guardian/price-migration-engine/pull/1016
- Part 3: https://github.com/guardian/price-migration-engine/pull/1018
- Part 4: https://github.com/guardian/price-migration-engine/pull/1019

This is the fifth PR in our series where we are using the GW2024 migration to show how to organise the changes required to build a modern migration.

Here we prepare the SalesforcePriceRiseCreation step, corresponding to the next lambda in the workflow after the Estimation step.  

This steps requires much less work than the previous one as the code is completely generic. We just unlock the lambda by removing the lock on "GW2024" and remember that we are applying a capping to prices (at 25%). For this we use the new PriceCap library (that we introduced recently: https://github.com/guardian/price-migration-engine/pull/1006, with an update here: https://github.com/guardian/price-migration-engine/pull/1017).


 