### PR TITLE
Orders Harmonization: Subscription Amendment 

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -106,119 +106,248 @@ object AmendmentHandler extends CohortHandler {
       item: CohortItem
   ): ZIO[Zuora with Logging, Failure, SuccessfulAmendmentResult] = {
 
-    for {
-      subscriptionBeforeUpdate <- fetchSubscription(item)
+    MigrationType(cohortSpec) match {
+      case SupporterPlus2024 => {
+        for {
+          subscriptionBeforeUpdate <- fetchSubscription(item)
 
-      startDate <- ZIO.fromOption(item.startDate).orElseFail(DataExtractionFailure(s"No start date in $item"))
+          startDate <- ZIO.fromOption(item.startDate).orElseFail(DataExtractionFailure(s"No start date in $item"))
 
-      oldPrice <- ZIO.fromOption(item.oldPrice).orElseFail(DataExtractionFailure(s"No old price in $item"))
+          oldPrice <- ZIO.fromOption(item.oldPrice).orElseFail(DataExtractionFailure(s"No old price in $item"))
 
-      estimatedNewPrice <-
-        ZIO
-          .fromOption(item.estimatedNewPrice)
-          .orElseFail(DataExtractionFailure(s"No estimated new price in $item"))
+          estimatedNewPrice <-
+            ZIO
+              .fromOption(item.estimatedNewPrice)
+              .orElseFail(DataExtractionFailure(s"No estimated new price in $item"))
 
-      invoicePreviewTargetDate = startDate.plusMonths(13)
+          invoicePreviewTargetDate = startDate.plusMonths(13)
 
-      account <- Zuora.fetchAccount(subscriptionBeforeUpdate.accountNumber, subscriptionBeforeUpdate.subscriptionNumber)
-
-      _ <- renewSubscription(subscriptionBeforeUpdate, subscriptionBeforeUpdate.termEndDate, account)
-
-      invoicePreviewBeforeUpdate <-
-        Zuora.fetchInvoicePreview(subscriptionBeforeUpdate.accountId, invoicePreviewTargetDate)
-
-      update <- MigrationType(cohortSpec) match {
-        case DigiSubs2023 =>
-          ZIO.fromEither(
-            DigiSubs2023Migration.zuoraUpdate(
-              subscriptionBeforeUpdate,
-              startDate,
-            )
+          account <- Zuora.fetchAccount(
+            subscriptionBeforeUpdate.accountNumber,
+            subscriptionBeforeUpdate.subscriptionNumber
           )
-        case Newspaper2024 =>
-          ZIO.fromEither(
-            newspaper2024Migration.Amendment.zuoraUpdate(
-              subscriptionBeforeUpdate,
-              startDate,
-            )
-          )
-        case GW2024 =>
-          ZIO.fromEither(
-            GW2024Migration.zuoraUpdate(
-              subscriptionBeforeUpdate,
-              startDate,
-              oldPrice,
-              estimatedNewPrice,
-              GW2024Migration.priceCap
-            )
-          )
-        case SupporterPlus2024 =>
-          ZIO.fromEither(
-            SupporterPlus2024Migration.zuoraUpdate(
-              subscriptionBeforeUpdate,
-              startDate,
-              oldPrice,
-              estimatedNewPrice,
-              SupporterPlus2024Migration.priceCap
-            )
-          )
-        case Default =>
-          ZIO.fromEither(
-            ZuoraSubscriptionUpdate
-              .zuoraUpdate(
-                account,
-                catalogue,
-                subscriptionBeforeUpdate,
-                invoicePreviewBeforeUpdate,
-                startDate,
-                Some(PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice))
+
+          _ <- renewSubscription(subscriptionBeforeUpdate, subscriptionBeforeUpdate.termEndDate, account)
+
+          invoicePreviewBeforeUpdate <-
+            Zuora.fetchInvoicePreview(subscriptionBeforeUpdate.accountId, invoicePreviewTargetDate)
+
+          update <- MigrationType(cohortSpec) match {
+            case DigiSubs2023 =>
+              ZIO.fromEither(
+                DigiSubs2023Migration.zuoraUpdate(
+                  subscriptionBeforeUpdate,
+                  startDate,
+                )
               )
+            case Newspaper2024 =>
+              ZIO.fromEither(
+                newspaper2024Migration.Amendment.zuoraUpdate(
+                  subscriptionBeforeUpdate,
+                  startDate,
+                )
+              )
+            case GW2024 =>
+              ZIO.fromEither(
+                GW2024Migration.zuoraUpdate(
+                  subscriptionBeforeUpdate,
+                  startDate,
+                  oldPrice,
+                  estimatedNewPrice,
+                  GW2024Migration.priceCap
+                )
+              )
+            case SupporterPlus2024 =>
+              ZIO.fromEither(
+                SupporterPlus2024Migration.zuoraUpdate(
+                  subscriptionBeforeUpdate,
+                  startDate,
+                  oldPrice,
+                  estimatedNewPrice,
+                  SupporterPlus2024Migration.priceCap
+                )
+              )
+            case Default =>
+              ZIO.fromEither(
+                ZuoraSubscriptionUpdate
+                  .zuoraUpdate(
+                    account,
+                    catalogue,
+                    subscriptionBeforeUpdate,
+                    invoicePreviewBeforeUpdate,
+                    startDate,
+                    Some(PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice))
+                  )
+              )
+          }
+
+          _ <- Logging.info(
+            s"Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with update ${update}"
           )
-      }
 
-      _ <- Logging.info(s"Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with update ${update}")
+          newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
 
-      newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
+          subscriptionAfterUpdate <- fetchSubscription(item)
 
-      subscriptionAfterUpdate <- fetchSubscription(item)
-
-      _ <- Logging.info(
-        s"[72f444e3] The new subscription id from Zuora.updateSubscription is ${newSubscriptionId}, and the the id from the newly retrieved subscription is ${subscriptionAfterUpdate.id}"
-      )
-
-      invoicePreviewAfterUpdate <-
-        Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)
-
-      newPrice <-
-        ZIO.fromEither(
-          AmendmentData.totalChargeAmount(
-            subscriptionAfterUpdate,
-            invoicePreviewAfterUpdate,
-            startDate
+          _ <- Logging.info(
+            s"[72f444e3] The new subscription id from Zuora.updateSubscription is ${newSubscriptionId}, and the the id from the newly retrieved subscription is ${subscriptionAfterUpdate.id}"
           )
-        )
 
-      _ <-
-        if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec) && (newPrice > estimatedNewPrice)) {
-          ZIO.fail(
-            DataExtractionFailure(
-              s"[e9054daa] Item ${item} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice}"
+          invoicePreviewAfterUpdate <-
+            Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)
+
+          newPrice <-
+            ZIO.fromEither(
+              AmendmentData.totalChargeAmount(
+                subscriptionAfterUpdate,
+                invoicePreviewAfterUpdate,
+                startDate
+              )
             )
-          )
-        } else {
-          ZIO.succeed(())
-        }
 
-      whenDone <- Clock.instant
-    } yield SuccessfulAmendmentResult(
-      item.subscriptionName,
-      startDate,
-      oldPrice,
-      newPrice,
-      estimatedNewPrice,
-      newSubscriptionId,
-      whenDone
-    )
+          _ <-
+            if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec) && (newPrice > estimatedNewPrice)) {
+              ZIO.fail(
+                DataExtractionFailure(
+                  s"[e9054daa] Item ${item} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice}"
+                )
+              )
+            } else {
+              ZIO.succeed(())
+            }
+
+          whenDone <- Clock.instant
+        } yield SuccessfulAmendmentResult(
+          item.subscriptionName,
+          startDate,
+          oldPrice,
+          newPrice,
+          estimatedNewPrice,
+          newSubscriptionId,
+          whenDone
+        )
+      }
+      case _ => {
+        for {
+          subscriptionBeforeUpdate <- fetchSubscription(item)
+
+          startDate <- ZIO.fromOption(item.startDate).orElseFail(DataExtractionFailure(s"No start date in $item"))
+
+          oldPrice <- ZIO.fromOption(item.oldPrice).orElseFail(DataExtractionFailure(s"No old price in $item"))
+
+          estimatedNewPrice <-
+            ZIO
+              .fromOption(item.estimatedNewPrice)
+              .orElseFail(DataExtractionFailure(s"No estimated new price in $item"))
+
+          invoicePreviewTargetDate = startDate.plusMonths(13)
+
+          account <- Zuora.fetchAccount(
+            subscriptionBeforeUpdate.accountNumber,
+            subscriptionBeforeUpdate.subscriptionNumber
+          )
+
+          _ <- renewSubscription(subscriptionBeforeUpdate, subscriptionBeforeUpdate.termEndDate, account)
+
+          invoicePreviewBeforeUpdate <-
+            Zuora.fetchInvoicePreview(subscriptionBeforeUpdate.accountId, invoicePreviewTargetDate)
+
+          update <- MigrationType(cohortSpec) match {
+            case DigiSubs2023 =>
+              ZIO.fromEither(
+                DigiSubs2023Migration.zuoraUpdate(
+                  subscriptionBeforeUpdate,
+                  startDate,
+                )
+              )
+            case Newspaper2024 =>
+              ZIO.fromEither(
+                newspaper2024Migration.Amendment.zuoraUpdate(
+                  subscriptionBeforeUpdate,
+                  startDate,
+                )
+              )
+            case GW2024 =>
+              ZIO.fromEither(
+                GW2024Migration.zuoraUpdate(
+                  subscriptionBeforeUpdate,
+                  startDate,
+                  oldPrice,
+                  estimatedNewPrice,
+                  GW2024Migration.priceCap
+                )
+              )
+            case SupporterPlus2024 =>
+              ZIO.fromEither(
+                SupporterPlus2024Migration.zuoraUpdate(
+                  subscriptionBeforeUpdate,
+                  startDate,
+                  oldPrice,
+                  estimatedNewPrice,
+                  SupporterPlus2024Migration.priceCap
+                )
+              )
+            case Default =>
+              ZIO.fromEither(
+                ZuoraSubscriptionUpdate
+                  .zuoraUpdate(
+                    account,
+                    catalogue,
+                    subscriptionBeforeUpdate,
+                    invoicePreviewBeforeUpdate,
+                    startDate,
+                    Some(PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice))
+                  )
+              )
+          }
+
+          _ <- Logging.info(
+            s"Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with update ${update}"
+          )
+
+          newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
+
+          subscriptionAfterUpdate <- fetchSubscription(item)
+
+          _ <- Logging.info(
+            s"[72f444e3] The new subscription id from Zuora.updateSubscription is ${newSubscriptionId}, and the the id from the newly retrieved subscription is ${subscriptionAfterUpdate.id}"
+          )
+
+          invoicePreviewAfterUpdate <-
+            Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)
+
+          newPrice <-
+            ZIO.fromEither(
+              AmendmentData.totalChargeAmount(
+                subscriptionAfterUpdate,
+                invoicePreviewAfterUpdate,
+                startDate
+              )
+            )
+
+          _ <-
+            if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec) && (newPrice > estimatedNewPrice)) {
+              ZIO.fail(
+                DataExtractionFailure(
+                  s"[e9054daa] Item ${item} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice}"
+                )
+              )
+            } else {
+              ZIO.succeed(())
+            }
+
+          whenDone <- Clock.instant
+        } yield SuccessfulAmendmentResult(
+          item.subscriptionName,
+          startDate,
+          oldPrice,
+          newPrice,
+          estimatedNewPrice,
+          newSubscriptionId,
+          whenDone
+        )
+      }
+    }
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -290,7 +290,7 @@ object AmendmentHandler extends CohortHandler {
           oldPrice,
           newPrice,
           estimatedNewPrice,
-          newSubscriptionId,
+          subscriptionAfterUpdate.id,
           whenDone
         )
       }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -176,9 +176,15 @@ object AmendmentHandler extends CohortHandler {
           )
       }
 
