### PR TITLE
Upgrade ZuoraRatePlanCharge

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlanCharge.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlanCharge.scala
@@ -22,7 +22,9 @@ case class ZuoraRatePlanCharge(
     triggerEvent: Option[String] = None,
     triggerDate: Option[LocalDate] = None,
     discountPercentage: Option[Double] = None,
-    originalOrderDate: Option[LocalDate] = None
+    originalOrderDate: Option[LocalDate] = None,
+    effectiveStartDate: Option[LocalDate] = None,
+    effectiveEndDate: Option[LocalDate] = None,
 )
 
 object ZuoraRatePlanCharge {

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -49,7 +49,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
         triggerEvent = Some("ContractEffective"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2016, 11, 13))
+        originalOrderDate = Some(LocalDate.of(2016, 11, 13)),
+        effectiveStartDate = Some(LocalDate.of(2016, 11, 13)),
+        effectiveEndDate = Some(LocalDate.of(2023, 11, 13))
       )
     )
 
@@ -88,7 +90,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
               triggerEvent = Some("ContractEffective"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2016, 11, 13))
+              originalOrderDate = Some(LocalDate.of(2016, 11, 13)),
+              effectiveStartDate = Some(LocalDate.of(2016, 11, 13)),
+              effectiveEndDate = Some(LocalDate.of(2023, 11, 13))
             )
           ),
           lastChangeType = None
@@ -157,7 +161,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
         triggerEvent = Some("ContractEffective"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2017, 1, 20))
+        originalOrderDate = Some(LocalDate.of(2017, 1, 20)),
+        effectiveStartDate = Some(LocalDate.of(2017, 1, 20)),
+        effectiveEndDate = Some(LocalDate.of(2024, 1, 20))
       )
     )
 
@@ -196,7 +202,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
               triggerEvent = Some("ContractEffective"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2017, 1, 20))
+              originalOrderDate = Some(LocalDate.of(2017, 1, 20)),
+              effectiveStartDate = Some(LocalDate.of(2017, 1, 20)),
+              effectiveEndDate = Some(LocalDate.of(2024, 1, 20))
             )
           ),
           lastChangeType = None
@@ -265,7 +273,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
         triggerEvent = Some("ContractEffective"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2017, 1, 20))
+        originalOrderDate = Some(LocalDate.of(2017, 1, 20)),
+        effectiveStartDate = Some(LocalDate.of(2017, 1, 20)),
+        effectiveEndDate = Some(LocalDate.of(2024, 1, 20))
       )
     )
 
@@ -304,7 +314,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
               triggerEvent = Some("ContractEffective"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2017, 1, 20))
+              originalOrderDate = Some(LocalDate.of(2017, 1, 20)),
+              effectiveStartDate = Some(LocalDate.of(2017, 1, 20)),
+              effectiveEndDate = Some(LocalDate.of(2024, 1, 20))
             )
           ),
           lastChangeType = None
@@ -374,7 +386,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 4, 1))
+        originalOrderDate = Some(LocalDate.of(2023, 4, 1)),
+        effectiveStartDate = Some(LocalDate.of(2023, 4, 1)),
+        effectiveEndDate = Some(LocalDate.of(2024, 7, 18))
       )
     )
 
@@ -413,7 +427,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2023, 4, 1))
+              originalOrderDate = Some(LocalDate.of(2023, 4, 1)),
+              effectiveStartDate = Some(LocalDate.of(2023, 4, 1)),
+              effectiveEndDate = Some(LocalDate.of(2024, 7, 18))
             )
           ),
           lastChangeType = Some("Add")
@@ -500,7 +516,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 7, 3))
+        originalOrderDate = Some(LocalDate.of(2023, 7, 3)),
+        effectiveStartDate = Some(LocalDate.of(2023, 7, 3)),
+        effectiveEndDate = Some(LocalDate.of(2024, 7, 3))
       )
     )
 
