### PR TITLE
Rename AmendmentDataFailure into DataExtractionFailure

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -124,14 +124,14 @@ object AmendmentHandler extends CohortHandler {
     for {
       subscriptionBeforeUpdate <- fetchSubscription(item)
 
-      startDate <- ZIO.fromOption(item.startDate).orElseFail(AmendmentDataFailure(s"No start date in $item"))
+      startDate <- ZIO.fromOption(item.startDate).orElseFail(DataExtractionFailure(s"No start date in $item"))
 
-      oldPrice <- ZIO.fromOption(item.oldPrice).orElseFail(AmendmentDataFailure(s"No old price in $item"))
+      oldPrice <- ZIO.fromOption(item.oldPrice).orElseFail(DataExtractionFailure(s"No old price in $item"))
 
       estimatedNewPrice <-
         ZIO
           .fromOption(item.estimatedNewPrice)
-          .orElseFail(AmendmentDataFailure(s"No estimated new price in $item"))
+          .orElseFail(DataExtractionFailure(s"No estimated new price in $item"))
 
       invoicePreviewTargetDate = startDate.plusMonths(13)
 
@@ -228,7 +228,7 @@ object AmendmentHandler extends CohortHandler {
       _ <-
         if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec) && (newPrice > estimatedNewPrice)) {
           ZIO.fail(
-            AmendmentDataFailure(
+            DataExtractionFailure(
               s"[e9054daa] Item ${item} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice}"
             )
           )

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -41,7 +41,7 @@ object EstimationHandler extends CohortHandler {
   ): ZIO[CohortTable with Zuora, Failure, EstimationResult] =
     doEstimation(catalogue, item, cohortSpec, today).foldZIO(
       failure = {
-        case failure: AmendmentDataFailure =>
+        case failure: DataExtractionFailure =>
           val result = FailedEstimationResult(item.subscriptionName, failure.reason)
           CohortTable.update(CohortItem.fromFailedEstimationResult(result)).as(result)
         case _: CancelledSubscriptionFailure =>

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -193,7 +193,7 @@ object NotificationHandler extends CohortHandler {
       subscription <- Zuora.fetchSubscription(item.subscriptionName)
       estimationInstant <- ZIO
         .fromOption(item.whenEstimationDone)
-        .mapError(ex => AmendmentDataFailure(s"[3026515c] Could not extract whenEstimationDone from item ${item}"))
+        .mapError(ex => DataExtractionFailure(s"[3026515c] Could not extract whenEstimationDone from item ${item}"))
       _ <- subscriptionRatePlansCheck(
         cohortSpec,
         item,

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GW2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GW2024Migration.scala
@@ -204,7 +204,7 @@ object GW2024Migration {
   def priceData(
       subscription: ZuoraSubscription,
       account: ZuoraAccount
-  ): Either[AmendmentDataFailure, PriceData] = {
+  ): Either[DataExtractionFailure, PriceData] = {
     val priceDataOpt = for {
       currency <- subscriptionToCurrency(subscription)
       ratePlan <- subscriptionToMigrationRatePlan(subscription)
@@ -215,7 +215,9 @@ object GW2024Migration {
     priceDataOpt match {
       case Some(pricedata) => Right(pricedata)
       case None =>
-        Left(AmendmentDataFailure(s"Could not determine PriceData for subscription ${subscription.subscriptionNumber}"))
+        Left(
+          DataExtractionFailure(s"Could not determine PriceData for subscription ${subscription.subscriptionNumber}")
+        )
     }
   }
 
@@ -225,20 +227,20 @@ object GW2024Migration {
       oldPrice: BigDecimal,
       estimatedNewPrice: BigDecimal,
       priceCap: BigDecimal
-  ): Either[AmendmentDataFailure, ZuoraSubscriptionUpdate] = {
+  ): Either[DataExtractionFailure, ZuoraSubscriptionUpdate] = {
     for {
       ratePlan <- subscriptionToMigrationRatePlan(subscription).toRight(
-        AmendmentDataFailure(
+        DataExtractionFailure(
           s"[a4d99cf3] Could not determine the Zuora migration rate plan for subscription ${subscription.subscriptionNumber}"
         )
       )
       ratePlanChargeId <- zuoraRatePlanToRatePlanChargeId(ratePlan).toRight(
-        AmendmentDataFailure(
+        DataExtractionFailure(
           s"[105f6c88] Could not determine the rate plan charge id for rate plan ${ratePlan}"
         )
       )
       billingPeriod <- subscriptionToBillingPeriod(subscription).toRight(
-        AmendmentDataFailure(
+        DataExtractionFailure(
           s"[17469705] Could not determine the billing period for subscription ${subscription.subscriptionNumber}"
         )
       )

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeeklyMigration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeeklyMigration.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.migrations
 import pricemigrationengine.model.AmendmentData.RatePlanChargePair
 import pricemigrationengine.model.ZuoraProductCatalogue.{homeDeliveryRatePlans, newGuardianWeeklyRatePlans}
 import pricemigrationengine.model.{
-  AmendmentDataFailure,
+  DataExtractionFailure,
   ZuoraAccount,
   ZuoraProductCatalogue,
   ZuoraProductRatePlan,
@@ -28,17 +28,17 @@ object GuardianWeeklyMigration {
       account: ZuoraAccount,
       catalogue: ZuoraProductCatalogue,
       ratePlanCharges: Seq[ZuoraRatePlanCharge]
-  ): Either[AmendmentDataFailure, GuardianWeeklyMigration] = {
+  ): Either[DataExtractionFailure, GuardianWeeklyMigration] = {
     val billingPeriod = ratePlanCharges.head.billingPeriod match {
       case Some(value) =>
         value match {
           case "Quarter" => "Quarterly"
           case "Month"   => "Monthly"
           case "Annual"  => "Annual"
-          case default   => Left(AmendmentDataFailure(s"billingPeriod is $default for ratePlan"))
+          case default   => Left(DataExtractionFailure(s"billingPeriod is $default for ratePlan"))
         }
 
-      case None => Left(AmendmentDataFailure("billingPeriod is null for ratePlan"))
+      case None => Left(DataExtractionFailure("billingPeriod is null for ratePlan"))
     }
 
     val guardianWeeklyRatePlans =
@@ -48,7 +48,7 @@ object GuardianWeeklyMigration {
     def fetchPlan(
         currentCharges: Seq[ZuoraRatePlanCharge],
         ratePlanName: String
-    ): Either[AmendmentDataFailure, GuardianWeeklyMigration] = {
+    ): Either[DataExtractionFailure, GuardianWeeklyMigration] = {
       val newRatePlan = guardianWeeklyRatePlans
         .find(_.name == ratePlanName)
         .find(_.productRatePlanCharges.head.billingPeriod == currentCharges.head.billingPeriod)
@@ -62,7 +62,7 @@ object GuardianWeeklyMigration {
           Right(GuardianWeeklyMigration(plan, chargePairs))
         case None =>
           Left(
-            AmendmentDataFailure(
+            DataExtractionFailure(
               s"Failed to find new rate plan for Guardian Weekly sub: $ratePlanName, ratePlanCharges: ${ratePlanCharges.mkString(", ")}"
             )
           )
@@ -80,7 +80,7 @@ object GuardianWeeklyMigration {
     def aaaa(
         currency: Currency,
         ratePlanCharges: Seq[ZuoraRatePlanCharge]
-    ): Either[AmendmentDataFailure, GuardianWeeklyMigration] = {
+    ): Either[DataExtractionFailure, GuardianWeeklyMigration] = {
       if (ratePlanCharges.head.currency == "USD") {
         for {
           ratePlan <-

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2024Migration/Amendment.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2024Migration/Amendment.scala
@@ -46,10 +46,12 @@ object Amendment {
   def zuoraUpdate(
       subscription: ZuoraSubscription,
       effectiveDate: LocalDate,
-  ): Either[AmendmentDataFailure, ZuoraSubscriptionUpdate] = {
+  ): Either[DataExtractionFailure, ZuoraSubscriptionUpdate] = {
     for {
-      data2024 <- Estimation.subscriptionToSubscriptionData2024(subscription).left.map(AmendmentDataFailure)
-      chargeDistribution <- subscriptionToNewChargeDistribution2024(subscription).toRight(AmendmentDataFailure("error"))
+      data2024 <- Estimation.subscriptionToSubscriptionData2024(subscription).left.map(DataExtractionFailure)
+      chargeDistribution <- subscriptionToNewChargeDistribution2024(subscription).toRight(
+        DataExtractionFailure("error")
+      )
     } yield ZuoraSubscriptionUpdate(
       add = List(
         AddZuoraRatePlan(

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2024Migration/Estimation.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2024Migration/Estimation.scala
@@ -110,11 +110,11 @@ object Estimation {
 
   def priceData(
       subscription: ZuoraSubscription,
-  ): Either[AmendmentDataFailure, PriceData] = {
+  ): Either[DataExtractionFailure, PriceData] = {
     for {
-      data2024 <- subscriptionToSubscriptionData2024(subscription).left.map(AmendmentDataFailure)
+      data2024 <- subscriptionToSubscriptionData2024(subscription).left.map(DataExtractionFailure)
       oldPrice = data2024.currentPrice
-      newPrice <- subscriptionToNewPrice(subscription).toRight(AmendmentDataFailure("error"))
+      newPrice <- subscriptionToNewPrice(subscription).toRight(DataExtractionFailure("error"))
     } yield PriceData(
       data2024.currency,
       oldPrice,

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -52,14 +52,14 @@ object AmendmentData {
       invoiceList: ZuoraInvoiceList,
       subscription: ZuoraSubscription,
       onOrAfter: LocalDate
-  ): Either[AmendmentDataFailure, LocalDate] =
+  ): Either[DataExtractionFailure, LocalDate] =
     ZuoraInvoiceItem
       .itemsForSubscription(invoiceList, subscription)
       .map(_.serviceStartDate)
       .sortBy(_.toEpochDay)
       .dropWhile(_.isBefore(onOrAfter))
       .headOption
-      .toRight(AmendmentDataFailure(s"Cannot determine next billing date on or after $onOrAfter from $invoiceList"))
+      .toRight(DataExtractionFailure(s"Cannot determine next billing date on or after $onOrAfter from $invoiceList"))
 
   def hasNotPriceAndDiscount(ratePlanCharge: ZuoraRatePlanCharge): Boolean =
     ratePlanCharge.price.isDefined ^ ratePlanCharge.discountPercentage.exists(_ > 0)
@@ -67,23 +67,23 @@ object AmendmentData {
   def ratePlanCharge(
       subscription: ZuoraSubscription,
       invoiceItem: ZuoraInvoiceItem
-  ): Either[AmendmentDataFailure, ZuoraRatePlanCharge] =
+  ): Either[DataExtractionFailure, ZuoraRatePlanCharge] =
     ZuoraRatePlanCharge
       .matchingRatePlanCharge(subscription, invoiceItem)
       .filterOrElse(
         hasNotPriceAndDiscount,
-        AmendmentDataFailure(s"Rate plan charge '${invoiceItem.chargeNumber}' has price and discount")
+        DataExtractionFailure(s"Rate plan charge '${invoiceItem.chargeNumber}' has price and discount")
       )
 
   def ratePlanChargesOrFail(
       subscription: ZuoraSubscription,
       invoiceItems: Seq[ZuoraInvoiceItem]
-  ): Either[AmendmentDataFailure, Seq[ZuoraRatePlanCharge]] = {
+  ): Either[DataExtractionFailure, Seq[ZuoraRatePlanCharge]] = {
     val ratePlanCharges = invoiceItems.map(item => ratePlanCharge(subscription, item))
     val failures = ratePlanCharges.collect { case Left(failure) => failure }
 
     if (failures.isEmpty) Right(ratePlanCharges.collect { case Right(charge) => charge })
-    else Left(AmendmentDataFailure(failures.map(_.reason).mkString(", ")))
+    else Left(DataExtractionFailure(failures.map(_.reason).mkString(", ")))
   }
 
   def ratePlanChargePair(
@@ -99,7 +99,7 @@ object AmendmentData {
   def ratePlanChargePairs(
       catalogue: ZuoraProductCatalogue,
       ratePlanCharges: Seq[ZuoraRatePlanCharge]
-  ): Either[AmendmentDataFailure, Seq[RatePlanChargePair]] = {
+  ): Either[DataExtractionFailure, Seq[RatePlanChargePair]] = {
     /*
      * distinct because where a sub has a discount rate plan,
      * the same discount will appear against each product rate plan charge in the invoice preview.
@@ -109,7 +109,7 @@ object AmendmentData {
     if (failures.isEmpty) Right(pairs.collect { case Right(pricing) => pricing })
     else
       Left(
-        AmendmentDataFailure(
+        DataExtractionFailure(
           s"[AmendmentData] Failed to find matching product rate plan charges for rate plan charges: ${failures.mkString(", ")}"
         )
       )
@@ -122,7 +122,7 @@ object AmendmentData {
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,
       serviceStartDate: LocalDate
-  ): Either[AmendmentDataFailure, BigDecimal] = {
+  ): Either[DataExtractionFailure, BigDecimal] = {
     /*
      * As charge amounts on Zuora invoice previews don't include tax,
      * we have to find the price of the rate plan charges on the subscription
@@ -135,7 +135,7 @@ object AmendmentData {
 
     val discounts = amounts.collect { case Left(percentageDiscount) => percentageDiscount }
 
-    if (discounts.length > 1) Left(AmendmentDataFailure(s"Multiple discounts applied: ${discounts.mkString(", ")}"))
+    if (discounts.length > 1) Left(DataExtractionFailure(s"Multiple discounts applied: ${discounts.mkString(", ")}"))
     else {
       val newPrice = applyDiscountAndThenSum(
         discountPercentage = discounts.headOption,
@@ -161,9 +161,9 @@ object AmendmentData {
     */
   private def totalChargeAmount(
       ratePlanChargePairs: Seq[RatePlanChargePair]
-  ): Either[AmendmentDataFailure, BigDecimal] = {
+  ): Either[DataExtractionFailure, BigDecimal] = {
 
-    def price(ratePlanChargePair: RatePlanChargePair): Either[AmendmentDataFailure, Option[BigDecimal]] =
+    def price(ratePlanChargePair: RatePlanChargePair): Either[DataExtractionFailure, Option[BigDecimal]] =
       ZuoraPricing
         .pricing(ratePlanChargePair.chargeFromProduct, ratePlanChargePair.chargeFromSubscription.currency)
         .flatMap(_.price)
@@ -177,7 +177,7 @@ object AmendmentData {
           ).map(Some(_))
             .left
             .map(e =>
-              AmendmentDataFailure(
+              DataExtractionFailure(
                 s"Failed to calculate amount of rate plan charge ${ratePlanChargePair.chargeFromSubscription.number}: $e"
               )
             )
@@ -185,7 +185,7 @@ object AmendmentData {
 
     val discountPercentageOrFailure = {
       val discounts = ratePlanChargePairs.flatMap(_.chargeFromSubscription.discountPercentage.filter(_ > 0))
-      if (discounts.length > 1) Left(AmendmentDataFailure("Subscription has more than one discount"))
+      if (discounts.length > 1) Left(DataExtractionFailure("Subscription has more than one discount"))
       else Right(discounts.headOption)
     }
 
@@ -216,7 +216,7 @@ object AmendmentData {
       price: BigDecimal,
       subscriptionBillingPeriod: Option[String],
       productBillingPeriod: Option[String]
-  ): Either[AmendmentDataFailure, BigDecimal] = {
+  ): Either[DataExtractionFailure, BigDecimal] = {
 
     val multiple = (subscriptionBillingPeriod, productBillingPeriod) match {
       case (Some(billingPeriod), Some(prodBillingPeriod)) if billingPeriod == prodBillingPeriod => Right(1)
@@ -224,10 +224,10 @@ object AmendmentData {
         monthMultiples
           .get(billingPeriod)
           .map(Right(_))
-          .getOrElse(Left(AmendmentDataFailure(s"Unknown billing period: $billingPeriod")))
+          .getOrElse(Left(DataExtractionFailure(s"Unknown billing period: $billingPeriod")))
       case (billingPeriod, productBillingPeriod) =>
         Left(
-          AmendmentDataFailure(
+          DataExtractionFailure(
             s"Invalid billing period combinations: subscription = $billingPeriod, product = $productBillingPeriod"
           )
         )
@@ -248,7 +248,7 @@ object AmendmentData {
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,
       nextServiceStartDate: LocalDate,
-  ): Either[AmendmentDataFailure, PriceData] = {
+  ): Either[DataExtractionFailure, PriceData] = {
 
     val invoiceItems = ZuoraInvoiceItem.items(invoiceList, subscription, nextServiceStartDate)
 
@@ -258,7 +258,7 @@ object AmendmentData {
       ratePlanCharges <- ratePlanChargesOrFail(subscription, invoiceItems)
       ratePlan <- ZuoraRatePlan
         .ratePlanChargeToMatchingRatePlan(subscription, ratePlanCharges.head)
-        .toRight(AmendmentDataFailure(s"Failed to get RatePlan for charges: $ratePlanCharges"))
+        .toRight(DataExtractionFailure(s"Failed to get RatePlan for charges: $ratePlanCharges"))
 
       isZoneABC = zoneABCPlanNames contains ratePlan.productName
 
@@ -269,13 +269,13 @@ object AmendmentData {
 
       currency <- pairs.headOption
         .map(p => Right(p.chargeFromSubscription.currency))
-        .getOrElse(Left(AmendmentDataFailure(s"No invoice items for date: $nextServiceStartDate")))
+        .getOrElse(Left(DataExtractionFailure(s"No invoice items for date: $nextServiceStartDate")))
       oldPrice <- totalChargeAmount(subscription, invoiceList, nextServiceStartDate)
       newPrice <- totalChargeAmount(pairs)
       billingPeriod <- pairs
         .flatMap(_.chargeFromSubscription.billingPeriod)
         .headOption
-        .toRight(AmendmentDataFailure("Unknown billing period"))
+        .toRight(DataExtractionFailure("Unknown billing period"))
     } yield PriceData(currency, oldPrice, newPrice, billingPeriod)
   }
 
@@ -286,7 +286,7 @@ object AmendmentData {
       invoiceList: ZuoraInvoiceList,
       nextServiceStartDate: LocalDate,
       cohortSpec: CohortSpec,
-  ): Either[AmendmentDataFailure, PriceData] = {
+  ): Either[DataExtractionFailure, PriceData] = {
 
     MigrationType(cohortSpec) match {
       case Membership2023Monthlies =>
@@ -340,7 +340,7 @@ object AmendmentData {
       invoiceList: ZuoraInvoiceList,
       startDateLowerBound: LocalDate,
       cohortSpec: CohortSpec,
-  ): Either[AmendmentDataFailure, AmendmentData] = {
+  ): Either[DataExtractionFailure, AmendmentData] = {
     for {
       startDate <- nextServiceStartDate(invoiceList, subscription, startDateLowerBound)
       price <- priceData(account, catalogue, subscription, invoiceList, startDate, cohortSpec)

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -29,7 +29,7 @@ object EstimationResult {
       invoiceList: ZuoraInvoiceList,
       startDateLowerBound: LocalDate,
       cohortSpec: CohortSpec,
-  ): Either[AmendmentDataFailure, EstimationData] = {
+  ): Either[DataExtractionFailure, EstimationData] = {
     for {
       startDate <- AmendmentData.nextServiceStartDate(invoiceList, subscription, startDateLowerBound)
       priceData <- AmendmentData.priceData(account, catalogue, subscription, invoiceList, startDate, cohortSpec)

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -7,6 +7,8 @@ sealed trait Failure {
 case class InputFailure(reason: String) extends Failure
 case class ConfigFailure(reason: String) extends Failure
 
+case class DataExtractionFailure(reason: String) extends Failure
+
 case class CohortStateMachineFailure(reason: String) extends Failure
 
 case class CohortSpecFetchFailure(reason: String) extends Failure
@@ -24,7 +26,6 @@ case class ZuoraFetchFailure(reason: String) extends Failure
 case class ZuoraUpdateFailure(reason: String) extends Failure
 case class ZuoraRenewalFailure(reason: String) extends Failure
 
-case class AmendmentDataFailure(reason: String) extends Failure
 case class CancelledSubscriptionFailure(reason: String) extends Failure
 case class ExpiringSubscriptionFailure(reason: String) extends Failure
 case class RatePlansProbeFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlanCharge.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlanCharge.scala
@@ -35,11 +35,11 @@ object ZuoraRatePlanCharge {
   def matchingRatePlanCharge(
       subscription: ZuoraSubscription,
       invoiceItem: ZuoraInvoiceItem
-  ): Either[AmendmentDataFailure, ZuoraRatePlanCharge] =
+  ): Either[DataExtractionFailure, ZuoraRatePlanCharge] =
     (for {
       ratePlan <- subscription.ratePlans
       ratePlanCharge <- ratePlan.ratePlanCharges
       if ratePlanCharge.number == invoiceItem.chargeNumber
     } yield ratePlanCharge).headOption
-      .toRight(AmendmentDataFailure(s"No matching rate plan charge for invoice item '${invoiceItem.chargeNumber}'"))
+      .toRight(DataExtractionFailure(s"No matching rate plan charge for invoice item '${invoiceItem.chargeNumber}'"))
 }


### PR DESCRIPTION
### What

We rename `AmendmentDataFailure` into `DataExtractionFailure`

### Why

The AmendmentDataFailure failure object was originally introduced to report failures during data collection for the Amendment handler, but past refactoring have aggregated and consolidated functions used by both the Estimation Handler and the Amendment handler, which then dictate the signature of data migration functions which may have nothing to do with the amendment step itself. 

In this change we simply perform a renaming to absorb the somehow extended role of this failure case, and make the code more intuitive.

This is part of preparing the PR for SupporterPlus2024 (the commit was made here: https://github.com/guardian/price-migration-engine/pull/1056/commits/b210e8cafcd5a542924197b4e006e2a84786df02)