### PR TITLE
move aws lambda runtime to java17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           distribution: corretto
-          java-version: 17
+          java-version: 11
           cache: sbt
 
       - name: Test PR from forked repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           distribution: corretto
-          java-version: 21
+          java-version: 17
           cache: sbt
 
       - name: Test PR from forked repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           distribution: corretto
-          java-version: 11
+          java-version: 21
           cache: sbt
 
       - name: Test PR from forked repo

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -402,7 +402,7 @@ Resources:
           - PriceMigrationEngineTableCreateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineTableCreateLambdaRole
@@ -426,7 +426,7 @@ Resources:
           - PriceMigrationEngineSubscriptionIdUploadLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSubscriptionIdUploadLambdaRole
@@ -451,7 +451,7 @@ Resources:
           - PriceMigrationEngineEstimationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineEstimationLambdaRole
@@ -475,7 +475,7 @@ Resources:
           - PriceMigrationEngineSalesforcePriceCreationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSalesforcePriceCreationLambdaRole
@@ -499,7 +499,7 @@ Resources:
           - PriceMigrationEngineAmendmentLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineAmendmentLambdaRole
@@ -525,7 +525,7 @@ Resources:
           - PriceMigrationEngineNotificationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineNotificationLambdaRole
@@ -549,7 +549,7 @@ Resources:
           - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
@@ -575,7 +575,7 @@ Resources:
           - PriceMigrationEngineSalesforceAmendmentUpdateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
 
   PriceMigrationEngineCohortTableDatalakeExportLambda:
@@ -598,7 +598,7 @@ Resources:
           - PriceMigrationEngineCohortTableDatalakeExportLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineCohortTableDatalakeExportLambdaRole

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -402,7 +402,7 @@ Resources:
           - PriceMigrationEngineTableCreateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineTableCreateLambdaRole
@@ -426,7 +426,7 @@ Resources:
           - PriceMigrationEngineSubscriptionIdUploadLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSubscriptionIdUploadLambdaRole
@@ -451,7 +451,7 @@ Resources:
           - PriceMigrationEngineEstimationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineEstimationLambdaRole
@@ -475,7 +475,7 @@ Resources:
           - PriceMigrationEngineSalesforcePriceCreationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSalesforcePriceCreationLambdaRole
@@ -499,7 +499,7 @@ Resources:
           - PriceMigrationEngineAmendmentLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineAmendmentLambdaRole
@@ -525,7 +525,7 @@ Resources:
           - PriceMigrationEngineNotificationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineNotificationLambdaRole
@@ -549,7 +549,7 @@ Resources:
           - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
@@ -575,7 +575,7 @@ Resources:
           - PriceMigrationEngineSalesforceAmendmentUpdateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
 
   PriceMigrationEngineCohortTableDatalakeExportLambda:
@@ -598,7 +598,7 @@ Resources:
           - PriceMigrationEngineCohortTableDatalakeExportLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineCohortTableDatalakeExportLambdaRole

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -402,7 +402,7 @@ Resources:
           - PriceMigrationEngineTableCreateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineTableCreateLambdaRole
@@ -426,7 +426,7 @@ Resources:
           - PriceMigrationEngineSubscriptionIdUploadLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSubscriptionIdUploadLambdaRole
@@ -451,7 +451,7 @@ Resources:
           - PriceMigrationEngineEstimationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineEstimationLambdaRole
@@ -475,7 +475,7 @@ Resources:
           - PriceMigrationEngineSalesforcePriceCreationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSalesforcePriceCreationLambdaRole
@@ -499,7 +499,7 @@ Resources:
           - PriceMigrationEngineAmendmentLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineAmendmentLambdaRole
@@ -525,7 +525,7 @@ Resources:
           - PriceMigrationEngineNotificationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineNotificationLambdaRole
@@ -549,7 +549,7 @@ Resources:
           - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
@@ -575,7 +575,7 @@ Resources:
           - PriceMigrationEngineSalesforceAmendmentUpdateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
 
   PriceMigrationEngineCohortTableDatalakeExportLambda:
@@ -598,7 +598,7 @@ Resources:
           - PriceMigrationEngineCohortTableDatalakeExportLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineCohortTableDatalakeExportLambdaRole

--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -402,7 +402,7 @@ Resources:
           - PriceMigrationEngineTableCreateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineTableCreateLambdaRole
@@ -426,7 +426,7 @@ Resources:
           - PriceMigrationEngineSubscriptionIdUploadLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSubscriptionIdUploadLambdaRole
@@ -451,7 +451,7 @@ Resources:
           - PriceMigrationEngineEstimationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineEstimationLambdaRole
@@ -475,7 +475,7 @@ Resources:
           - PriceMigrationEngineSalesforcePriceCreationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSalesforcePriceCreationLambdaRole
@@ -499,7 +499,7 @@ Resources:
           - PriceMigrationEngineAmendmentLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineAmendmentLambdaRole
@@ -525,7 +525,7 @@ Resources:
           - PriceMigrationEngineNotificationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineNotificationLambdaRole
@@ -549,7 +549,7 @@ Resources:
           - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineSalesforceNotificationDateUpdateLambdaRole
@@ -575,7 +575,7 @@ Resources:
           - PriceMigrationEngineSalesforceAmendmentUpdateLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java17
       Timeout: 900
 
   PriceMigrationEngineCohortTableDatalakeExportLambda:
@@ -598,7 +598,7 @@ Resources:
           - PriceMigrationEngineCohortTableDatalakeExportLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java17
       Timeout: 900
     DependsOn:
       - PriceMigrationEngineCohortTableDatalakeExportLambdaRole

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -130,7 +130,7 @@ Resources:
           - PriceMigrationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java11
       Timeout: 900
 
   PriceMigrationLambdaScheduleRule:

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -130,7 +130,7 @@ Resources:
           - PriceMigrationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java21
+      Runtime: java17
       Timeout: 900
 
   PriceMigrationLambdaScheduleRule:

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -130,7 +130,7 @@ Resources:
           - PriceMigrationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java11
+      Runtime: java17
       Timeout: 900
 
   PriceMigrationLambdaScheduleRule:

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -130,7 +130,7 @@ Resources:
           - PriceMigrationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java17
+      Runtime: java21
       Timeout: 900
 
   PriceMigrationLambdaScheduleRule:

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -130,7 +130,7 @@ Resources:
           - PriceMigrationLambdaRole
           - Arn
       MemorySize: 1536
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
 
   PriceMigrationLambdaScheduleRule:


### PR DESCRIPTION
Move the aws lambda runtime from java8.al2 to java11

An updated version of ZIO, which was introduced here: https://github.com/guardian/price-migration-engine/pull/1042, is not compatible with java8

Note that we originally attempted to migrate to Java 21 or Java 17 but encountered the problem described here: https://github.com/guardian/support-service-lambdas/pull/2204, so we are just migrating to 11 for the moment. 