@@ -539,7 +557,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2023, 7, 3))
+              originalOrderDate = Some(LocalDate.of(2023, 7, 3)),
+              effectiveStartDate = Some(LocalDate.of(2023, 7, 3)),
+              effectiveEndDate = Some(LocalDate.of(2024, 7, 3))
             )
           ),
           lastChangeType = None
@@ -637,7 +657,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 7, 2))
+        originalOrderDate = Some(LocalDate.of(2023, 7, 2)),
+        effectiveStartDate = Some(LocalDate.of(2023, 7, 2)),
+        effectiveEndDate = Some(LocalDate.of(2024, 7, 2))
       )
     )
 
@@ -676,7 +698,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2023, 7, 2))
+              originalOrderDate = Some(LocalDate.of(2023, 7, 2)),
+              effectiveStartDate = Some(LocalDate.of(2023, 7, 2)),
+              effectiveEndDate = Some(LocalDate.of(2024, 7, 2))
             )
           ),
           lastChangeType = None
@@ -760,7 +784,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 6, 28))
+        originalOrderDate = Some(LocalDate.of(2023, 6, 28)),
+        effectiveStartDate = Some(LocalDate.of(2023, 6, 28)),
+        effectiveEndDate = Some(LocalDate.of(2024, 6, 28))
       )
     )
 
@@ -799,7 +825,9 @@ class AmendmentHandlerTest extends munit.FunSuite {
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2023, 6, 28))
+              originalOrderDate = Some(LocalDate.of(2023, 6, 28)),
+              effectiveStartDate = Some(LocalDate.of(2023, 6, 28)),
+              effectiveEndDate = Some(LocalDate.of(2024, 6, 28))
             )
           ),
           lastChangeType = None

--- a/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
@@ -53,7 +53,9 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
             Some("CustomerAcceptance"),
             None,
             None,
-            originalOrderDate = Some(LocalDate.of(2016, 7, 5))
+            originalOrderDate = Some(LocalDate.of(2016, 7, 5)),
+            effectiveStartDate = Some(LocalDate.of(2016, 6, 28)),
+            effectiveEndDate = Some(LocalDate.of(2024, 6, 28)),
           )
         ),
         None
@@ -81,7 +83,9 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2016, 7, 5))
+        originalOrderDate = Some(LocalDate.of(2016, 7, 5)),
+        effectiveStartDate = Some(LocalDate.of(2016, 6, 28)),
+        effectiveEndDate = Some(LocalDate.of(2024, 6, 28))
       )
     )
 
@@ -157,7 +161,9 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
             Some("CustomerAcceptance"),
             None,
             None,
-            originalOrderDate = Some(LocalDate.of(2023, 10, 3))
+            originalOrderDate = Some(LocalDate.of(2023, 10, 3)),
+            effectiveStartDate = Some(LocalDate.of(2023, 10, 19)),
+            effectiveEndDate = Some(LocalDate.of(2024, 10, 3))
           )
         ),
         None
@@ -185,7 +191,9 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 10, 3))
+        originalOrderDate = Some(LocalDate.of(2023, 10, 3)),
+        effectiveStartDate = Some(LocalDate.of(2023, 10, 19)),
+        effectiveEndDate = Some(LocalDate.of(2024, 10, 3))
       )
     )
 
@@ -291,7 +299,9 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
             discountPercentage = None,
-            originalOrderDate = Some(LocalDate.of(2016, 6, 16))
+            originalOrderDate = Some(LocalDate.of(2016, 6, 16)),
+            effectiveStartDate = Some(LocalDate.of(2016, 5, 10)),
+            effectiveEndDate = Some(LocalDate.of(2024, 5, 10))
           )
         ),
         None
@@ -319,7 +329,9 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2016, 6, 16))
+        originalOrderDate = Some(LocalDate.of(2016, 6, 16)),
+        effectiveStartDate = Some(LocalDate.of(2016, 5, 10)),
+        effectiveEndDate = Some(LocalDate.of(2024, 5, 10))
       )
     )
 
