### PR TITLE
Introduce coding convention around MigrationType(cohortSpec)

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -96,7 +96,12 @@ object AmendmentHandler extends CohortHandler {
 
     MigrationType(cohortSpec) match {
       case SupporterPlus2023V1V2MA => false
-      case _                       => true
+      case Membership2023Monthlies => true
+      case Membership2023Annuals   => true
+      case DigiSubs2023            => true
+      case Newspaper2024           => true
+      case GW2024                  => true
+      case Legacy                  => true
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -109,8 +109,13 @@ object NotificationHandler extends CohortHandler {
       currencySymbol <- currencyISOtoSymbol(currencyISOCode)
 
       cappedEstimatedNewPriceWithCurrencySymbol = MigrationType(cohortSpec) match {
-        case Legacy => s"${currencySymbol}${PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice)}"
-        case _      => s"${currencySymbol}${estimatedNewPrice}"
+        case Legacy                  => s"${currencySymbol}${PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice)}"
+        case Membership2023Monthlies => s"${currencySymbol}${estimatedNewPrice}"
+        case Membership2023Annuals   => s"${currencySymbol}${estimatedNewPrice}"
+        case SupporterPlus2023V1V2MA => s"${currencySymbol}${estimatedNewPrice}"
+        case DigiSubs2023            => s"${currencySymbol}${estimatedNewPrice}"
+        case Newspaper2024           => s"${currencySymbol}${estimatedNewPrice}"
+        case GW2024                  => s"${currencySymbol}${estimatedNewPrice}"
       }
 
       _ <- logMissingEmailAddress(cohortItem, contact)

--- a/lambda/src/main/scala/pricemigrationengine/util/StartDates.scala
+++ b/lambda/src/main/scala/pricemigrationengine/util/StartDates.scala
@@ -27,8 +27,13 @@ object StartDates {
   // This function returns the optional date of the last price rise.
   def lastPriceRiseDate(cohortSpec: CohortSpec, subscription: ZuoraSubscription): Option[LocalDate] = {
     MigrationType(cohortSpec) match {
-      case GW2024 => GW2024Migration.subscriptionToLastPriceMigrationDate(subscription)
-      case _      => None
+      case GW2024                  => GW2024Migration.subscriptionToLastPriceMigrationDate(subscription)
+      case SupporterPlus2023V1V2MA => None
+      case Membership2023Monthlies => None
+      case Membership2023Annuals   => None
+      case DigiSubs2023            => None
+      case Newspaper2024           => None
+      case Legacy                  => None
     }
   }
   def cohortSpecLowerBound(
@@ -85,7 +90,10 @@ object StartDates {
         case Membership2023Monthlies => 1
         case Membership2023Annuals   => 1
         case Newspaper2024           => newspaper2024Migration.Estimation.startDateSpreadPeriod(subscription)
-        case _                       => 3
+        case SupporterPlus2023V1V2MA => 3
+        case DigiSubs2023            => 3
+        case GW2024                  => 3
+        case Legacy                  => 3
       }
     } else 1
   }
@@ -101,7 +109,12 @@ object StartDates {
     val startDateLowerBound1 = MigrationType(cohortSpec) match {
       case Newspaper2024 =>
         newspaper2024Migration.Estimation.startDateLowerbound(today, subscription)
-      case _ => cohortSpecLowerBound(cohortSpec, today)
+      case SupporterPlus2023V1V2MA => cohortSpecLowerBound(cohortSpec, today)
+      case Membership2023Monthlies => cohortSpecLowerBound(cohortSpec, today)
+      case Membership2023Annuals   => cohortSpecLowerBound(cohortSpec, today)
+      case DigiSubs2023            => cohortSpecLowerBound(cohortSpec, today)
+      case GW2024                  => cohortSpecLowerBound(cohortSpec, today)
+      case Legacy                  => cohortSpecLowerBound(cohortSpec, today)
     }
 
     // We now respect the policy of not increasing members during their first year


### PR DESCRIPTION
Here we introduce a new feature: coding conventions for the engine, and we declare our first coding convention: avoiding using the wildcard convention with `MigrationType(cohortSpec)`. 