### PR TITLE
SalesforcePriceRiseCreationComplete

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -47,7 +47,7 @@ object NotificationHandler extends CohortHandler {
     for {
       today <- Clock.currentDateTime.map(_.toLocalDate)
       count <- CohortTable
-        .fetch(SalesforcePriceRiceCreationComplete, Some(today.plusDays(maxLeadTime(cohortSpec))))
+        .fetch(SalesforcePriceRiseCreationComplete, Some(today.plusDays(maxLeadTime(cohortSpec))))
         .take(batchSize)
         .mapZIO(item => sendNotification(cohortSpec)(item, today))
         .runCount

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.migrations.GW2024Migration
-import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiceCreationComplete}
+import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiseCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
 import zio.{Clock, IO, ZIO}
@@ -34,7 +34,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
       now <- Clock.instant
       salesforcePriceRiseCreationDetails = CohortItem(
         subscriptionName = item.subscriptionName,
-        processingStage = SalesforcePriceRiceCreationComplete,
+        processingStage = SalesforcePriceRiseCreationComplete,
         salesforcePriceRiseId = optionalNewPriceRiseId,
         whenSfShowEstimate = Some(now)
       )

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -11,7 +11,7 @@ object CohortTableFilter {
 
   case object EstimationComplete extends CohortTableFilter { override val value: String = "EstimationComplete" }
 
-  case object SalesforcePriceRiceCreationComplete extends CohortTableFilter {
+  case object SalesforcePriceRiseCreationComplete extends CohortTableFilter {
     override val value: String = "SalesforcePriceRiseCreationComplete"
   }
 
@@ -69,6 +69,6 @@ object CohortTableFilter {
     NotificationSendComplete,
     NotificationSendDateWrittenToSalesforce,
     ReadyForEstimation,
-    SalesforcePriceRiceCreationComplete
+    SalesforcePriceRiseCreationComplete
   )
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -74,7 +74,7 @@ class NotificationHandlerTest extends munit.FunSuite {
             filter: CohortTableFilter,
             beforeDateInclusive: Option[LocalDate]
         ): ZStream[Any, CohortFetchFailure, CohortItem] = {
-          assertEquals(filter, SalesforcePriceRiceCreationComplete)
+          assertEquals(filter, SalesforcePriceRiseCreationComplete)
           ZStream(cohortItem)
         }
 
@@ -660,7 +660,7 @@ class NotificationHandlerTest extends munit.FunSuite {
     val itemStartDate = LocalDate.of(2023, 5, 4)
 
     val cohortSpec = CohortSpec("CohortName", "BrazeCampaignName", LocalDate.of(2000, 1, 1), itemStartDate)
-    val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate))
+    val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate))
 
     // The two following dates are chosen to be after 1st Dec 2022, to hit the non trivial case of the check
     val date2 = LocalDate.of(2023, 3, 1)
@@ -683,7 +683,7 @@ class NotificationHandlerTest extends munit.FunSuite {
     val itemStartDate = LocalDate.of(2023, 5, 4)
 
     val cohortSpec = CohortSpec("Membership2023_Batch1", "BrazeCampaignName", LocalDate.of(2000, 1, 1), itemStartDate)
-    val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate))
+    val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate))
 
     val date2 = LocalDate.of(2023, 3, 1) // true
     val date3 = LocalDate.of(2023, 4, 1) // 33 days to target, should true
@@ -703,7 +703,7 @@ class NotificationHandlerTest extends munit.FunSuite {
     val itemStartDate = LocalDate.of(2023, 6, 4)
 
     val cohortSpec = CohortSpec("Membership2023_Batch2", "BrazeCampaignName", LocalDate.of(2000, 1, 1), itemStartDate)
-    val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate))
+    val cohortItem = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate))
 
     val date2 = LocalDate.of(2023, 4, 1) // true
     val date3 = LocalDate.of(2023, 5, 1) // 34 days to target, should true
@@ -730,11 +730,11 @@ class NotificationHandlerTest extends munit.FunSuite {
     val itemStartDate4 = LocalDate.of(2023, 8, 7) // +33 days
     val itemStartDate5 = LocalDate.of(2023, 8, 8) // +34 days
 
-    val cohortItem1 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate1))
-    val cohortItem2 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate2))
-    val cohortItem3 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate3))
-    val cohortItem4 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate4))
-    val cohortItem5 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate5))
+    val cohortItem1 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate1))
+    val cohortItem2 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate2))
+    val cohortItem3 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate3))
+    val cohortItem4 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate4))
+    val cohortItem5 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate5))
 
     val cohortSpec =
       CohortSpec("Membership2023_Batch3", "BrazeCampaignName", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 1, 1))