@@ -397,7 +409,9 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
             discountPercentage = None,
-            originalOrderDate = Some(LocalDate.of(2022, 11, 1))
+            originalOrderDate = Some(LocalDate.of(2022, 11, 1)),
+            effectiveStartDate = Some(LocalDate.of(2022, 11, 17)),
+            effectiveEndDate = Some(LocalDate.of(2024, 11, 1))
           )
         ),
         None
@@ -425,7 +439,9 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 11, 1))
+        originalOrderDate = Some(LocalDate.of(2022, 11, 1)),
+        effectiveStartDate = Some(LocalDate.of(2022, 11, 17)),
+        effectiveEndDate = Some(LocalDate.of(2024, 11, 1))
       )
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/migrations/GW2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/GW2024MigrationTest.scala
@@ -53,7 +53,9 @@ class GW2024MigrationTest extends munit.FunSuite {
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2020, 6, 8))
+              originalOrderDate = Some(LocalDate.of(2020, 6, 8)),
+              effectiveStartDate = Some(LocalDate.of(2020, 6, 19)),
+              effectiveEndDate = Some(LocalDate.of(2024, 6, 19))
             )
           ),
           lastChangeType = Some("Add")
@@ -90,7 +92,9 @@ class GW2024MigrationTest extends munit.FunSuite {
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2020, 6, 15))
+              originalOrderDate = Some(LocalDate.of(2020, 6, 15)),
+              effectiveStartDate = Some(LocalDate.of(2020, 6, 26)),
+              effectiveEndDate = Some(LocalDate.of(2024, 6, 26))
             )
           ),
           lastChangeType = None
@@ -129,7 +133,9 @@ class GW2024MigrationTest extends munit.FunSuite {
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2020, 6, 8))
+              originalOrderDate = Some(LocalDate.of(2020, 6, 8)),
+              effectiveStartDate = Some(LocalDate.of(2020, 6, 19)),
+              effectiveEndDate = Some(LocalDate.of(2024, 6, 19))
             )
           ),
           lastChangeType = Some("Add")
@@ -170,7 +176,9 @@ class GW2024MigrationTest extends munit.FunSuite {
               triggerEvent = Some("CustomerAcceptance"),
               triggerDate = None,
               discountPercentage = None,
-              originalOrderDate = Some(LocalDate.of(2020, 6, 15))
+              originalOrderDate = Some(LocalDate.of(2020, 6, 15)),
+              effectiveStartDate = Some(LocalDate.of(2020, 6, 26)),
+              effectiveEndDate = Some(LocalDate.of(2024, 6, 26))
             )
           ),
           lastChangeType = None

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2024MigrationTest.scala
@@ -116,7 +116,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2016, 10, 11))
+        originalOrderDate = Some(LocalDate.of(2016, 10, 11)),
+        effectiveStartDate = Some(LocalDate.of(2016, 9, 21)),
+        effectiveEndDate = Some(LocalDate.of(2055, 9, 21))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0ff560d311b0156136ba0523996",
@@ -135,7 +137,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2016, 10, 11))
+        originalOrderDate = Some(LocalDate.of(2016, 10, 11)),
+        effectiveStartDate = Some(LocalDate.of(2016, 9, 21)),
+        effectiveEndDate = Some(LocalDate.of(2055, 9, 21))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0ff560d311b0156136b9fac3976",
@@ -154,7 +158,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2016, 10, 11))
+        originalOrderDate = Some(LocalDate.of(2016, 10, 11)),
+        effectiveStartDate = Some(LocalDate.of(2016, 9, 21)),
+        effectiveEndDate = Some(LocalDate.of(2055, 9, 21))
       )
     )
     val ratePlan =
