### PR TITLE
Prevent public access for S3 Bucket price-migration-engine-*

### DIFF
--- a/lambda/cfn.yaml
+++ b/lambda/cfn.yaml
@@ -383,6 +383,11 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !FindInMap [StageMap, !Ref Stage, BucketName]
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
 
   PriceMigrationEngineTableCreateLambda:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
This enhances security by preventing public access to the price-migration-engine-[PROD/CODE] S3 buckets.