### PR TITLE
Prelude to: Orders Harmonization: Subscription Amendment 

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -137,54 +137,15 @@ object AmendmentHandler extends CohortHandler {
           invoicePreviewBeforeUpdate <-
             Zuora.fetchInvoicePreview(subscriptionBeforeUpdate.accountId, invoicePreviewTargetDate)
 
-          update <- MigrationType(cohortSpec) match {
-            case DigiSubs2023 =>
-              ZIO.fromEither(
-                DigiSubs2023Migration.zuoraUpdate(
-                  subscriptionBeforeUpdate,
-                  startDate,
-                )
-              )
-            case Newspaper2024 =>
-              ZIO.fromEither(
-                newspaper2024Migration.Amendment.zuoraUpdate(
-                  subscriptionBeforeUpdate,
-                  startDate,
-                )
-              )
-            case GW2024 =>
-              ZIO.fromEither(
-                GW2024Migration.zuoraUpdate(
-                  subscriptionBeforeUpdate,
-                  startDate,
-                  oldPrice,
-                  estimatedNewPrice,
-                  GW2024Migration.priceCap
-                )
-              )
-            case SupporterPlus2024 =>
-              ZIO.fromEither(
-                SupporterPlus2024Migration.zuoraUpdate(
-                  subscriptionBeforeUpdate,
-                  startDate,
-                  oldPrice,
-                  estimatedNewPrice,
-                  SupporterPlus2024Migration.priceCap
-                )
-              )
-            case Default =>
-              ZIO.fromEither(
-                ZuoraSubscriptionUpdate
-                  .zuoraUpdate(
-                    account,
-                    catalogue,
-                    subscriptionBeforeUpdate,
-                    invoicePreviewBeforeUpdate,
-                    startDate,
-                    Some(PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice))
-                  )
-              )
-          }
+          update <- ZIO.fromEither(
+            SupporterPlus2024Migration.zuoraUpdate(
+              subscriptionBeforeUpdate,
+              startDate,
+              oldPrice,
+              estimatedNewPrice,
+              SupporterPlus2024Migration.priceCap
+            )
+          )
 
           newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -167,7 +167,7 @@ object AmendmentHandler extends CohortHandler {
           oldPrice,
           newPrice,
           estimatedNewPrice,
-          newSubscriptionId,
+          subscriptionAfterUpdate.id,
           whenDone
         )
       }
@@ -279,7 +279,7 @@ object AmendmentHandler extends CohortHandler {
           oldPrice,
           newPrice,
           estimatedNewPrice,
-          newSubscriptionId,
+          subscriptionAfterUpdate.id,
           whenDone
         )
       }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -79,7 +79,12 @@ object AmendmentHandler extends CohortHandler {
       effectDate: LocalDate,
       account: ZuoraAccount
   ): ZIO[Zuora with Logging, Failure, Unit] = {
-    val payload = ZuoraRenewOrderPayload(subscription.subscriptionNumber, effectDate, account.basicInfo.accountNumber)
+    val payload = ZuoraRenewOrderPayload(
+      LocalDate.now(),
+      subscription.subscriptionNumber,
+      account.basicInfo.accountNumber,
+      effectDate
+    )
     for {
       _ <- Logging.info(s"Renewing subscription ${subscription.subscriptionNumber} with payload $payload")
       _ <- Zuora.renewSubscription(subscription.subscriptionNumber, payload)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -144,6 +144,10 @@ object AmendmentHandler extends CohortHandler {
             )
           )
 
+          _ <- Logging.info(
+            s"Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with update ${update}"
+          )
+
           newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
 
           subscriptionAfterUpdate <- fetchSubscription(item)
@@ -244,6 +248,10 @@ object AmendmentHandler extends CohortHandler {
                   )
               )
           }
+
+          _ <- Logging.info(
+            s"Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with update ${update}"
+          )
 
           newSubscriptionId <- Zuora.updateSubscription(subscriptionBeforeUpdate, update)
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -202,17 +202,6 @@ object AmendmentHandler extends CohortHandler {
               )
             )
 