@@ -199,7 +205,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 6, 2))
+        originalOrderDate = Some(LocalDate.of(2022, 6, 2)),
+        effectiveStartDate = Some(LocalDate.of(2022, 7, 9)),
+        effectiveEndDate = Some(LocalDate.of(2024, 11, 5))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd5614305c01561dc88f8975c8",
@@ -218,7 +226,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 6, 2))
+        originalOrderDate = Some(LocalDate.of(2022, 6, 2)),
+        effectiveStartDate = Some(LocalDate.of(2022, 7, 9)),
+        effectiveEndDate = Some(LocalDate.of(2024, 11, 5))
       )
     )
     val ratePlan =
@@ -263,7 +273,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2021, 6, 28))
+        originalOrderDate = Some(LocalDate.of(2021, 6, 28)),
+        effectiveStartDate = Some(LocalDate.of(2021, 6, 30)),
+        effectiveEndDate = Some(LocalDate.of(2024, 12, 8))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c6ce2ef1",
@@ -282,7 +294,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2021, 6, 28))
+        originalOrderDate = Some(LocalDate.of(2021, 6, 28)),
+        effectiveStartDate = Some(LocalDate.of(2021, 6, 30)),
+        effectiveEndDate = Some(LocalDate.of(2024, 12, 8))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c6872ee9",
@@ -301,7 +315,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2021, 6, 28))
+        originalOrderDate = Some(LocalDate.of(2021, 6, 28)),
+        effectiveStartDate = Some(LocalDate.of(2021, 6, 30)),
+        effectiveEndDate = Some(LocalDate.of(2024, 12, 8))
       )
     )
     val ratePlan =
@@ -346,7 +362,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 5, 29))
+        originalOrderDate = Some(LocalDate.of(2022, 5, 29)),
+        effectiveStartDate = Some(LocalDate.of(2022, 7, 5)),
+        effectiveEndDate = Some(LocalDate.of(2024, 10, 5))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740d28e3024",
@@ -365,7 +383,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 5, 29))
+        originalOrderDate = Some(LocalDate.of(2022, 5, 29)),
+        effectiveStartDate = Some(LocalDate.of(2022, 7, 5)),
+        effectiveEndDate = Some(LocalDate.of(2024, 10, 5))
       )
     )
     val ratePlan =
@@ -410,7 +430,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12)),
+        effectiveStartDate = Some(LocalDate.of(2022, 9, 21)),
+        effectiveEndDate = Some(LocalDate.of(2024, 9, 21))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cd012f90",
@@ -429,7 +451,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12)),
+        effectiveStartDate = Some(LocalDate.of(2022, 9, 21)),
+        effectiveEndDate = Some(LocalDate.of(2024, 9, 21))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cc9b2f88",
@@ -448,7 +472,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12)),
+        effectiveStartDate = Some(LocalDate.of(2022, 9, 21)),
+        effectiveEndDate = Some(LocalDate.of(2024, 9, 21))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cc2c2f80",
@@ -467,7 +493,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12)),
+        effectiveStartDate = Some(LocalDate.of(2022, 9, 21)),
+        effectiveEndDate = Some(LocalDate.of(2024, 9, 21))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cbb32f77",
@@ -486,7 +514,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12)),
+        effectiveStartDate = Some(LocalDate.of(2022, 9, 21)),
+        effectiveEndDate = Some(LocalDate.of(2024, 9, 21))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740cb4e2f6b",
@@ -505,7 +535,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2022, 8, 12))
+        originalOrderDate = Some(LocalDate.of(2022, 8, 12)),
+        effectiveStartDate = Some(LocalDate.of(2022, 9, 21)),
+        effectiveEndDate = Some(LocalDate.of(2024, 9, 21))
       )
     )
     val ratePlan =