@@ -758,11 +758,11 @@ class NotificationHandlerTest extends munit.FunSuite {
     val itemStartDate4 = LocalDate.of(2023, 8, 22) // +33 days
     val itemStartDate5 = LocalDate.of(2023, 8, 23) // +34 days
 
-    val cohortItem1 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate1))
-    val cohortItem2 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate2))
-    val cohortItem3 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate3))
-    val cohortItem4 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate4))
-    val cohortItem5 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate5))
+    val cohortItem1 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate1))
+    val cohortItem2 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate2))
+    val cohortItem3 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate3))
+    val cohortItem4 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate4))
+    val cohortItem5 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate5))
 
     val cohortSpec =
       CohortSpec("Membership2023_Batch3", "BrazeCampaignName", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 8, 22))

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.TestLogging
-import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiceCreationComplete}
+import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiseCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
 import pricemigrationengine.util.Runner.unsafeRunSync
@@ -153,7 +153,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     )
     assertEquals(
       updatedResultsWrittenToCohortTable(0).processingStage,
-      SalesforcePriceRiceCreationComplete
+      SalesforcePriceRiseCreationComplete
     )
     assertEquals(
       updatedResultsWrittenToCohortTable(0).salesforcePriceRiseId,
@@ -218,7 +218,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     )
     assertEquals(
       updatedResultsWrittenToCohortTable(0).processingStage,
-      SalesforcePriceRiceCreationComplete
+      SalesforcePriceRiseCreationComplete
     )
     assertEquals(
       updatedResultsWrittenToCohortTable(0).salesforcePriceRiseId,
@@ -283,7 +283,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     )
     assertEquals(
       updatedResultsWrittenToCohortTable(0).processingStage,
-      SalesforcePriceRiceCreationComplete
+      SalesforcePriceRiseCreationComplete
     )
     assertEquals(
       updatedResultsWrittenToCohortTable(0).salesforcePriceRiseId,
@@ -350,7 +350,7 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
     )
     assertEquals(
       updatedResultsWrittenToCohortTable(0).processingStage,
-      SalesforcePriceRiceCreationComplete
+      SalesforcePriceRiseCreationComplete
     )
     assertEquals(
       updatedResultsWrittenToCohortTable(0).salesforcePriceRiseId,

--- a/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2023MigrationTest.scala
@@ -13,7 +13,7 @@ import pricemigrationengine.migrations.DigiSubs2023Migration.{
   subscriptionRatePlanCharge,
   zuoraUpdate
 }
-import pricemigrationengine.model.CohortTableFilter.SalesforcePriceRiceCreationComplete
+import pricemigrationengine.model.CohortTableFilter.SalesforcePriceRiseCreationComplete
 class DigiSubs2023MigrationTest extends munit.FunSuite {
   test("monthly (1)") {
 
@@ -241,11 +241,11 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
     val itemStartDate4 = LocalDate.of(2023, 11, 11) // +33 days (earliest start date for DigiSubs2023_Batch1)
     val itemStartDate5 = LocalDate.of(2023, 11, 12) // +34 days
 
-    val cohortItem1 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate1))
-    val cohortItem2 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate2))
-    val cohortItem3 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate3))
-    val cohortItem4 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate4))
-    val cohortItem5 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate5))
+    val cohortItem1 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate1))
+    val cohortItem2 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate2))
+    val cohortItem3 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate3))
+    val cohortItem4 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate4))
+    val cohortItem5 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate5))
 
     val cohortSpec =
       CohortSpec("DigiSubs2023_Batch1", "BrazeCampaignName", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 1, 1))
@@ -492,11 +492,11 @@ class DigiSubs2023MigrationTest extends munit.FunSuite {
     val itemStartDate4 = LocalDate.of(2023, 12, 9) // +33 days (earliest start date for DigiSubs2023_Batch2)
     val itemStartDate5 = LocalDate.of(2023, 12, 10) // +34 days
 
-    val cohortItem1 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate1))
-    val cohortItem2 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate2))
-    val cohortItem3 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate3))
-    val cohortItem4 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate4))
-    val cohortItem5 = CohortItem("subscriptionNumber", SalesforcePriceRiceCreationComplete, Some(itemStartDate5))
+    val cohortItem1 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate1))
+    val cohortItem2 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate2))
+    val cohortItem3 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate3))
+    val cohortItem4 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate4))
+    val cohortItem5 = CohortItem("subscriptionNumber", SalesforcePriceRiseCreationComplete, Some(itemStartDate5))
 
     val cohortSpec =
       CohortSpec("DigiSubs2023_Batch2", "BrazeCampaignName", LocalDate.of(2000, 1, 1), LocalDate.of(2023, 1, 1))


### PR DESCRIPTION
Correct a typo that was in the code for more than 4 years.

```
SalesforcePriceRiceCreationComplete -> SalesforcePriceRiseCreationComplete
```