### PR TITLE
Reactivate normal Notifications for GW2024

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -26,23 +26,19 @@ object NotificationHandler extends CohortHandler {
   val Cancelled_Status = "Cancelled"
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    MigrationType(input) match {
-      case GW2024 => ZIO.succeed(HandlerOutput(isComplete = true))
-      case _ =>
-        main(input).provideSome[Logging](
-          EnvConfig.salesforce.layer,
-          EnvConfig.cohortTable.layer,
-          EnvConfig.emailSender.layer,
-          EnvConfig.zuora.layer,
-          EnvConfig.stage.layer,
-          DynamoDBClientLive.impl,
-          DynamoDBZIOLive.impl,
-          CohortTableLive.impl(input),
-          SalesforceClientLive.impl,
-          EmailSenderLive.impl,
-          ZuoraLive.impl
-        )
-    }
+    main(input).provideSome[Logging](
+      EnvConfig.salesforce.layer,
+      EnvConfig.cohortTable.layer,
+      EnvConfig.emailSender.layer,
+      EnvConfig.zuora.layer,
+      EnvConfig.stage.layer,
+      DynamoDBClientLive.impl,
+      DynamoDBZIOLive.impl,
+      CohortTableLive.impl(input),
+      SalesforceClientLive.impl,
+      EmailSenderLive.impl,
+      ZuoraLive.impl
+    )
   }
 
   def main(


### PR DESCRIPTION
Marketing have installed a new canvas for GW2024 ( https://github.com/guardian/membership-workflow/pull/509  ). We can now reactivate the normal flow for GW2024 (and stop using the direct Latcham link prototype Pascal had build). 