@@ -550,7 +582,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5)),
+        effectiveStartDate = Some(LocalDate.of(2023, 5, 25)),
+        effectiveEndDate = Some(LocalDate.of(2024, 5, 25))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c9802f59",
@@ -569,7 +603,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5)),
+        effectiveStartDate = Some(LocalDate.of(2023, 5, 25)),
+        effectiveEndDate = Some(LocalDate.of(2024, 5, 25))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c91d2f4d",
@@ -588,7 +624,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5)),
+        effectiveStartDate = Some(LocalDate.of(2023, 5, 25)),
+        effectiveEndDate = Some(LocalDate.of(2024, 5, 25))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c8c42f40",
@@ -607,7 +645,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5)),
+        effectiveStartDate = Some(LocalDate.of(2023, 5, 25)),
+        effectiveEndDate = Some(LocalDate.of(2024, 5, 25))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c8652f37",
@@ -626,7 +666,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5)),
+        effectiveStartDate = Some(LocalDate.of(2023, 5, 25)),
+        effectiveEndDate = Some(LocalDate.of(2024, 5, 25))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c80f2f26",
@@ -645,7 +687,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5)),
+        effectiveStartDate = Some(LocalDate.of(2023, 5, 25)),
+        effectiveEndDate = Some(LocalDate.of(2024, 5, 25))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a00870ec598001710740c7b82f1c",
@@ -664,7 +708,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2023, 4, 5))
+        originalOrderDate = Some(LocalDate.of(2023, 4, 5)),
+        effectiveStartDate = Some(LocalDate.of(2023, 5, 25)),
+        effectiveEndDate = Some(LocalDate.of(2024, 5, 25))
       )
     )
     val ratePlan =
@@ -709,7 +755,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 7, 19))
+        originalOrderDate = Some(LocalDate.of(2020, 7, 19)),
+        effectiveStartDate = Some(LocalDate.of(2020, 8, 15)),
+        effectiveEndDate = Some(LocalDate.of(2025, 7, 19))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fe56fe33ff015709bb986636d8",
@@ -728,7 +776,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 7, 19))
+        originalOrderDate = Some(LocalDate.of(2020, 7, 19)),
+        effectiveStartDate = Some(LocalDate.of(2020, 8, 15)),
+        effectiveEndDate = Some(LocalDate.of(2025, 7, 19))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd56fe26b601570432f4e33d17",
@@ -747,7 +797,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 7, 19))
+        originalOrderDate = Some(LocalDate.of(2020, 7, 19)),
+        effectiveStartDate = Some(LocalDate.of(2020, 8, 15)),
+        effectiveEndDate = Some(LocalDate.of(2025, 7, 19))
       )
     )
     val ratePlan =
@@ -791,7 +843,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 9, 19))
+        originalOrderDate = Some(LocalDate.of(2020, 9, 19)),
+        effectiveStartDate = Some(LocalDate.of(2020, 10, 26)),
+        effectiveEndDate = Some(LocalDate.of(2024, 10, 26))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fe56fe33ff015709bb986636d8",
@@ -810,7 +864,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 9, 19))
+        originalOrderDate = Some(LocalDate.of(2020, 9, 19)),
+        effectiveStartDate = Some(LocalDate.of(2020, 10, 26)),
+        effectiveEndDate = Some(LocalDate.of(2024, 10, 26))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd56fe26b601570432f4e33d17",
@@ -829,7 +885,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 9, 19))
+        originalOrderDate = Some(LocalDate.of(2020, 9, 19)),
+        effectiveStartDate = Some(LocalDate.of(2020, 10, 26)),
+        effectiveEndDate = Some(LocalDate.of(2024, 10, 26))
       )
     )
     val ratePlan =
@@ -874,7 +932,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 7, 20))
+        originalOrderDate = Some(LocalDate.of(2020, 7, 20)),
+        effectiveStartDate = Some(LocalDate.of(2020, 8, 24)),
+        effectiveEndDate = Some(LocalDate.of(2024, 8, 24))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fe56fe33ff015709bb986636d8",
@@ -893,7 +953,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 7, 20))
+        originalOrderDate = Some(LocalDate.of(2020, 7, 20)),
+        effectiveStartDate = Some(LocalDate.of(2020, 8, 24)),
+        effectiveEndDate = Some(LocalDate.of(2024, 8, 24))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd56fe26b601570432f4e33d17",
@@ -912,7 +974,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 7, 20))
+        originalOrderDate = Some(LocalDate.of(2020, 7, 20)),
+        effectiveStartDate = Some(LocalDate.of(2020, 8, 24)),
+        effectiveEndDate = Some(LocalDate.of(2024, 8, 24))
       )
     )
     val ratePlan =
