### PR TITLE
GW2024 Part 6: User Notification Step

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
@@ -74,17 +74,13 @@ object SalesforceNotificationDateUpdateHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
-    MigrationType(input) match {
-      case GW2024 => ZIO.succeed(HandlerOutput(isComplete = true))
-      case _ =>
-        main(input).provideSome[Logging](
-          EnvConfig.cohortTable.layer,
-          EnvConfig.salesforce.layer,
-          EnvConfig.stage.layer,
-          DynamoDBZIOLive.impl,
-          DynamoDBClientLive.impl,
-          CohortTableLive.impl(input),
-          SalesforceClientLive.impl
-        )
-    }
+    main(input).provideSome[Logging](
+      EnvConfig.cohortTable.layer,
+      EnvConfig.salesforce.layer,
+      EnvConfig.stage.layer,
+      DynamoDBZIOLive.impl,
+      DynamoDBClientLive.impl,
+      CohortTableLive.impl(input),
+      SalesforceClientLive.impl
+    )
 }

--- a/lambda/src/test/scala/pricemigrationengine/migrations/GW2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/GW2024MigrationTest.scala
@@ -4,8 +4,7 @@ import pricemigrationengine.model._
 
 import java.time.LocalDate
 import pricemigrationengine.Fixtures
-import pricemigrationengine.migrations.GW2024Migration
-import pricemigrationengine.migrations.GW2024Migration
+import pricemigrationengine.handlers.NotificationHandler
 import pricemigrationengine.util.StartDates
 
 class GW2024MigrationTest extends munit.FunSuite {
@@ -257,5 +256,30 @@ class GW2024MigrationTest extends munit.FunSuite {
       )
     )
   }
+
+  // ------------------------------------
+  // Notification timetable
+
+  // Note that as part of the test, we purposely set CohortSpec's
+  // earliestPriceMigrationStartDate to Jan 1st
+
+  val cohortSpec = CohortSpec("GW2024", "", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 1))
+
+  // The startDates in the dynamo table are spread from `2024-05-20` and `2025-05-19`
+
+  // Here are are going to test that the notifications are going to start on April 1st
+
+  // First let's ensure that the GW2024 start of notification window is at 49
+
+  assertEquals(GW2024Migration.maxLeadTime, 49)
+
+  // And that this is the value the Notification Handler itself thinks is right
+
+  assertEquals(NotificationHandler.maxLeadTime(cohortSpec), 49)
+
+  // Then let us make sure that for an items with a start date of exactly `2024-05-20`,
+  // April 1st is the first day that we get clearance for notification
+
+  assertEquals(LocalDate.of(2024, 4, 1).plusDays(49), LocalDate.of(2024, 5, 20))
 
 }


### PR DESCRIPTION
Previously:
- Part 1: https://github.com/guardian/price-migration-engine/pull/1012
- Part 2: https://github.com/guardian/price-migration-engine/pull/1016
- Part 3: https://github.com/guardian/price-migration-engine/pull/1018
- Part 4: https://github.com/guardian/price-migration-engine/pull/1019
- Part 5: https://github.com/guardian/price-migration-engine/pull/1020

This is the sixth PR in our series where we are using the GW2024 migration to show how to organise the changes required to build a modern migration.

Here we prepare the Notification step. 

The Notification step is very generic and doesn't need customisation, and updating the code only required to make sure that we apply this migration's capping for the communication to the user. (Remember that we store uncapped prices, and apply capping during the Salesforce notification step, the Notification step and the Amendment step). We also add a test to clarify the notification schedule. Which clarifies that the natural first date for notifications will be April 1st.

This test is written in a different way that similar tests we wrote in the past. It started from the assumption that we knew for sure the first available start date. I downloaded the Dynamo table and printed the list of dates to get confirmation that the Estimation step has set up the first start date of this migration to May 20th.  

Note: We also unlock the following Salesforce update step: SalesforceNotificationDateUpdateHandler. We are doing both in one step instead of staging two changes as we did here: https://github.com/guardian/price-migration-engine/pull/1019 and here: https://github.com/guardian/price-migration-engine/pull/1020 .

---------------------
Finding the date distribution using Ruby:

"""
aws dynamodb scan --region eu-west-1 --table-name PriceMigration-PROD-GW2024 --select ALL_ATTRIBUTES --page-size 50000 --max-items 50000 --output json --profile membership > 02-data.json
"""

```
data = JSON.parse(IO.read('02-data.json'))

puts data["Items"]
    .select{|item| item["startDate"] }
    .map{|item| item["startDate"]["S"] }
    .uniq
    .sort
```

The dates are between `2024-05-20` and `2025-05-19`
 
---------------------
A note on running the Notification step:

Over the first few days we will run the state machine manually, it won't yet be on automatic pilot. Notably we will run the Notification step for the first time on April 2nd. This implies that on that date the engine will process items with a start date of `2024-05-20` and `2024-05-21`.

Also note that it is not un-usual that we get errors the first couple of days because of incomplete user data in Salesforce, which require slight changes in the data retrieval rules. This is expected and there is no real way to test for it before hand. Any user provided data is bound to be slightly dirty.  

 