### PR TITLE
Add id to ZuoraSubscription

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraSubscription.scala
@@ -7,6 +7,7 @@ import upickle.default._
 
 case class ZuoraSubscription(
     subscriptionNumber: String,
+    id: String,
     version: Int,
     customerAcceptanceDate: LocalDate,
     contractEffectiveDate: LocalDate,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/EstimationHandlerSpec.scala
@@ -28,6 +28,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
 
   private val subscription1 = ZuoraSubscription(
     subscriptionNumber = "S1",
+    id = "I1",
     version = 4,
     accountNumber = "A9107",
     customerAcceptanceDate = LocalDate.of(2022, 1, 1),
@@ -66,6 +67,7 @@ object EstimationHandlerSpec extends ZIOSpecDefault {
 
   private val subscription2 = ZuoraSubscription(
     subscriptionNumber = "S1",
+    id = "I2",
     version = 4,
     accountNumber = "A9107",
     customerAcceptanceDate = LocalDate.of(2022, 1, 1),

--- a/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/NotificationHandlerTest.scala
@@ -131,6 +131,7 @@ class NotificationHandlerTest extends munit.FunSuite {
           ZIO.succeed(
             ZuoraSubscription(
               subscriptionNumber = "subscriptionNumber",
+              id = "id",
               version = 1,
               customerAcceptanceDate = LocalDate.of(2024, 2, 7),
               contractEffectiveDate = LocalDate.of(2024, 2, 7),


### PR DESCRIPTION
Add the `id` attribute to a ZuoraSubscription which, interestingly, didn't have it. (This is preliminary work for the Zuora Orders migration for amendments). 