+      _ <- Logging.info(s"Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with update ${update}")
+
       newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
 
       subscriptionAfterUpdate <- fetchSubscription(item)
+
+      _ <- Logging.info(
+        s"[72f444e3] The new subscription id from Zuora.updateSubscription is ${newSubscriptionId}, and the the id from the newly retrieved subscription is ${subscriptionAfterUpdate.id}"
+      )
 
       invoicePreviewAfterUpdate <-
         Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -260,10 +260,6 @@ object AmendmentHandler extends CohortHandler {
 
           subscriptionAfterUpdate <- fetchSubscription(item)
 
-          _ <- Logging.info(
-            s"[72f444e3] The new subscription id from Zuora.updateSubscription is ${newSubscriptionId}, and the the id from the newly retrieved subscription is ${subscriptionAfterUpdate.id}"
-          )
-
           invoicePreviewAfterUpdate <-
             Zuora.fetchInvoicePreview(subscriptionAfterUpdate.accountId, invoicePreviewTargetDate)
 

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
@@ -323,4 +323,127 @@ object SupporterPlus2024Migration {
       )
     }
   }
+
+  /*
+{
+  "orderDate": "2024-10-24",
+  "existingAccountNumber": "A01955911",
+  "subscriptions": [
+    {
+      "subscriptionNumber": "A-S02019224",
+      "orderActions": [
+        {
+          "type": "RemoveProduct",
+          "triggerDates": [
+            {
+              "name": "ContractEffective",
+              "triggerDate": "2024-11-26"
+            },
+            {
+              "name": "ServiceActivation",
+              "triggerDate": "2024-11-26"
+            },
+            {
+              "name": "CustomerAcceptance",
+              "triggerDate": "2024-11-26"
+            }
+          ],
+          "removeProduct": {
+            "ratePlanId": "8a128e208bdd4251018c0d5050970bd9"
+          }
+        },
+        {
+          "type": "AddProduct",
+          "triggerDates": [
+            {
+              "name": "ContractEffective",
+              "triggerDate": "2024-11-26"
+            },
+            {
+              "name": "ServiceActivation",
+              "triggerDate": "2024-11-26"
+            },
+            {
+              "name": "CustomerAcceptance",
+              "triggerDate": "2024-11-26"
+            }
+          ],
+          "addProduct": {
+            "productRatePlanId": "8a128ed885fc6ded018602296ace3eb8",
+            "chargeOverrides": [
+              {
+                "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
+                "pricing": {
+                  "recurringFlatFee": {
+                    "listPrice": 15
+                  }
+                }
+              },
+              {
+                "productRatePlanChargeId": "8a128d7085fc6dec01860234cd075270",
+                "pricing": {
+                  "recurringFlatFee": {
+                    "listPrice": 0
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "processingOptions": {
+    "runBilling": false,
+    "collectPayment": false
+  }
+}
+   */
+
+  def amendmentOrdersPayload(
+      orderDate: LocalDate,
+      accountNumber: String,
+      subscriptionNumber: String,
+      effectDate: LocalDate,
+      removeRatePlanId: String,
+      newBaseAmount: BigDecimal,
+      newContributionAmount: BigDecimal
+  ): ZuoraAmendmentOrderPayload = {
+    val triggerDates = List(
+      ZuoraAmendmentOrderPayloadOrderActionTriggerDate("ContractEffective", effectDate),
+      ZuoraAmendmentOrderPayloadOrderActionTriggerDate("ServiceActivation", effectDate),
+      ZuoraAmendmentOrderPayloadOrderActionTriggerDate("CustomerAcceptance", effectDate)
+    )
+    val actionRemove = ZuoraAmendmentOrderPayloadOrderActionRemove(
+      triggerDates = triggerDates,
+      removeProduct = ZuoraAmendmentOrderPayloadOrderActionRemoveProduct(removeRatePlanId)
+    )
+    val actionAdd = ZuoraAmendmentOrderPayloadOrderActionAdd(
+      triggerDates = triggerDates,
+      addProduct = ZuoraAmendmentOrderPayloadOrderActionAddProduct(
+        productRatePlanId = "8a128ed885fc6ded018602296ace3eb8",
+        chargeOverrides = List(
+          ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+            productRatePlanChargeId = "8a128ed885fc6ded018602296af13eba",
+            pricing = Map("recurringFlatFee" -> Map("listPrice" -> newBaseAmount))
+          ),
+          ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+            productRatePlanChargeId = "8a128d7085fc6dec01860234cd075270",
+            pricing = Map("recurringFlatFee" -> Map("listPrice" -> newContributionAmount))
+          )
+        )
+      )
+    )
+    val orderActions = List(actionRemove, actionAdd)
+    val subscriptions = List(
+      ZuoraAmendmentOrderPayloadSubscription(subscriptionNumber, orderActions)
+    )
+    val processingOptions = ZuoraAmendmentOrderPayloadProcessingOptions(runBilling = false, collectPayment = false)
+    ZuoraAmendmentOrderPayload(
+      orderDate = orderDate,
+      existingAccountNumber = accountNumber,
+      subscriptions = subscriptions,
+      processingOptions = processingOptions
+    )
+  }
 }

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
@@ -349,10 +349,12 @@ object SupporterPlus2024Migration {
       ZuoraAmendmentOrderPayloadOrderActionTriggerDate("CustomerAcceptance", effectDate)
     )
     val actionRemove = ZuoraAmendmentOrderPayloadOrderActionRemove(
+      `type` = "RemoveProduct",
       triggerDates = triggerDates,
       removeProduct = ZuoraAmendmentOrderPayloadOrderActionRemoveProduct(removeRatePlanId)
     )
     val actionAdd = ZuoraAmendmentOrderPayloadOrderActionAdd(
+      `type` = "AddProduct",
       triggerDates = triggerDates,
       addProduct = ZuoraAmendmentOrderPayloadOrderActionAddProduct(
         productRatePlanId = productRatePlanId,

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -25,6 +25,7 @@ case class ZuoraFailure(reason: String) extends Failure
 case class ZuoraFetchFailure(reason: String) extends Failure
 case class ZuoraUpdateFailure(reason: String) extends Failure
 case class ZuoraRenewalFailure(reason: String) extends Failure
+case class ZuoraOrderFailure(reason: String) extends Failure
 
 case class CancelledSubscriptionFailure(reason: String) extends Failure
 case class ExpiringSubscriptionFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraAmendmentOrderPayload.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraAmendmentOrderPayload.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.model
 
 import java.time.LocalDate
-import upickle.default.{ReadWriter, macroRW}
+import upickle.default._
 
 // Zuora documentation: https://knowledgecenter.zuora.com/Zuora_Billing/Manage_subscription_transactions/Orders/Order_actions_tutorials/D_Replace_a_product_in_a_subscription
 
@@ -25,7 +25,73 @@ case class ZuoraAmendmentOrderPayloadOrderActionRemove(
     removeProduct: ZuoraAmendmentOrderPayloadOrderActionRemoveProduct
 ) extends ZuoraAmendmentOrderPayloadOrderAction
 object ZuoraAmendmentOrderPayloadOrderActionRemove {
-  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionRemove] = macroRW
+
+  /*
+
+  We are using a custom JSON serialisation for this class because the JSON serialisation provided by upickle
+  would produce:
+
+  {
+    "$type": "ZuoraAmendmentOrderPayloadOrderActionRemove",
+    "triggerDates": [
+      {
+        "name": "ContractEffective",
+        "triggerDate": "2024-11-26"
+      },
+      {
+        "name": "ServiceActivation",
+        "triggerDate": "2024-11-26"
+      },
+      {
+        "name": "CustomerAcceptance",
+        "triggerDate": "2024-11-26"
+      }
+    ],
+    "removeProduct": {
+      "ratePlanId": "8a128e208bdd4251018c0d5050970bd9"
+    }
+  }
+
+  whereas we want:
+
+  {
+    "type": "RemoveProduct",
+    "triggerDates": [
+      {
+        "name": "ContractEffective",
+        "triggerDate": "2024-11-26"
+      },
+      {
+        "name": "ServiceActivation",
+        "triggerDate": "2024-11-26"
+      },
+      {
+        "name": "CustomerAcceptance",
+        "triggerDate": "2024-11-26"
+      }
+    ],
+    "removeProduct": {
+      "ratePlanId": "8a128e208bdd4251018c0d5050970bd9"
+    }
+  }
+
+   */
+
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionRemove] = {
+    readwriter[ujson.Value].bimap[ZuoraAmendmentOrderPayloadOrderActionRemove](
+      action =>
+        ujson.Obj(
+          "type" -> ujson.Str("RemoveProduct"),
+          "triggerDates" -> writeJs(action.triggerDates),
+          "removeProduct" -> writeJs(action.removeProduct)
+        ),
+      json =>
+        ZuoraAmendmentOrderPayloadOrderActionRemove(
+          triggerDates = read[List[ZuoraAmendmentOrderPayloadOrderActionTriggerDate]](json("triggerDates")),
+          removeProduct = read[ZuoraAmendmentOrderPayloadOrderActionRemoveProduct](json("removeProduct"))
+        )
+    )
+  }
 }
 
 case class ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