-          _ <-
-            if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec) && (newPrice > estimatedNewPrice)) {
-              ZIO.fail(
-                DataExtractionFailure(
-                  s"[e9054daa] Item ${item} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice}"
-                )
-              )
-            } else {
-              ZIO.succeed(())
-            }
-
           whenDone <- Clock.instant
         } yield SuccessfulAmendmentResult(
           item.subscriptionName,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -76,10 +76,10 @@ object AmendmentHandler extends CohortHandler {
 
   private def renewSubscription(
       subscription: ZuoraSubscription,
-      startDate: LocalDate,
+      effectDate: LocalDate,
       account: ZuoraAccount
   ): ZIO[Zuora with Logging, Failure, Unit] = {
-    val payload = ZuoraRenewOrderPayload(subscription.subscriptionNumber, startDate, account.basicInfo.accountNumber)
+    val payload = ZuoraRenewOrderPayload(subscription.subscriptionNumber, effectDate, account.basicInfo.accountNumber)
     for {
       _ <- Logging.info(s"Renewing subscription ${subscription.subscriptionNumber} with payload $payload")
       _ <- Zuora.renewSubscription(subscription.subscriptionNumber, payload)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -134,9 +134,6 @@ object AmendmentHandler extends CohortHandler {
 
           _ <- renewSubscription(subscriptionBeforeUpdate, subscriptionBeforeUpdate.termEndDate, account)
 
-          invoicePreviewBeforeUpdate <-
-            Zuora.fetchInvoicePreview(subscriptionBeforeUpdate.accountId, invoicePreviewTargetDate)
-
           update <- ZIO.fromEither(
             SupporterPlus2024Migration.zuoraUpdate(
               subscriptionBeforeUpdate,

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraRenewOrderPayload.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraRenewOrderPayload.scala
@@ -40,9 +40,10 @@ object ZuoraRenewOrderPayload {
   implicit val rwZuoraRenewOrderPayload: ReadWriter[ZuoraRenewOrderPayload] = macroRW
 
   def apply(
+      orderDate: LocalDate,
       subscriptionNumber: String,
-      effectDate: LocalDate,
-      accountNumber: String
+      accountNumber: String,
+      effectDate: LocalDate
   ): ZuoraRenewOrderPayload = {
     val triggerDates = List(
       ZuoraRenewOrderPayloadOrderActionTriggerDate(
@@ -76,7 +77,7 @@ object ZuoraRenewOrderPayload {
     val processingOptions = ZuoraRenewOrderPayloadProcessingOptions(runBilling = false, collectPayment = false)
 
     ZuoraRenewOrderPayload(
-      orderDate = effectDate,
+      orderDate = orderDate,
       existingAccountNumber = accountNumber,
       subscriptions = subscriptions,
       processingOptions = processingOptions

--- a/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/ZuoraLive.scala
@@ -220,7 +220,7 @@ object ZuoraLive {
             failure = e =>
               ZIO.fail(
                 ZuoraRenewalFailure(
-                  s"[06f5bd6f] subscription number: $subscriptionNumber, payload: ${payload}, reason: ${e.reason}"
+                  s"[06f5bd6f] subscription number: ${subscriptionNumber}, payload: ${payload}, reason: ${e.reason}"
                 )
               ),
             success = response =>
@@ -229,7 +229,7 @@ object ZuoraLive {
               } else {
                 ZIO.fail(
                   ZuoraRenewalFailure(
-                    s"[bc532694] subscription number: $subscriptionNumber, payload: ${payload}, with answer ${response}"
+                    s"[bc532694] subscription number: ${subscriptionNumber}, payload: ${payload}, with answer ${response}"
                   )
                 )
               }


### PR DESCRIPTION
This PR is a prelude to https://github.com/guardian/price-migration-engine/pull/1087

At the time these lines are written, https://github.com/guardian/price-migration-engine/pull/1087 is a little bit daunting, but only because it's both a refactoring followed by adding the code required to support the new Zuora Orders API in the case of the amendment step (and notably specific to SupporterPlus2024). This prelude performs the refactoring, and once it's going to be merged, the diff between `main` and https://github.com/guardian/price-migration-engine/pull/1087 with be much easier to understand.

Here we 

1. update the signature of  ZuoraRenewOrderPayload to make the difference between the Order date and the effect date. (In this PR, https://github.com/guardian/price-migration-engine/pull/1085, we worked with the general principle that they are equal, but that doesn't have to be the case.)

2. Perform a simple refactoring of the doAmendment function in the amendment handler to create a split between SupporterPlus2024 and the other migrations. That split does not change any functionality but makes the diff of https://github.com/guardian/price-migration-engine/pull/1087 appear to be more complex than it actually is. 


Note that the ability to call a subscription's id was introduced here: https://github.com/guardian/price-migration-engine/pull/1089