@@ -957,7 +1021,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 12, 28))
+        originalOrderDate = Some(LocalDate.of(2020, 12, 28)),
+        effectiveStartDate = Some(LocalDate.of(2021, 2, 3)),
+        effectiveEndDate = Some(LocalDate.of(2024, 2, 3))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fe56fe33ff015709bb986636d8",
@@ -976,7 +1042,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 12, 28))
+        originalOrderDate = Some(LocalDate.of(2020, 12, 28)),
+        effectiveStartDate = Some(LocalDate.of(2021, 2, 3)),
+        effectiveEndDate = Some(LocalDate.of(2024, 2, 3))
       ),
       ZuoraRatePlanCharge(
         productRatePlanChargeId = "2c92a0fd56fe26b601570432f4e33d17",
@@ -995,7 +1063,9 @@ class Newspaper2024MigrationTest extends munit.FunSuite {
         triggerEvent = Some("CustomerAcceptance"),
         triggerDate = None,
         discountPercentage = None,
-        originalOrderDate = Some(LocalDate.of(2020, 12, 28))
+        originalOrderDate = Some(LocalDate.of(2020, 12, 28)),
+        effectiveStartDate = Some(LocalDate.of(2021, 2, 3)),
+        effectiveEndDate = Some(LocalDate.of(2024, 2, 3))
       )
     )
     val ratePlan =

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -660,7 +660,9 @@ class AmendmentDataTest extends munit.FunSuite {
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
             discountPercentage = None,
-            originalOrderDate = Some(LocalDate.of(2023, 4, 1))
+            originalOrderDate = Some(LocalDate.of(2023, 4, 1)),
+            effectiveStartDate = Some(LocalDate.of(2023, 4, 1)),
+            effectiveEndDate = Some(LocalDate.of(2024, 7, 18))
           )
         )
       )
@@ -730,7 +732,9 @@ class AmendmentDataTest extends munit.FunSuite {
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
             discountPercentage = None,
-            originalOrderDate = Some(LocalDate.of(2023, 7, 3))
+            originalOrderDate = Some(LocalDate.of(2023, 7, 3)),
+            effectiveStartDate = Some(LocalDate.of(2023, 7, 3)),
+            effectiveEndDate = Some(LocalDate.of(2024, 7, 3))
           )
         )
       )
@@ -799,7 +803,9 @@ class AmendmentDataTest extends munit.FunSuite {
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
             discountPercentage = None,
-            originalOrderDate = Some(LocalDate.of(2023, 7, 2))
+            originalOrderDate = Some(LocalDate.of(2023, 7, 2)),
+            effectiveStartDate = Some(LocalDate.of(2023, 7, 2)),
+            effectiveEndDate = Some(LocalDate.of(2024, 7, 2))
           )
         )
       )
@@ -865,7 +871,9 @@ class AmendmentDataTest extends munit.FunSuite {
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
             discountPercentage = None,
-            originalOrderDate = Some(LocalDate.of(2023, 4, 1))
+            originalOrderDate = Some(LocalDate.of(2023, 4, 1)),
+            effectiveStartDate = Some(LocalDate.of(2023, 4, 1)),
+            effectiveEndDate = Some(LocalDate.of(2024, 7, 18))
           )
         ),
         lastChangeType = Some("Add")
