### PR TITLE
Notify Salesforce of migration interrupted at Notification with a reason

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
@@ -17,7 +17,7 @@ case class SalesforcePriceRise(
 )
 
 // [1] The processing state of the cohort item at time of salesforce notification
-//     and "Cancellation", if the item is bout to or has been cancelled.
+//     and "Cancellation", if the item is about to or has been cancelled.
 
 // Note that Cancellation_Reason__c should remain withing 255 chars. This is a limitation
 // imposed by Salesforce which came during the initial

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -111,7 +111,7 @@ class NotificationHandlerTest extends munit.FunSuite {
         override def updatePriceRise(
             priceRiseId: String,
             priceRise: SalesforcePriceRise
-        ): IO[SalesforceClientFailure, Unit] = ???
+        ): IO[SalesforceClientFailure, Unit] = ZIO.succeed(())
 
         override def getContact(
             contactId: String
@@ -612,7 +612,13 @@ class NotificationHandlerTest extends munit.FunSuite {
     val cancelledSubscription = salesforceSubscription.copy(Status__c = "Cancelled")
     val stubSalesforceClient = stubSFClient(List(cancelledSubscription), List(salesforceContact))
     val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
-    val stubCohortTable = createStubCohortTable(updatedResultsWrittenToCohortTable, cohortItem)
+    val stubCohortTable = createStubCohortTable(
+      updatedResultsWrittenToCohortTable,
+      cohortItem.copy(
+        salesforcePriceRiseId = Option("salesforcePriceRiseId"),
+        newSubscriptionId = Option("newSubscriptionId")
+      )
+    )
     val sentMessages = ArrayBuffer[EmailMessage]()
     val stubEmailSender = createStubEmailSender(sentMessages)
 


### PR DESCRIPTION
# Current Situation

The engine notifies Salesforce of the progress of a subscription migration in three places.

1. The SalesforcePriceRiseCreationHandler where we notify Salesforce that a subscription has been scheduled for migration (this happens just after the estimation step).

2. The SalesforceNotificationDateUpdateHandler, where we notify Salesforce that a subscription has just undergone its notification step.

3. The SalesforceAmendmentUpdateHandler, where we notify Salesforce that a subscription has been amended in Zuora.

When undergoing the estimation step, the engine may discover that the subscription was cancelled in Zuora. In this case it it marked as cancelled in the DynamoDB and Salesforce is not notified of anything.

When undergoing the notification step, the engine can discover that the subscription had been cancelled in Zuora, in this case the subscription is marked as cancelled in the DynamoDB. The engine can also discover, thanks to the work done in RateplansProbe that the subscription is in a state incompatible with the price rise, in this case the event is marked into the DynamoDB.

# This change

Here we add to the logic of the engine a notification sent to Salesforce to inform Salesforce of the case of a migration which has been interrupted at notification step because the subscription was found to have been cancelled in Zuora, but also the case where the subscription fails its RateplansProbe check. 
