### PR TITLE
ensure that the doNotProcessUntil value is at least 6 months in all cases

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -92,7 +92,7 @@ object NotificationHandler extends CohortHandler {
           CohortItem(
             subscriptionName = item.subscriptionName,
             processingStage = DoNotProcessUntil,
-            doNotProcessUntil = Some(cancellationDate.plusMonths(months * 2))
+            doNotProcessUntil = Some(cancellationDate.plusMonths(List(months * 2, 6).max))
           )
         )
     } yield ()


### PR DESCRIPTION
This is a follow up of https://github.com/guardian/price-migration-engine/pull/1099 

Here we ensure that the doNotProcessUntil value is at least 6 months in all cases. 