@@ -894,7 +902,9 @@ class AmendmentDataTest extends munit.FunSuite {
           triggerEvent = Some("CustomerAcceptance"),
           triggerDate = None,
           discountPercentage = None,
-          originalOrderDate = Some(LocalDate.of(2023, 4, 1))
+          originalOrderDate = Some(LocalDate.of(2023, 4, 1)),
+          effectiveStartDate = Some(LocalDate.of(2023, 4, 1)),
+          effectiveEndDate = Some(LocalDate.of(2024, 7, 18))
         )
       )
     )
@@ -983,7 +993,9 @@ class AmendmentDataTest extends munit.FunSuite {
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
             discountPercentage = None,
-            originalOrderDate = Some(LocalDate.of(2023, 7, 3))
+            originalOrderDate = Some(LocalDate.of(2023, 7, 3)),
+            effectiveStartDate = Some(LocalDate.of(2023, 7, 3)),
+            effectiveEndDate = Some(LocalDate.of(2024, 7, 3))
           )
         ),
         lastChangeType = None
@@ -1012,7 +1024,9 @@ class AmendmentDataTest extends munit.FunSuite {
           triggerEvent = Some("CustomerAcceptance"),
           triggerDate = None,
           discountPercentage = None,
-          originalOrderDate = Some(LocalDate.of(2023, 7, 3))
+          originalOrderDate = Some(LocalDate.of(2023, 7, 3)),
+          effectiveStartDate = Some(LocalDate.of(2023, 7, 3)),
+          effectiveEndDate = Some(LocalDate.of(2024, 7, 3))
         )
       )
     )
@@ -1100,7 +1114,9 @@ class AmendmentDataTest extends munit.FunSuite {
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
             discountPercentage = None,
-            originalOrderDate = Some(LocalDate.of(2023, 7, 2))
+            originalOrderDate = Some(LocalDate.of(2023, 7, 2)),
+            effectiveStartDate = Some(LocalDate.of(2023, 7, 2)),
+            effectiveEndDate = Some(LocalDate.of(2024, 7, 2))
           )
         ),
         None
@@ -1129,7 +1145,9 @@ class AmendmentDataTest extends munit.FunSuite {
           triggerEvent = Some("CustomerAcceptance"),
           triggerDate = None,
           discountPercentage = None,
-          originalOrderDate = Some(LocalDate.of(2023, 7, 2))
+          originalOrderDate = Some(LocalDate.of(2023, 7, 2)),
+          effectiveStartDate = Some(LocalDate.of(2023, 7, 2)),
+          effectiveEndDate = Some(LocalDate.of(2024, 7, 2))
         )
       )
     )
@@ -1218,7 +1236,9 @@ class AmendmentDataTest extends munit.FunSuite {
             triggerEvent = Some("CustomerAcceptance"),
             triggerDate = None,
             discountPercentage = None,
-            originalOrderDate = Some(LocalDate.of(2023, 6, 28))
+            originalOrderDate = Some(LocalDate.of(2023, 6, 28)),
+            effectiveStartDate = Some(LocalDate.of(2023, 6, 28)),
+            effectiveEndDate = Some(LocalDate.of(2024, 6, 28))
           )
         ),
         None
@@ -1247,7 +1267,9 @@ class AmendmentDataTest extends munit.FunSuite {
           triggerEvent = Some("CustomerAcceptance"),
           triggerDate = None,
           discountPercentage = None,
-          originalOrderDate = Some(LocalDate.of(2023, 6, 28))
+          originalOrderDate = Some(LocalDate.of(2023, 6, 28)),
+          effectiveStartDate = Some(LocalDate.of(2023, 6, 28)),
+          effectiveEndDate = Some(LocalDate.of(2024, 6, 28))
         )
       )
     )


### PR DESCRIPTION
As part of the Supporter+ 2024 migration, we are going to probe rate plans and rate plan charges looking for cancellation save discounts and their effective dates. 

This change upgrade the `ZuoraRatePlanCharge` case class to register `effectiveStartDate` and `effectiveEndDate`. The rest is just upgrading the tests where `ZuoraRatePlanCharge`s were in literal form.  