@@ -49,7 +115,107 @@ case class ZuoraAmendmentOrderPayloadOrderActionAdd(
     addProduct: ZuoraAmendmentOrderPayloadOrderActionAddProduct
 ) extends ZuoraAmendmentOrderPayloadOrderAction
 object ZuoraAmendmentOrderPayloadOrderActionAdd {
-  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionAdd] = macroRW
+  /*
+
+  We are using a custom JSON serialisation for this class because the JSON serialisation provided by upickle
+would produce:
+
+  {
+    "$type": "ZuoraAmendmentOrderPayloadOrderActionAdd",
+    "triggerDates": [
+      {
+        "name": "ContractEffective",
+        "triggerDate": "2024-11-26"
+      },
+      {
+        "name": "ServiceActivation",
+        "triggerDate": "2024-11-26"
+      },
+      {
+        "name": "CustomerAcceptance",
+        "triggerDate": "2024-11-26"
+      }
+    ],
+    "addProduct": {
+      "productRatePlanId": "8a128ed885fc6ded018602296ace3eb8",
+      "chargeOverrides": [
+        {
+          "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
+          "pricing": {
+            "recurringFlatFee": {
+              "listPrice": 15
+            }
+          }
+        },
+        {
+          "productRatePlanChargeId": "8a128d7085fc6dec01860234cd075270",
+          "pricing": {
+            "recurringFlatFee": {
+              "listPrice": 0
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  whereas we want:
+
+  {
+    "type": "AddProduct",
+    "triggerDates": [
+      {
+        "name": "ContractEffective",
+        "triggerDate": "2024-11-26"
+      },
+      {
+        "name": "ServiceActivation",
+        "triggerDate": "2024-11-26"
+      },
+      {
+        "name": "CustomerAcceptance",
+        "triggerDate": "2024-11-26"
+      }
+    ],
+    "addProduct": {
+      "productRatePlanId": "8a128ed885fc6ded018602296ace3eb8",
+      "chargeOverrides": [
+        {
+          "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
+          "pricing": {
+            "recurringFlatFee": {
+              "listPrice": 15
+            }
+          }
+        },
+        {
+          "productRatePlanChargeId": "8a128d7085fc6dec01860234cd075270",
+          "pricing": {
+            "recurringFlatFee": {
+              "listPrice": 0
+            }
+          }
+        }
+      ]
+    }
+  }
+
+   */
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionAdd] = {
+    readwriter[ujson.Value].bimap[ZuoraAmendmentOrderPayloadOrderActionAdd](
+      action =>
+        ujson.Obj(
+          "type" -> ujson.Str("AddProduct"),
+          "triggerDates" -> writeJs(action.triggerDates),
+          "addProduct" -> writeJs(action.addProduct)
+        ),
+      json =>
+        ZuoraAmendmentOrderPayloadOrderActionAdd(
+          triggerDates = read[List[ZuoraAmendmentOrderPayloadOrderActionTriggerDate]](json("triggerDates")),
+          addProduct = read[ZuoraAmendmentOrderPayloadOrderActionAddProduct](json("addProduct"))
+        )
+    )
+  }
 }
 
 case class ZuoraAmendmentOrderPayloadSubscription(

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraAmendmentOrderPayload.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraAmendmentOrderPayload.scala
@@ -74,3 +74,12 @@ case class ZuoraAmendmentOrderPayload(
 object ZuoraAmendmentOrderPayload {
   implicit val rw: ReadWriter[ZuoraAmendmentOrderPayload] = macroRW
 }
+
+case class ZuoraAmendmentOrderResponse(
+    success: Boolean
+    // Be careful if you are considering extending this class because the answer's shape
+    // varies depending on whether the operation was successful or not.
+)
+object ZuoraAmendmentOrderResponse {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderResponse] = macroRW
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraAmendmentOrderPayload.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraAmendmentOrderPayload.scala
@@ -3,7 +3,117 @@ package pricemigrationengine.model
 import java.time.LocalDate
 import upickle.default._
 
-// Zuora documentation: https://knowledgecenter.zuora.com/Zuora_Billing/Manage_subscription_transactions/Orders/Order_actions_tutorials/D_Replace_a_product_in_a_subscription
+/*
+  Author: Pascal
+  Comment id: 4eb4b0a9
+
+  This file was written in October 2024 when we introduced Zuora.applyAmendmentOrder with the aim
+  of eventually decommissioning Zuora.updateSubscription.
+
+  The documentation for this Order is available here:
+  Zuora documentation: https://knowledgecenter.zuora.com/Zuora_Billing/Manage_subscription_transactions/Orders/Order_actions_tutorials/D_Replace_a_product_in_a_subscription
+
+  The migration to the new Orders API is currently a work in progress and the choice of the
+  model hierarchy in this file reflects the fact that we are migrating SupporterPlus2024
+  from the old API to the new Orders API; in other words migrating the amendment a
+  SupporterPlus2024 subscription from using Zuora.updateSubscription to using Zuora.applyAmendmentOrder
+ */
+
+/*
+  Author: Pascal
+  Comment id: cada56ad
+
+  The model hierarchy presented in this file captures the making of a ZuoraAmendmentOrderPayload according
+  to the schema presented here: https://knowledgecenter.zuora.com/Zuora_Billing/Manage_subscription_transactions/Orders/Order_actions_tutorials/D_Replace_a_product_in_a_subscription
+
+  One interesting note about the design is using a sealed trait to represent the different types of an Order action,
+  in the context of replacing a product in a subscription. Indeed, the two actions in that order are:
+
+  {
+    "type": "RemoveProduct",
+    "triggerDates": [
+        {
+            "name": "ContractEffective",
+            "triggerDate": "2024-11-28"
+        },
+        {
+            "name": "ServiceActivation",
+            "triggerDate": "2024-11-28"
+        },
+        {
+            "name": "CustomerAcceptance",
+            "triggerDate": "2024-11-28"
+        }
+    ],
+    "removeProduct": {
+        "ratePlanId": "8a12867e92c341870192c7c46bdb47d6"
+    }
+}
+
+and
+
+{
+    "type": "AddProduct",
+    "triggerDates": [
+        {
+            "name": "ContractEffective",
+            "triggerDate": "2024-11-28"
+        },
+        {
+            "name": "ServiceActivation",
+            "triggerDate": "2024-11-28"
+        },
+        {
+            "name": "CustomerAcceptance",
+            "triggerDate": "2024-11-28"
+        }
+    ],
+    "addProduct": {
+        "productRatePlanId": "8a128ed885fc6ded018602296ace3eb8",
+        "chargeOverrides": [
+            {
+                "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
+                "pricing": {
+                    "recurringFlatFee": {
+                        "listPrice": 12
+                    }
+                }
+            },
+            {
+                "productRatePlanChargeId": "8a128d7085fc6dec01860234cd075270",
+                "pricing": {
+                    "recurringFlatFee": {
+                        "listPrice": 0
+                    }
+                }
+            }
+        ]
+    }
+}
+
+They are respectively modeled as
+
+ZuoraAmendmentOrderPayloadOrderActionRemove
+and
+ZuoraAmendmentOrderPayloadOrderActionAdd
+
+Because of the way upickle works, we end up with a JSON serialization that has a "$type" field which is a bit annoying.
+We can see it in the test data in SupporterPlus2024MigrationTest.
+
+I have tried to submit the Orders payload to Zuora with the "$type" field left inside the JSON but
+Zuora errors during the processing. (Technically, it should actually work, but I think that Zuora may be doing payload introspection
+beyond the mandatory fields and is error'ing on the "$type" field)
+
+I have tried to remove the "$type" field by providing a custom writer for the serialization of two classes, but
+could not get that to work.
+
+In the end the solution I have chosen was to remove the "$type" field from the JSON before sending it to Zuora,
+which explains the function type_flush in the ZuoraLive implementation of applyAmendmentOrder
+
+This is, for all intent and purpose a hack and in a future change we may try and get those
+custom writers to work to avoid string manipulation in the implementation of applyAmendmentOrder.
+
+ */
 
 sealed trait ZuoraAmendmentOrderPayloadOrderAction
 object ZuoraAmendmentOrderPayloadOrderAction {

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraAmendmentOrderPayload.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraAmendmentOrderPayload.scala
@@ -1,0 +1,76 @@
+package pricemigrationengine.model
+
+import java.time.LocalDate
+import upickle.default.{ReadWriter, macroRW}
+
+// Zuora documentation: https://knowledgecenter.zuora.com/Zuora_Billing/Manage_subscription_transactions/Orders/Order_actions_tutorials/D_Replace_a_product_in_a_subscription
+
+sealed trait ZuoraAmendmentOrderPayloadOrderAction
+object ZuoraAmendmentOrderPayloadOrderAction {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderAction] = macroRW
+}
+
+case class ZuoraAmendmentOrderPayloadOrderActionTriggerDate(name: String, triggerDate: LocalDate)
+object ZuoraAmendmentOrderPayloadOrderActionTriggerDate {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionTriggerDate] = macroRW
+}
+
+case class ZuoraAmendmentOrderPayloadOrderActionRemoveProduct(ratePlanId: String)
+object ZuoraAmendmentOrderPayloadOrderActionRemoveProduct {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionRemoveProduct] = macroRW
+}
+
+case class ZuoraAmendmentOrderPayloadOrderActionRemove(
+    triggerDates: List[ZuoraAmendmentOrderPayloadOrderActionTriggerDate],
+    removeProduct: ZuoraAmendmentOrderPayloadOrderActionRemoveProduct
+) extends ZuoraAmendmentOrderPayloadOrderAction
+object ZuoraAmendmentOrderPayloadOrderActionRemove {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionRemove] = macroRW
+}
+
+case class ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+    productRatePlanChargeId: String,
+    pricing: Map[String, Map[String, BigDecimal]]
+)
+object ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride] = macroRW
+}
+
+case class ZuoraAmendmentOrderPayloadOrderActionAddProduct(
+    productRatePlanId: String,
+    chargeOverrides: List[ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride]
+)
+object ZuoraAmendmentOrderPayloadOrderActionAddProduct {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionAddProduct] = macroRW
+}
+
+case class ZuoraAmendmentOrderPayloadOrderActionAdd(
+    triggerDates: List[ZuoraAmendmentOrderPayloadOrderActionTriggerDate],
+    addProduct: ZuoraAmendmentOrderPayloadOrderActionAddProduct
+) extends ZuoraAmendmentOrderPayloadOrderAction
+object ZuoraAmendmentOrderPayloadOrderActionAdd {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadOrderActionAdd] = macroRW
+}
+
+case class ZuoraAmendmentOrderPayloadSubscription(
+    subscriptionNumber: String,
+    orderActions: List[ZuoraAmendmentOrderPayloadOrderAction]
+)
+object ZuoraAmendmentOrderPayloadSubscription {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadSubscription] = macroRW
+}
+
+case class ZuoraAmendmentOrderPayloadProcessingOptions(runBilling: Boolean, collectPayment: Boolean)
+object ZuoraAmendmentOrderPayloadProcessingOptions {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayloadProcessingOptions] = macroRW
+}
+
+case class ZuoraAmendmentOrderPayload(
+    orderDate: LocalDate,
+    existingAccountNumber: String,
+    subscriptions: List[ZuoraAmendmentOrderPayloadSubscription],
+    processingOptions: ZuoraAmendmentOrderPayloadProcessingOptions
+)
+object ZuoraAmendmentOrderPayload {
+  implicit val rw: ReadWriter[ZuoraAmendmentOrderPayload] = macroRW
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraRenewOrderPayload.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraRenewOrderPayload.scala
@@ -40,9 +40,10 @@ object ZuoraRenewOrderPayload {
   implicit val rwZuoraRenewOrderPayload: ReadWriter[ZuoraRenewOrderPayload] = macroRW
 
   def apply(
+      orderDate: LocalDate,
       subscriptionNumber: String,
-      effectDate: LocalDate,
-      accountNumber: String
+      accountNumber: String,
+      effectDate: LocalDate
   ): ZuoraRenewOrderPayload = {
     val triggerDates = List(
       ZuoraRenewOrderPayloadOrderActionTriggerDate(
@@ -76,7 +77,7 @@ object ZuoraRenewOrderPayload {
     val processingOptions = ZuoraRenewOrderPayloadProcessingOptions(runBilling = false, collectPayment = false)
 
     ZuoraRenewOrderPayload(
-      orderDate = effectDate,
+      orderDate = orderDate,
       existingAccountNumber = accountNumber,
       subscriptions = subscriptions,
       processingOptions = processingOptions

--- a/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/Zuora.scala
@@ -20,6 +20,11 @@ trait Zuora {
       update: ZuoraSubscriptionUpdate
   ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId]
 
+  def applyAmendmentOrder(
+      subscription: ZuoraSubscription,
+      payload: ZuoraAmendmentOrderPayload
+  ): ZIO[Any, ZuoraOrderFailure, Unit]
+
   def renewSubscription(
       subscriptionNumber: String,
       payload: ZuoraRenewOrderPayload
@@ -45,6 +50,12 @@ object Zuora {
       update: ZuoraSubscriptionUpdate
   ): ZIO[Zuora, ZuoraUpdateFailure, ZuoraSubscriptionId] =
     ZIO.environmentWithZIO(_.get.updateSubscription(subscription, update))
+
+  def applyAmendmentOrder(
+      subscription: ZuoraSubscription,
+      payload: ZuoraAmendmentOrderPayload
+  ): ZIO[Zuora, ZuoraOrderFailure, Unit] =
+    ZIO.environmentWithZIO(_.get.applyAmendmentOrder(subscription, payload))
 
   def renewSubscription(
       subscriptionNumber: String,

--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -208,11 +208,37 @@ object ZuoraLive {
           )
         }
 
+        override def applyAmendmentOrder(
+            subscription: ZuoraSubscription,
+            payload: ZuoraAmendmentOrderPayload
+        ): ZIO[Any, ZuoraOrderFailure, Unit] = {
+          post[ZuoraAmendmentOrderResponse](
+            path = s"orders",
+            body = write(payload)
+          ).foldZIO(
+            failure = e =>
+              ZIO.fail(
+                ZuoraOrderFailure(
+                  s"[f8569839] subscription number: ${subscription.subscriptionNumber}, payload: ${payload}, reason: ${e.reason}"
+                )
+              ),
+            success = response =>
+              if (response.success) {
+                ZIO.succeed(())
+              } else {
+                ZIO.fail(
+                  ZuoraOrderFailure(
+                    s"[bb6f22ef] subscription number: ${subscription.subscriptionNumber}, payload: ${payload}, with answer ${response}"
+                  )
+                )
+              }
+          )
+        }
+
         override def renewSubscription(
             subscriptionNumber: String,
             payload: ZuoraRenewOrderPayload
         ): ZIO[Any, ZuoraRenewalFailure, Unit] = {
-
           post[ZuoraRenewOrderResponse](
             path = s"orders",
             body = write(payload)
@@ -220,7 +246,7 @@ object ZuoraLive {
             failure = e =>
               ZIO.fail(
                 ZuoraRenewalFailure(
-                  s"[06f5bd6f] subscription number: $subscriptionNumber, payload: ${payload}, reason: ${e.reason}"
+                  s"[06f5bd6f] subscription number: ${subscriptionNumber}, payload: ${payload}, reason: ${e.reason}"
                 )
               ),
             success = response =>
@@ -229,7 +255,7 @@ object ZuoraLive {
               } else {
                 ZIO.fail(
                   ZuoraRenewalFailure(
-                    s"[bc532694] subscription number: $subscriptionNumber, payload: ${payload}, with answer ${response}"
+                    s"[bc532694] subscription number: ${subscriptionNumber}, payload: ${payload}, with answer ${response}"
                   )
                 )
               }

--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -228,7 +228,7 @@ object ZuoraLive {
               } else {
                 ZIO.fail(
                   ZuoraOrderFailure(
-                    s"[bb6f22ef] subscription number: ${subscription.subscriptionNumber}, payload: ${payload}, with answer ${response}"
+                    s"[bb6f22ef] subscription number: ${subscription.subscriptionNumber}, payload: ${payload}, serialised payload: ${write(payload)}, with answer ${response}"
                   )
                 )
               }

--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -212,9 +212,18 @@ object ZuoraLive {
             subscription: ZuoraSubscription,
             payload: ZuoraAmendmentOrderPayload
         ): ZIO[Any, ZuoraOrderFailure, Unit] = {
+
+          def type_flush(str: String): String = {
+            str
+              .replace(""""$type":"ZuoraAmendmentOrderPayloadOrderActionAdd",""", "")
+              .replace(""""$type":"ZuoraAmendmentOrderPayloadOrderActionRemove",""", "")
+          }
+
+          val body = type_flush(write(payload))
+
           post[ZuoraAmendmentOrderResponse](
             path = s"orders",
-            body = write(payload)
+            body = type_flush(write(payload))
           ).foldZIO(
             failure = e =>
               ZIO.fail(
@@ -228,7 +237,7 @@ object ZuoraLive {
               } else {
                 ZIO.fail(
                   ZuoraOrderFailure(
-                    s"[bb6f22ef] subscription number: ${subscription.subscriptionNumber}, payload: ${payload}, serialised payload: ${write(payload)}, with answer ${response}"
+                    s"[bb6f22ef] subscription number: ${subscription.subscriptionNumber}, payload: ${payload}, serialised payload: ${body}, with answer ${response}"
                   )
                 )
               }

--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -213,6 +213,11 @@ object ZuoraLive {
             payload: ZuoraAmendmentOrderPayload
         ): ZIO[Any, ZuoraOrderFailure, Unit] = {
 
+          // The existence of type_flush is explained in comment cada56ad.
+          // This is, for all intent and purpose a hack due to the way upickle deals with sealed traits
+          // and in a future change we will get rid of it, either by changing JSON library or coming up
+          // with the correct writers.
+
           def type_flush(str: String): String = {
             str
               .replace(""""$type":"ZuoraAmendmentOrderPayloadOrderActionAdd",""", "")

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -163,6 +163,11 @@ class NotificationHandlerTest extends munit.FunSuite {
             update: ZuoraSubscriptionUpdate
         ): ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId] = ZIO.succeed("ZuoraSubscriptionId")
 
+        override def applyAmendmentOrder(
+            subscription: ZuoraSubscription,
+            payload: ZuoraAmendmentOrderPayload
+        ): ZIO[Any, ZuoraOrderFailure, Unit] = ZIO.succeed(())
+
         override def renewSubscription(
             subscriptionNumber: String,
             payload: ZuoraRenewOrderPayload

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
@@ -1,10 +1,10 @@
 package pricemigrationengine.migrations
 
 import pricemigrationengine.model._
+import upickle.default._
 
 import java.time.LocalDate
 import pricemigrationengine.Fixtures
-import pricemigrationengine.migrations.SupporterPlus2024Migration
 
 class SupporterPlus2024MigrationTest extends munit.FunSuite {
 
@@ -857,6 +857,390 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
           currentTermPeriodType = None
         )
       )
+    )
+  }
+
+  // -----------------------------------
+  // Orders API
+
+  test("amendmentOrderPayload (monthly)") {
+    val subscription = Fixtures.subscriptionFromJson("Migrations/SupporterPlus2024/monthly/subscription.json")
+    assertEquals(
+      SupporterPlus2024Migration.amendmentOrderPayload(
+        orderDate = LocalDate.of(2024, 10, 25),
+        accountNumber = "74bff0f2",
+        subscriptionNumber = subscription.subscriptionNumber,
+        effectDate = LocalDate.of(2024, 11, 27),
+        subscription = subscription,
+        oldPrice = 10,
+        estimatedNewPrice = 12,
+        priceCap = 1.27
+      ),
+      Right(
+        ZuoraAmendmentOrderPayload(
+          orderDate = LocalDate.of(2024, 10, 25),
+          existingAccountNumber = "74bff0f2",
+          subscriptions = List(
+            ZuoraAmendmentOrderPayloadSubscription(
+              subscriptionNumber = "SUBSCRIPTION-NUMBER",
+              orderActions = List(
+                ZuoraAmendmentOrderPayloadOrderActionRemove(
+                  triggerDates = List(
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ContractEffective",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ServiceActivation",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "CustomerAcceptance",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    )
+                  ),
+                  removeProduct = ZuoraAmendmentOrderPayloadOrderActionRemoveProduct(
+                    ratePlanId = "8a12908b8dd07f56018de8f4950923b8"
+                  )
+                ),
+                ZuoraAmendmentOrderPayloadOrderActionAdd(
+                  triggerDates = List(
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ContractEffective",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ServiceActivation",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "CustomerAcceptance",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    )
+                  ),
+                  addProduct = ZuoraAmendmentOrderPayloadOrderActionAddProduct(
+                    productRatePlanId = "8a128ed885fc6ded018602296ace3eb8",
+                    chargeOverrides = List(
+                      ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+                        productRatePlanChargeId = "8a128ed885fc6ded018602296af13eba",
+                        pricing = Map(
+                          "recurringFlatFee" -> Map(
+                            "listPrice" -> 12
+                          )
+                        )
+                      ),
+                      ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+                        productRatePlanChargeId = "8a128d7085fc6dec01860234cd075270",
+                        pricing = Map(
+                          "recurringFlatFee" -> Map(
+                            "listPrice" -> 0.0
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          ),
+          processingOptions = ZuoraAmendmentOrderPayloadProcessingOptions(false, false)
+        )
+      )
+    )
+  }
+
+  test("amendmentOrderPayload (monthly), with artificial cap") {
+    val subscription = Fixtures.subscriptionFromJson("Migrations/SupporterPlus2024/monthly/subscription.json")
+    assertEquals(
+      SupporterPlus2024Migration.amendmentOrderPayload(
+        orderDate = LocalDate.of(2024, 10, 25),
+        accountNumber = "74bff0f2",
+        subscriptionNumber = subscription.subscriptionNumber,
+        effectDate = LocalDate.of(2024, 11, 27),
+        subscription = subscription,
+        oldPrice = 10,
+        estimatedNewPrice = 12,
+        priceCap = 1.1
+      ),
+      Right(
+        ZuoraAmendmentOrderPayload(
+          orderDate = LocalDate.of(2024, 10, 25),
+          existingAccountNumber = "74bff0f2",
+          subscriptions = List(
+            ZuoraAmendmentOrderPayloadSubscription(
+              subscriptionNumber = "SUBSCRIPTION-NUMBER",
+              orderActions = List(
+                ZuoraAmendmentOrderPayloadOrderActionRemove(
+                  triggerDates = List(
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ContractEffective",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ServiceActivation",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "CustomerAcceptance",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    )
+                  ),
+                  removeProduct = ZuoraAmendmentOrderPayloadOrderActionRemoveProduct(
+                    ratePlanId = "8a12908b8dd07f56018de8f4950923b8"
+                  )
+                ),
+                ZuoraAmendmentOrderPayloadOrderActionAdd(
+                  triggerDates = List(
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ContractEffective",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ServiceActivation",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "CustomerAcceptance",
+                      triggerDate = LocalDate.of(2024, 11, 27)
+                    )
+                  ),
+                  addProduct = ZuoraAmendmentOrderPayloadOrderActionAddProduct(
+                    productRatePlanId = "8a128ed885fc6ded018602296ace3eb8",
+                    chargeOverrides = List(
+                      ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+                        productRatePlanChargeId = "8a128ed885fc6ded018602296af13eba",
+                        pricing = Map(
+                          "recurringFlatFee" -> Map(
+                            "listPrice" -> 11
+                          )
+                        )
+                      ),
+                      ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+                        productRatePlanChargeId = "8a128d7085fc6dec01860234cd075270",
+                        pricing = Map(
+                          "recurringFlatFee" -> Map(
+                            "listPrice" -> 0.0
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          ),
+          processingOptions = ZuoraAmendmentOrderPayloadProcessingOptions(false, false)
+        )
+      )
+    )
+  }
+  test("amendmentOrderPayload (annual, with capping)") {
+    val subscription = Fixtures.subscriptionFromJson("Migrations/SupporterPlus2024/annual/subscription.json")
+    assertEquals(
+      SupporterPlus2024Migration.amendmentOrderPayload(
+        orderDate = LocalDate.of(2024, 9, 9),
+        accountNumber = "d4a7d0af",
+        subscriptionNumber = subscription.subscriptionNumber,
+        effectDate = LocalDate.of(2024, 10, 11),
+        subscription = subscription,
+        oldPrice = 150,
+        estimatedNewPrice = 200,
+        priceCap = 1.27
+      ),
+      Right(
+        ZuoraAmendmentOrderPayload(
+          orderDate = LocalDate.of(2024, 9, 9),
+          existingAccountNumber = "d4a7d0af",
+          subscriptions = List(
+            ZuoraAmendmentOrderPayloadSubscription(
+              subscriptionNumber = "SUBSCRIPTION-NUMBER",
+              orderActions = List(
+                ZuoraAmendmentOrderPayloadOrderActionRemove(
+                  triggerDates = List(
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ContractEffective",
+                      triggerDate = LocalDate.of(2024, 10, 11)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ServiceActivation",
+                      triggerDate = LocalDate.of(2024, 10, 11)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "CustomerAcceptance",
+                      triggerDate = LocalDate.of(2024, 10, 11)
+                    )
+                  ),
+                  removeProduct = ZuoraAmendmentOrderPayloadOrderActionRemoveProduct(
+                    ratePlanId = "8a12820a8c0ff963018c2504ba045b2f"
+                  )
+                ),
+                ZuoraAmendmentOrderPayloadOrderActionAdd(
+                  triggerDates = List(
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ContractEffective",
+                      triggerDate = LocalDate.of(2024, 10, 11)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "ServiceActivation",
+                      triggerDate = LocalDate.of(2024, 10, 11)
+                    ),
+                    ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+                      name = "CustomerAcceptance",
+                      triggerDate = LocalDate.of(2024, 10, 11)
+                    )
+                  ),
+                  addProduct = ZuoraAmendmentOrderPayloadOrderActionAddProduct(
+                    productRatePlanId = "8a128ed885fc6ded01860228f77e3d5a",
+                    chargeOverrides = List(
+                      ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+                        productRatePlanChargeId = "8a128ed885fc6ded01860228f7cb3d5f",
+                        pricing = Map(
+                          "recurringFlatFee" -> Map(
+                            "listPrice" -> 190.50
+                          )
+                        )
+                      ),
+                      ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+                        productRatePlanChargeId = "8a12892d85fc6df4018602451322287f",
+                        pricing = Map(
+                          "recurringFlatFee" -> Map(
+                            "listPrice" -> 340.0
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          ),
+          processingOptions = ZuoraAmendmentOrderPayloadProcessingOptions(false, false)
+        )
+      )
+    )
+  }
+  test("Correct JSON serialisation for ZuoraAmendmentOrderPayloadOrderActionRemove") {
+    val data = ZuoraAmendmentOrderPayloadOrderActionRemove(
+      triggerDates = List(
+        ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+          name = "ContractEffective",
+          triggerDate = LocalDate.of(2024, 10, 11)
+        ),
+        ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+          name = "ServiceActivation",
+          triggerDate = LocalDate.of(2024, 10, 11)
+        ),
+        ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+          name = "CustomerAcceptance",
+          triggerDate = LocalDate.of(2024, 10, 11)
+        )
+      ),
+      removeProduct = ZuoraAmendmentOrderPayloadOrderActionRemoveProduct(
+        ratePlanId = "8a12820a8c0ff963018c2504ba045b2f"
+      )
+    )
+    assertEquals(
+      write(data, indent = 2),
+      """{
+        |  "type": "RemoveProduct",
+        |  "triggerDates": [
+        |    {
+        |      "name": "ContractEffective",
+        |      "triggerDate": "2024-10-11"
+        |    },
+        |    {
+        |      "name": "ServiceActivation",
+        |      "triggerDate": "2024-10-11"
+        |    },
+        |    {
+        |      "name": "CustomerAcceptance",
+        |      "triggerDate": "2024-10-11"
+        |    }
+        |  ],
+        |  "removeProduct": {
+        |    "ratePlanId": "8a12820a8c0ff963018c2504ba045b2f"
+        |  }
+        |}""".stripMargin
+    )
+  }
+  test("Correct JSON serialisation for ZuoraAmendmentOrderPayloadOrderActionAdd") {
+    val data = ZuoraAmendmentOrderPayloadOrderActionAdd(
+      triggerDates = List(
+        ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+          name = "ContractEffective",
+          triggerDate = LocalDate.of(2024, 10, 11)
+        ),
+        ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+          name = "ServiceActivation",
+          triggerDate = LocalDate.of(2024, 10, 11)
+        ),
+        ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
+          name = "CustomerAcceptance",
+          triggerDate = LocalDate.of(2024, 10, 11)
+        )
+      ),
+      addProduct = ZuoraAmendmentOrderPayloadOrderActionAddProduct(
+        productRatePlanId = "8a128ed885fc6ded01860228f77e3d5a",
+        chargeOverrides = List(
+          ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+            productRatePlanChargeId = "8a128ed885fc6ded01860228f7cb3d5f",
+            pricing = Map(
+              "recurringFlatFee" -> Map(
+                "listPrice" -> 190.50
+              )
+            )
+          ),
+          ZuoraAmendmentOrderPayloadOrderActionAddProductChargeOverride(
+            productRatePlanChargeId = "8a12892d85fc6df4018602451322287f",
+            pricing = Map(
+              "recurringFlatFee" -> Map(
+                "listPrice" -> 340.0
+              )
+            )
+          )
+        )
+      )
+    )
+    assertEquals(
+      write(data, indent = 2),
+      """{
+        |  "type": "AddProduct",
+        |  "triggerDates": [
+        |    {
+        |      "name": "ContractEffective",
+        |      "triggerDate": "2024-10-11"
+        |    },
+        |    {
+        |      "name": "ServiceActivation",
+        |      "triggerDate": "2024-10-11"
+        |    },
+        |    {
+        |      "name": "CustomerAcceptance",
+        |      "triggerDate": "2024-10-11"
+        |    }
+        |  ],
+        |  "addProduct": {
+        |    "productRatePlanId": "8a128ed885fc6ded01860228f77e3d5a",
+        |    "chargeOverrides": [
+        |      {
+        |        "productRatePlanChargeId": "8a128ed885fc6ded01860228f7cb3d5f",
+        |        "pricing": {
+        |          "recurringFlatFee": {
+        |            "listPrice": 190.5
+        |          }
+        |        }
+        |      },
+        |      {
+        |        "productRatePlanChargeId": "8a12892d85fc6df4018602451322287f",
+        |        "pricing": {
+        |          "recurringFlatFee": {
+        |            "listPrice": 340
+        |          }
+        |        }
+        |      }
+        |    ]
+        |  }
+        |}""".stripMargin
     )
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
@@ -1125,6 +1125,12 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
     )
   }
   test("Correct JSON serialisation for ZuoraAmendmentOrderPayloadOrderActionRemove") {
+
+    // Here we are testing the natural serialization of the whole payload, by upickle.
+    // The purpose is to ensure that the model hierarchy leads to the same essential JSON structure.
+    // See comment cada56ad for more details on the structure and information about how we sanitize the JSON
+    // before we send it to Zuora.
+
     val data = ZuoraAmendmentOrderPayloadOrderActionRemove(
       `type` = "RemoveProduct",
       triggerDates = List(
@@ -1171,6 +1177,12 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
     )
   }
   test("Correct JSON serialisation for ZuoraAmendmentOrderPayloadOrderActionAdd") {
+
+    // Here we are testing the natural serialization of the whole payload, by upickle.
+    // The purpose is to ensure that the model hierarchy leads to the same essential JSON structure.
+    // See comment cada56ad for more details on the structure and information about how we sanitize the JSON
+    // before we send it to Zuora.
+
     val data = ZuoraAmendmentOrderPayloadOrderActionAdd(
       `type` = "AddProduct",
       triggerDates = List(
@@ -1255,6 +1267,12 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
   test(
     "Correct JSON serialisation for ZuoraAmendmentOrderPayload using SupporterPlus2024Migration.amendmentOrdersPayload"
   ) {
+
+    // Here we are testing the natural serialization of the whole payload, by upickle.
+    // The purpose is to ensure that the model hierarchy leads to the same essential JSON structure.
+    // See comment cada56ad for more details on the structure and information about how we sanitize the JSON
+    // before we send it to Zuora.
+
     val data = SupporterPlus2024Migration.amendmentOrdersPayload(
       orderDate = LocalDate.of(2024, 10, 24),
       accountNumber = "A01955911",

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
@@ -885,6 +885,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
               subscriptionNumber = "SUBSCRIPTION-NUMBER",
               orderActions = List(
                 ZuoraAmendmentOrderPayloadOrderActionRemove(
+                  `type` = "RemoveProduct",
                   triggerDates = List(
                     ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
                       name = "ContractEffective",
@@ -904,6 +905,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
                   )
                 ),
                 ZuoraAmendmentOrderPayloadOrderActionAdd(
+                  `type` = "AddProduct",
                   triggerDates = List(
                     ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
                       name = "ContractEffective",
@@ -948,7 +950,6 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
       )
     )
   }
-
   test("amendmentOrderPayload (monthly), with artificial cap") {
     val subscription = Fixtures.subscriptionFromJson("Migrations/SupporterPlus2024/monthly/subscription.json")
     assertEquals(
@@ -971,6 +972,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
               subscriptionNumber = "SUBSCRIPTION-NUMBER",
               orderActions = List(
                 ZuoraAmendmentOrderPayloadOrderActionRemove(
+                  `type` = "RemoveProduct",
                   triggerDates = List(
                     ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
                       name = "ContractEffective",
@@ -990,6 +992,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
                   )
                 ),
                 ZuoraAmendmentOrderPayloadOrderActionAdd(
+                  `type` = "AddProduct",
                   triggerDates = List(
                     ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
                       name = "ContractEffective",
@@ -1056,6 +1059,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
               subscriptionNumber = "SUBSCRIPTION-NUMBER",
               orderActions = List(
                 ZuoraAmendmentOrderPayloadOrderActionRemove(
+                  `type` = "RemoveProduct",
                   triggerDates = List(
                     ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
                       name = "ContractEffective",
@@ -1075,6 +1079,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
                   )
                 ),
                 ZuoraAmendmentOrderPayloadOrderActionAdd(
+                  `type` = "AddProduct",
                   triggerDates = List(
                     ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
                       name = "ContractEffective",
@@ -1121,6 +1126,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
   }
   test("Correct JSON serialisation for ZuoraAmendmentOrderPayloadOrderActionRemove") {
     val data = ZuoraAmendmentOrderPayloadOrderActionRemove(
+      `type` = "RemoveProduct",
       triggerDates = List(
         ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
           name = "ContractEffective",
@@ -1142,6 +1148,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
     assertEquals(
       write(data, indent = 2),
       """{
+        |  "$type": "ZuoraAmendmentOrderPayloadOrderActionRemove",
         |  "type": "RemoveProduct",
         |  "triggerDates": [
         |    {
@@ -1165,6 +1172,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
   }
   test("Correct JSON serialisation for ZuoraAmendmentOrderPayloadOrderActionAdd") {
     val data = ZuoraAmendmentOrderPayloadOrderActionAdd(
+      `type` = "AddProduct",
       triggerDates = List(
         ZuoraAmendmentOrderPayloadOrderActionTriggerDate(
           name = "ContractEffective",
@@ -1204,6 +1212,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
     assertEquals(
       write(data, indent = 2),
       """{
+        |  "$type": "ZuoraAmendmentOrderPayloadOrderActionAdd",
         |  "type": "AddProduct",
         |  "triggerDates": [
         |    {
@@ -1239,6 +1248,100 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
         |        }
         |      }
         |    ]
+        |  }
+        |}""".stripMargin
+    )
+  }
+  test(
+    "Correct JSON serialisation for ZuoraAmendmentOrderPayload using SupporterPlus2024Migration.amendmentOrdersPayload"
+  ) {
+    val data = SupporterPlus2024Migration.amendmentOrdersPayload(
+      orderDate = LocalDate.of(2024, 10, 24),
+      accountNumber = "A01955911",
+      subscriptionNumber = "A-S02019224",
+      effectDate = LocalDate.of(2024, 11, 26),
+      removeRatePlanId = "8a128e208bdd4251018c0d5050970bd9",
+      productRatePlanId = "8a128ed885fc6ded018602296ace3eb8",
+      existingBaseProductRatePlanChargeId = "8a128ed885fc6ded018602296af13eba",
+      existingContributionRatePlanChargeId = "8a128d7085fc6dec01860234cd075270",
+      newBaseAmount = 15,
+      newContributionAmount = 0
+    )
+    assertEquals(
+      write(data, indent = 2),
+      """{
+        |  "orderDate": "2024-10-24",
+        |  "existingAccountNumber": "A01955911",
+        |  "subscriptions": [
+        |    {
+        |      "subscriptionNumber": "A-S02019224",
+        |      "orderActions": [
+        |        {
+        |          "$type": "ZuoraAmendmentOrderPayloadOrderActionRemove",
+        |          "type": "RemoveProduct",
+        |          "triggerDates": [
+        |            {
+        |              "name": "ContractEffective",
+        |              "triggerDate": "2024-11-26"
+        |            },
+        |            {
+        |              "name": "ServiceActivation",
+        |              "triggerDate": "2024-11-26"
+        |            },
+        |            {
+        |              "name": "CustomerAcceptance",
+        |              "triggerDate": "2024-11-26"
+        |            }
+        |          ],
+        |          "removeProduct": {
+        |            "ratePlanId": "8a128e208bdd4251018c0d5050970bd9"
+        |          }
+        |        },
+        |        {
+        |          "$type": "ZuoraAmendmentOrderPayloadOrderActionAdd",
+        |          "type": "AddProduct",
+        |          "triggerDates": [
+        |            {
+        |              "name": "ContractEffective",
+        |              "triggerDate": "2024-11-26"
+        |            },
+        |            {
+        |              "name": "ServiceActivation",
+        |              "triggerDate": "2024-11-26"
+        |            },
+        |            {
+        |              "name": "CustomerAcceptance",
+        |              "triggerDate": "2024-11-26"
+        |            }
+        |          ],
+        |          "addProduct": {
+        |            "productRatePlanId": "8a128ed885fc6ded018602296ace3eb8",
+        |            "chargeOverrides": [
+        |              {
+        |                "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
+        |                "pricing": {
+        |                  "recurringFlatFee": {
+        |                    "listPrice": 15
+        |                  }
+        |                }
+        |              },
+        |              {
+        |                "productRatePlanChargeId": "8a128d7085fc6dec01860234cd075270",
+        |                "pricing": {
+        |                  "recurringFlatFee": {
+        |                    "listPrice": 0
+        |                  }
+        |                }
+        |              }
+        |            ]
+        |          }
+        |        }
+        |      ]
+        |    }
+        |  ],
+        |  "processingOptions": {
+        |    "runBilling": false,
+        |    "collectPayment": false
         |  }
         |}""".stripMargin
     )

--- a/lambda/src/test/scala/pricemigrationengine/service/MockZuora.scala
+++ b/lambda/src/test/scala/pricemigrationengine/service/MockZuora.scala
@@ -15,7 +15,7 @@ object MockZuora extends Mock[Zuora] {
   object FetchProductCatalogue extends Effect[Unit, ZuoraFetchFailure, ZuoraProductCatalogue]
   object UpdateSubscription
       extends Effect[(ZuoraSubscription, ZuoraSubscriptionUpdate), ZuoraUpdateFailure, ZuoraSubscriptionId]
-
+  object ApplyAmendmentOrder extends Effect[(ZuoraSubscription, ZuoraAmendmentOrderPayload), ZuoraOrderFailure, Unit]
   object RenewSubscription extends Effect[String, ZuoraRenewalFailure, Unit]
 
   val compose: URLayer[Proxy, Zuora] = ZLayer.fromZIO(ZIO.service[Proxy].map { proxy =>
@@ -37,6 +37,11 @@ object MockZuora extends Mock[Zuora] {
       override def updateSubscription(subscription: ZuoraSubscription, update: ZuoraSubscriptionUpdate)
           : ZIO[Any, ZuoraUpdateFailure, ZuoraSubscriptionId] =
         proxy(UpdateSubscription, subscription, update)
+
+      override def applyAmendmentOrder(
+          subscription: ZuoraSubscription,
+          payload: ZuoraAmendmentOrderPayload
+      ): ZIO[Any, ZuoraOrderFailure, Unit] = proxy(ApplyAmendmentOrder, subscription, payload)
 
       override def renewSubscription(subscriptionNumber: String, payload: ZuoraRenewOrderPayload)
           : ZIO[Any, ZuoraRenewalFailure, Unit] =


### PR DESCRIPTION
This PR is the second part of the migration to the new Zuora Orders API. ( In part 1 we have updated the subscription renewal function: https://github.com/guardian/price-migration-engine/pull/1085 )

In this part we cannot just update the ZuoraLive function that is performing the update, mostly because of signature differences between the old API and the new one that cause changes in the way the amendment handler is structured. Consequently we are performing that migration only for SupporterPlus2024, while leaving DigiSubs2023_Batch2, Newspaper2024 and GW2024 untouched.

The situation with the engine is now 

```
subscription renew: new Orders API for all migrations

amendment:
  DigiSubs2023_Batch2  : old API
  Newspaper2024        : old API
  GW2024               : old API
  SupporterPlus2024    : new Orders API
```

Although the three first migrations are still using the old API, we will not specifically migrate them to the new API, because they will be completed by the time the old API is decommissioned. Another reason for not migrating them is that although the migration of SupporterPlus2024 makes the engine de facto support the new API, slight diffrences between the ways the Order is to be build between migrations is not something that it necessarily worth doing.

The model hierarchy presented in this PR captures the making of a ZuoraAmendmentOrderPayload according
to the schema presented here: https://knowledgecenter.zuora.com/Zuora_Billing/Manage_subscription_transactions/Orders/Order_actions_tutorials/D_Replace_a_product_in_a_subscription

One interesting note about the design is using a sealed trait to represent the different types of an Order action,
in the context of replacing a product in a subscription. Indeed, the two actions in that order are:

```
{
  "type": "RemoveProduct",
  "triggerDates": [
      {
          "name": "ContractEffective",
          "triggerDate": "2024-11-28"
      },
      {
          "name": "ServiceActivation",
          "triggerDate": "2024-11-28"
      },
      {
          "name": "CustomerAcceptance",
          "triggerDate": "2024-11-28"
      }
  ],
  "removeProduct": {
      "ratePlanId": "8a12867e92c341870192c7c46bdb47d6"
  }
}
```

and

```
{
  "type": "AddProduct",
  "triggerDates": [
      {
          "name": "ContractEffective",
          "triggerDate": "2024-11-28"
      },
      {
          "name": "ServiceActivation",
          "triggerDate": "2024-11-28"
      },
      {
          "name": "CustomerAcceptance",
          "triggerDate": "2024-11-28"
      }
  ],
  "addProduct": {
      "productRatePlanId": "8a128ed885fc6ded018602296ace3eb8",
      "chargeOverrides": [
          {
              "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
              "pricing": {
                  "recurringFlatFee": {
                      "listPrice": 12
                  }
              }
          },
          {
              "productRatePlanChargeId": "8a128d7085fc6dec01860234cd075270",
              "pricing": {
                  "recurringFlatFee": {
                      "listPrice": 0
                  }
              }
          }
      ]
  }
}
```

They are respectively modeled as `ZuoraAmendmentOrderPayloadOrderActionRemove` and `ZuoraAmendmentOrderPayloadOrderActionAdd`

Because of the way upickle works, we end up with a JSON serialization that has a "$type" field which is a bit annoying. We can see it in the test data in SupporterPlus2024MigrationTest.

I have tried to submit the Orders payload to Zuora with the "$type" field left inside the JSON but Zuora errors during the processing. (Technically, it should actually work, but I think that Zuora may be doing payload introspection beyond the mandatory fields and is error'ing on the "$type" field)

I have tried to remove the "$type" field by providing a custom writer for the serialization of the two classes, but could not get that to work.

In the end the solution I have chosen was to remove the "$type" field from the JSON before sending it to Zuora, which explains the function type_flush in the ZuoraLive implementation of applyAmendmentOrder

This is, for all intent and purpose a hack and in a future change we may try and get those custom writers to work to avoid string manipulation in the implementation of applyAmendmentOrder.
