### PR TITLE
handle amendment failed due to lock

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
@@ -21,3 +21,7 @@ case class CancelledAmendmentResult(
 case class ExpiringSubscriptionResult(
     subscriptionNumber: String
 ) extends AmendmentResult
+
+case class AmendmentPreventedDueToLockResult(
+    subscriptionNumber: String
+) extends AmendmentResult


### PR DESCRIPTION
6 days ago we made this PR: https://github.com/guardian/price-migration-engine/pull/1035 to prevent a rare situation where Zuora would perform two price rises on a subscription. At this aim we succeeded (as far as Pascal can tell), but this created another problem...

Each day the DigiSubs2023_Batch2 migration would fail. More exactly the state machine would be interrupted with the error: "ZuoraUpdateFailure: Operation failed due to a lock competition, please retry later". Interestingly just rerunning the Amendment lambda would fix it, without any particular correction needed to be applied in Zuora or on the DynamoDB cohort item. The only problem is that it would then happen a dozen times across all amendments for the day. 

Originally we thought it was limited to DigiSubs2023_Batch2, but a couple of days ago it also started affecting GW2024 too.

We did not want to reintroduce the blanket automatic retry (for obvious reasons), the solution was to capture the ZuoraUpdateFailures corresponding to a "lock competition", and return a `ZIO.succeed` without updating the cohort item. 

We have just seen it happening in PROD 🎉

![Screenshot 2024-04-23 at 23 51 26](https://github.com/guardian/price-migration-engine/assets/6035518/f0325cd5-ddbe-49cc-83ad-447d4f3fba37)

When an item is being locked for amendment by Zuora, it will simply be amended the next time the lambda runs. This may be on the same day, or the day after (if it was the last run of the amendment for that day).


