### PR TITLE
Avoid retrying Zuora amendment

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -198,17 +198,15 @@ object ZuoraLive {
         override def updateSubscription(
             subscription: ZuoraSubscription,
             update: ZuoraSubscriptionUpdate
-        ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId] =
-          retry(
-            put[SubscriptionUpdateResponse](
-              path = s"subscriptions/${subscription.subscriptionNumber}",
-              body = write(update)
-            ).mapBoth(
-              e =>
-                ZuoraUpdateFailure(s"Subscription ${subscription.subscriptionNumber} and update $update: ${e.reason}"),
-              response => response.subscriptionId
-            )
-          ) <* logging.info(s"Updated subscription ${subscription.subscriptionNumber} with: $update")
+        ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId] = {
+          put[SubscriptionUpdateResponse](
+            path = s"subscriptions/${subscription.subscriptionNumber}",
+            body = write(update)
+          ).mapBoth(
+            e => ZuoraUpdateFailure(s"Subscription ${subscription.subscriptionNumber} and update $update: ${e.reason}"),
+            response => response.subscriptionId
+          )
+        }
 
         override def renewSubscription(subscriptionNumber: String): ZIO[Any, ZuoraRenewalFailure, Unit] =
           retry(


### PR DESCRIPTION
Two years ago @kelvin-chappell introduced retry for Zuora.updateSubscription ( https://github.com/guardian/price-migration-engine/pull/591 ). This was a sensible solution to the problem of Zuora sometimes timing out, but I have noticed recently that there are moments where that seems to result in multiple amendments being submitted to Zuora (resulting in subscribers over paying and work required to repair the subscriptions).

This change removes the retry. Consequently the engine will fail and alarm when this happens. Resulting in a preferable situation because we can then just check that the sub is fine and let the amendment lambda run again. 

Note: Interestingly the engine has a post amendment check of the post amendment price, which could always catch when the subscription has been incorrectly amended, but I have seen it fail when Zuora is dealing with subscriptions with lots of amendments. (This suggest a race conditions in Zuora, but it's not something we can really do anything about.)