### PR TITLE
Rename migration type Legacy into Default

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -95,7 +95,7 @@ object AmendmentHandler extends CohortHandler {
       case Newspaper2024     => true
       case GW2024            => true
       case SupporterPlus2024 => false
-      case Legacy            => true
+      case Default           => true
     }
   }
 
@@ -161,7 +161,7 @@ object AmendmentHandler extends CohortHandler {
               SupporterPlus2024Migration.priceCap
             )
           )
-        case Legacy =>
+        case Default =>
           ZIO.fromEither(
             ZuoraSubscriptionUpdate
               .zuoraUpdate(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -145,7 +145,7 @@ object NotificationHandler extends CohortHandler {
       currencySymbol <- currencyISOtoSymbol(currencyISOCode)
 
       priceWithOptionalCappingWithCurrencySymbol = MigrationType(cohortSpec) match {
-        case Legacy        => s"${currencySymbol}${PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice)}"
+        case Default       => s"${currencySymbol}${PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice)}"
         case DigiSubs2023  => s"${currencySymbol}${estimatedNewPrice}"
         case Newspaper2024 => s"${currencySymbol}${estimatedNewPrice}"
         case GW2024 =>
@@ -290,7 +290,7 @@ object NotificationHandler extends CohortHandler {
       case Newspaper2024     => newspaper2024Migration.StaticData.maxLeadTime
       case GW2024            => GW2024Migration.maxLeadTime
       case SupporterPlus2024 => SupporterPlus2024Migration.maxLeadTime
-      case Legacy            => 49
+      case Default           => 49
     }
   }
 
@@ -300,7 +300,7 @@ object NotificationHandler extends CohortHandler {
       case Newspaper2024     => newspaper2024Migration.StaticData.minLeadTime
       case GW2024            => GW2024Migration.minLeadTime
       case SupporterPlus2024 => SupporterPlus2024Migration.minLeadTime
-      case Legacy            => 35
+      case Default           => 35
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -86,7 +86,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
         case Newspaper2024 => estimatedNewPrice
         case GW2024        => PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, GW2024Migration.priceCap)
         case SupporterPlus2024 => estimatedNewPrice // [1]
-        case Legacy            => PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice)
+        case Default           => PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice)
       }
       // [1]
       // (Comment group: 7992fa98)

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -293,7 +293,7 @@ object AmendmentData {
       case Newspaper2024     => newspaper2024Migration.Estimation.priceData(subscription)
       case GW2024            => GW2024Migration.priceData(subscription, account)
       case SupporterPlus2024 => SupporterPlus2024Migration.priceData(subscription)
-      case Legacy => priceDataWithRatePlanMatching(account, catalogue, subscription, invoiceList, nextServiceStartDate)
+      case Default => priceDataWithRatePlanMatching(account, catalogue, subscription, invoiceList, nextServiceStartDate)
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
@@ -1,18 +1,7 @@
 package pricemigrationengine.model
 
-/*
-  MigrationType.apply: CohortSpec -> MigrationType
-  was introduced to help remove the `if else if else if ... else` pattern that was showing up as we started to
-  have more migrations, notably the SupporterPlus 2023 migration after the membership annuals. Having defined a
-  sealed trait means that we can use a `match / case` layout, which makes the code more readable
-
-  MigrationType does not identity a migration (despite the fact that some migrations map to a unique migration type)
-  It simply helps identify common code used by possibly more than one migration. For instance all the pre 2023 migrations
-  map to `Legacy`
- */
-
 sealed trait MigrationType
-object Legacy extends MigrationType // refers to all migrations before membership 2023 and supporter 2023
+object Default extends MigrationType
 object DigiSubs2023 extends MigrationType
 object Newspaper2024 extends MigrationType
 object GW2024 extends MigrationType
@@ -25,6 +14,6 @@ object MigrationType {
     case "Newspaper2024"       => Newspaper2024
     case "GW2024"              => GW2024
     case "SupporterPlus2024"   => SupporterPlus2024
-    case _                     => Legacy
+    case _                     => Default
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/util/StartDates.scala
+++ b/lambda/src/main/scala/pricemigrationengine/util/StartDates.scala
@@ -31,7 +31,7 @@ object StartDates {
       case DigiSubs2023      => None
       case Newspaper2024     => None
       case SupporterPlus2024 => None
-      case Legacy            => None
+      case Default           => None
     }
   }
 
@@ -90,7 +90,7 @@ object StartDates {
         case DigiSubs2023      => 3
         case GW2024            => 3
         case SupporterPlus2024 => 1 // no spread for S+2024 monthlies
-        case Legacy            => 3
+        case Default           => 3
       }
     } else 1
   }
@@ -109,7 +109,7 @@ object StartDates {
       case DigiSubs2023      => cohortSpecLowerBound(cohortSpec, today)
       case GW2024            => cohortSpecLowerBound(cohortSpec, today)
       case SupporterPlus2024 => cohortSpecLowerBound(cohortSpec, today)
-      case Legacy            => cohortSpecLowerBound(cohortSpec, today)
+      case Default           => cohortSpecLowerBound(cohortSpec, today)
     }
 
     // We now respect the policy of not increasing members during their first year


### PR DESCRIPTION
We no longer have "Legacy" migrations (a concept that was introduced here: https://github.com/guardian/price-migration-engine/pull/897), but we cannot get rid of that default case of the MigrationType's apply method, because a lot of tests that are using non standard cohort names are triggering it. Consequently we rename it to "Default".

