### PR TITLE
Specify base price for SupporterPlus 2023 migration

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2023V1V2Migration.scala
@@ -229,8 +229,14 @@ object SupporterPlus2023V1V2Migration {
       price <- currencyToNewPrice("Month", currency).toOption
       oldPrice <- item.oldPrice
     } yield {
+      val baseCharge = ChargeOverride(
+        productRatePlanChargeId = "8a128ed885fc6ded018602296af13eba", // Monthly Base Charge
+        billingPeriod = "Month",
+        price = price
+      )
       if (oldPrice > price) {
         List(
+          baseCharge,
           ChargeOverride(
             productRatePlanChargeId = "8a128d7085fc6dec01860234cd075270", // Monthly Contribution
             billingPeriod = "Month",
@@ -238,7 +244,7 @@ object SupporterPlus2023V1V2Migration {
           )
         )
       } else {
-        List()
+        List(baseCharge)
       }
     }
 
@@ -269,8 +275,14 @@ object SupporterPlus2023V1V2Migration {
       price <- currencyToNewPrice("Annual", currency).toOption
       oldPrice <- item.oldPrice
     } yield {
+      val baseCharge = ChargeOverride(
+        productRatePlanChargeId = "8a128ed885fc6ded01860228f7cb3d5f", // Annual Base Charge
+        billingPeriod = "Annual",
+        price = price
+      )
       if (oldPrice > price) {
         List(
+          baseCharge,
           ChargeOverride(
             productRatePlanChargeId = "8a12892d85fc6df4018602451322287f", // Annual Contribution
             billingPeriod = "Annual",
@@ -278,7 +290,7 @@ object SupporterPlus2023V1V2Migration {
           )
         )
       } else {
-        List()
+        List(baseCharge)
       }
     }
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/AmendmentHandlerTest.scala
@@ -462,7 +462,19 @@ class AmendmentHandlerTest extends munit.FunSuite {
       update,
       Right(
         ZuoraSubscriptionUpdate(
-          add = List(AddZuoraRatePlan("8a128ed885fc6ded01860228f77e3d5a", LocalDate.of(2023, 8, 1))),
+          add = List(
+            AddZuoraRatePlan(
+              "8a128ed885fc6ded01860228f77e3d5a",
+              LocalDate.of(2023, 8, 1),
+              List(
+                ChargeOverride(
+                  productRatePlanChargeId = "8a128ed885fc6ded01860228f7cb3d5f",
+                  billingPeriod = "Annual",
+                  price = 120
+                )
+              )
+            )
+          ),
           remove = List(RemoveZuoraRatePlan("8a129d388962fe000189679374ce42a1", LocalDate.of(2023, 8, 1))),
           currentTerm = None,
           currentTermPeriodType = None
@@ -600,6 +612,11 @@ class AmendmentHandlerTest extends munit.FunSuite {
               LocalDate.of(2023, 8, 3),
               chargeOverrides = List(
                 ChargeOverride(
+                  productRatePlanChargeId = "8a128ed885fc6ded018602296af13eba",
+                  billingPeriod = "Month",
+                  price = 10
+                ),
+                ChargeOverride(
                   productRatePlanChargeId = "8a128d7085fc6dec01860234cd075270",
                   billingPeriod = "Month",
                   price = 15
@@ -733,7 +750,19 @@ class AmendmentHandlerTest extends munit.FunSuite {
       update,
       Right(
         ZuoraSubscriptionUpdate(
-          add = List(AddZuoraRatePlan("8a128ed885fc6ded01860228f77e3d5a", LocalDate.of(2024, 7, 2))),
+          add = List(
+            AddZuoraRatePlan(
+              "8a128ed885fc6ded01860228f77e3d5a",
+              LocalDate.of(2024, 7, 2),
+              List(
+                ChargeOverride(
+                  productRatePlanChargeId = "8a128ed885fc6ded01860228f7cb3d5f",
+                  billingPeriod = "Annual",
+                  price = 120
+                )
+              )
+            )
+          ),
           remove = List(RemoveZuoraRatePlan("8a128432890171d1018914866bee0e7f", LocalDate.of(2024, 7, 2))),
           currentTerm = None,
           currentTermPeriodType = None
@@ -862,6 +891,11 @@ class AmendmentHandlerTest extends munit.FunSuite {
               "8a128ed885fc6ded01860228f77e3d5a",
               LocalDate.of(2024, 6, 28),
               chargeOverrides = List(
+                ChargeOverride(
+                  productRatePlanChargeId = "8a128ed885fc6ded01860228f7cb3d5f",
+                  billingPeriod = "Annual",
+                  price = 95
+                ),
                 ChargeOverride(
                   productRatePlanChargeId = "8a12892d85fc6df4018602451322287f",
                   billingPeriod = "Annual",


### PR DESCRIPTION
### Context (Part 1)

The SupporterPlus 2023 migration, was not a price migration. It was a change of rate plan (and in that case the user communication was a change of terms and conditions). The logic of the migration was that a subscription on the rate plan version 1 paying, say, GBP 13, would be split between a base charge of GBP 10 and an extra contribution of GBP 3 in rate plan version 2. If the subscription was paying GBP 10 in version 1, then it would pay the same base charge of GBP 10, but with no extra contribution in version 2.

### Context (Part 2) 

When Pascal encoded the migration, charge overrides were only used for the extra contribution, when needed, to override the default value which is set to zero. The base rate was not specified as a charge override, because we intended to inherit the default price that was specified in the price catalogue. 

### Problem

The price catalogue has been updated (to match the coming 2024 migration which happens to be a price rise). This was done before the final subscriptions from 2023 were notified and amended by the engine. This also meant that this last subset of subscriptions from 2023, as part of undergoing the 2023 rate plan migration, inherited the 2024 prices. Thereby undergoing a price migration without the correct communication. 

### Solution

This PR specifies the base price as a charge override in all cases: monthlies and annuals with and without extra contributions.

### Lessons

We were a bit unlucky here: two engine migrations back to back on the same subscriptions, with the first one being a terms and conditions update, followed by a catalogue driven price update before the end of the first migration. This doesn't happen often, but the lesson to maybe learn here is that it's not harmful to over specify a target rate plan as part of an engine migration, with or without effective price rise. 

### ps

The product rate plan charge ids, come from the catalogue (below). Ignore the prices. 

Monthly Base Charge: `8a128ed885fc6ded018602296af13eba`

Annual Base Charge: `8a128ed885fc6ded01860228f7cb3d5f`
 
![Screenshot 2024-08-13 at 13 17 10](https://github.com/user-attachments/assets/bde427b9-d454-4c42-b348-4a368737bfa5)
