### PR TITLE
upgrade android-price-rise for the modern era

### DIFF
--- a/android-price-rise/README.md
+++ b/android-price-rise/README.md
@@ -4,7 +4,7 @@ This directory contains scripts for performing an Android price migration.
 
 We define a price migration as increasing the prices for new customers (this is sometimes called a "price increase"), and then increasing the prices of existing customers (sometimes called a "price rise")
 
-The file `migration1.ts` performs the price increase, and the file `migration2.ts` performs the price rise. They much be ran in that order and under the instructions of Marketing.
+The file `migration1.ts` performs the price increase, and the file `migration2.ts` performs the price rise. They must be ran in that order and under the instructions of Marketing.
 
 Marketing will also provide the data file that describes how the prices should increase. This file is a .csv file with the following data
 

--- a/android-price-rise/README.md
+++ b/android-price-rise/README.md
@@ -1,33 +1,69 @@
 ## Android Price Rise
 
-This directory contains a script for performing an Android price rise.
+This directory contains scripts for performing an Android price migration.
 
-Once a price rise has been done, you can migrate existing subscribers to the new price from the Google Play web console.
+We define a price migration as increasing the prices for new customers (this is sometimes called a "price increase"), and then increasing the prices of existing customers (sometimes called a "price rise")
+
+The file `migration1.ts` performs the price increase, and the file `migration2.ts` performs the price rise. They much be ran in that order and under the instructions of Marketing.
+
+Marketing will also provide the data file that describes how the prices should increase. This file is a .csv file with the following data
+
+```
+productName,country,currency,price
+```
+
+An example is
+
+```
+com.guardian.subscription.annual.14.freetrial,AU,AUD,169.99
+com.guardian.subscription.annual.14.freetrial,CA,CAD,144.99
+com.guardian.subscription.annual.14.freetrial,AL,USD,126.04
+```
+
+### How does it work ?
+
+This scripts uses two Google API end points:
+
+1. [monetization.subscriptions/patch](https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions/patch)
+2. [monetization.subscriptions.basePlans/batchMigratePrices](https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions.basePlans/batchMigratePrices)
+
+The first script, for instance, works as follows:
+
+- It reads in a CSV file with the new prices for each product_id/region (see testPriceRise.csv for an example).
+- For each product_id, it fetches the existing Rate Plan from the Google API. It then sends a modified version of this Rate Plan to the PATCH endpoint, based on the prices from the CSV.
+
+The first script output a file at a location specified by the user.
+
+Notes:
+
+- When we ran the scripts for the Android price rise in Feb 2025, the `regionsVersion.version` needed to be updated from being `2022/02` to `2025/01`. It is possible that the version might need to be updated in the future. If the script fails, the error message will indicate what value should be used.
 
 ### Preparations
+
+To connect to the play store, the script will be using credentials stored in AWS Parameter Store. So give yourself the following Janus credentials.
+
+```
+account: mobile
+path   : /mobile-purchase/android-subscription/google.serviceAccountJson2
+```
+
+Then make sure you install the dependencies
 
 ```
 $ nvm use
 $ yarn install
 ```
 
-### Credentials
+### Running the scripts
 
-The scripts require credentials for a Google service account to be stored in AWS Parameter Store.
+```
+INPUT_FILE_PATH=/path/to/datafile.csv \
+OUTPUT_FILE_PATH=/path/to/output.csv \
+yarn android-price-migration-p1 --dry-run [--dry-run]
 
-The Parameter Store key is configured in `./googleClient.ts`.
+INPUT_FILE_PATH=/path/to/datafile.csv \
+OUTPUT_FILE_PATH=/path/to/output.csv \
+yarn android-price-migration-p2 --dry-run [--dry-run]
+```
 
-### `runPriceRise.ts`
-
-This script uses the [PATCH endpoint](https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions/patch) to change the prices.
-
-`FILE_PATH=/path/to/price-rise.csv yarn android-price-rise [--dry-run]`
-
-It works as follows:
-
-1. It reads in a CSV file with the new prices for each product_id/region (see testPriceRise.csv for an example).
-2. For each product_id, it fetches the existing Rate Plan from the Google API. It then sends a modified version of this Rate Plan to the PATCH endpoint, based on the prices from the CSV.
-
-The script outputs a CSV file listing every product_id/region that was updated.
-
-Use the `--dry-run` parameter to check the changes before running the script for real.
+You can use the `--dry-run` parameter to check the changes before running with side effects.

--- a/android-price-rise/README.md
+++ b/android-price-rise/README.md
@@ -38,6 +38,8 @@ Notes:
 
 - When we ran the scripts for the Android price rise in Feb 2025, the `regionsVersion.version` needed to be updated from being `2022/02` to `2025/01`. It is possible that the version might need to be updated in the future. If the script fails, the error message will indicate what value should be used.
 
+Note: There is an important difference between the two scripts. The first one can be run several times and sometimes you might have to do that if for instance the prices provided by Marketing are rejected (for being too high, or not having the right rounding, etc). But the second one cannot be reran after it has succeeded. Google doesn't allow the same product to be price rise within the same year.
+
 ### Preparations
 
 To connect to the play store, the script will be using credentials stored in AWS Parameter Store. So give yourself the following Janus credentials.

--- a/android-price-rise/package.json
+++ b/android-price-rise/package.json
@@ -3,11 +3,12 @@
   "version": "1.0.0",
   "description": "scripts to perform the andriod price rise",
   "scripts": {
-    "android-price-rise": "AWS_PROFILE=mobile ts-node ./src/runPriceRise.ts"
+    "android-price-migration-p1": "AWS_PROFILE=mobile ts-node ./src/migration1.ts",
+    "android-price-migration-p2": "AWS_PROFILE=mobile ts-node ./src/migration2.ts"
   },
   "devDependencies": {
-    "@guardian/prettier": "^8.0.1",
     "@guardian/eslint-config-typescript": "12.0.0",
+    "@guardian/prettier": "^8.0.1",
     "@types/jest": "^27.4.1",
     "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -25,13 +26,9 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@aws/dynamodb-data-mapper": "^0.7.3",
-    "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
-    "@aws/dynamodb-expressions": "^0.7.3",
     "@googleapis/androidpublisher": "22.0.0",
     "@guardian/types": "^9.0.1",
     "@okta/jwt-verifier": "^4.0.1",
-    "@types/aws-lambda": "8.10.147",
     "@types/node": "^22.12.0",
     "aws-sdk": "^2.1692.0",
     "jsonwebtoken": "^9.0.2",

--- a/android-price-rise/src/googleClient.ts
+++ b/android-price-rise/src/googleClient.ts
@@ -1,6 +1,6 @@
 import type { androidpublisher_v3 } from '@googleapis/androidpublisher';
 import { androidpublisher, auth } from '@googleapis/androidpublisher';
-import SSM = require('aws-sdk/clients/ssm');
+import SSM from 'aws-sdk/clients/ssm';
 import { GoogleAuth } from 'google-auth-library';
 
 export const ssm: SSM = new SSM({

--- a/android-price-rise/src/migration1.ts
+++ b/android-price-rise/src/migration1.ts
@@ -9,8 +9,8 @@ import type { RegionPriceMap } from './parsePriceRiseCsv';
 
 const packageName = 'com.guardian';
 
-const dataFilePath = process.env.INPUT_FILE_PATH;
-if (!dataFilePath) {
+const inputDataFilePath = process.env.INPUT_FILE_PATH;
+if (!inputDataFilePath) {
   console.log('Missing INPUT_FILE_PATH');
   process.exit(1);
 }
@@ -30,7 +30,7 @@ if (DRY_RUN) {
   console.log('*****DRY RUN*****');
 }
 
-const priceRiseData = parsePriceRiseCsv(dataFilePath);
+const priceRiseData = parsePriceRiseCsv(inputDataFilePath);
 
 const buildPrice = (
   currency: string,

--- a/android-price-rise/src/migration2.ts
+++ b/android-price-rise/src/migration2.ts
@@ -1,0 +1,263 @@
+// Read the README.md for instructions on when and how to run this script.
+
+import type { androidpublisher_v3 } from '@googleapis/androidpublisher';
+import { regionsThatAllowOptOut } from './getRegionsThatAllowOptOut';
+import { getClient } from './googleClient';
+import { parsePriceRiseCsv } from './parsePriceRiseCsv';
+
+const packageName = 'com.guardian';
+// productId is like this 'com.guardian.subscription.annual.14.freetrial'
+// basePlanId is like this 'p1m'
+
+const dataFilePath = process.env.FILE_PATH;
+if (!dataFilePath) {
+  console.log('Missing FILE_PATH');
+  process.exit(1);
+}
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const priceRiseData = parsePriceRiseCsv(dataFilePath);
+/*
+{
+    "com.guardian.subscription.annual.14.freetrial": {
+        "AU": {
+            "price": 169.99,
+            "currency": "AUD"
+        },
+        "CA": {
+            "price": 144.99,
+            "currency": "CAD"
+        },
+        (...)
+        "US": {
+            "price": 144.99,
+            "currency": "USD"
+        }
+    },
+    "com.guardian.subscription.monthly.11.freetrial": {
+        "AU": {
+            "price": 16.99,
+            "currency": "AUD"
+        },
+        "CA": {
+            "price": 14.99,
+            "currency": "CAD"
+        },
+        "AL": {
+            "price": 12.59,
+            "currency": "USD"
+        },
+        (...)
+*/
+
+const getProductIdCurrentBasePlan = (
+  client: androidpublisher_v3.Androidpublisher,
+  packageName: string,
+  productId: string,
+): Promise<androidpublisher_v3.Schema$BasePlan> =>
+  client.monetization.subscriptions
+    .get({ packageName, productId })
+    .then((resp) => {
+      const bp = resp.data.basePlans ? resp.data.basePlans[0] : undefined;
+      if (bp) {
+        return bp;
+      } else {
+        return Promise.reject('No base plan found');
+      }
+    });
+
+getClient()
+  .then((client) => 
+    Promise.all(
+      // For each product_id in priceRiseData, update the prices in each region
+      Object.entries(priceRiseData)
+      .map(([productId, regionPriceMap]) => {
+
+        // productId = 'com.guardian.subscription.annual.14.freetrial';
+        /* 
+          regionPriceMap = {        
+              "AU": {
+                  "price": 169.99,
+                  "currency": "AUD"
+              },
+              "CA": {
+                  "price": 144.99,
+                  "currency": "CAD"
+              },
+              (...)
+              "US": {
+                  "price": 144.99,
+                  "currency": "USD"
+              }
+        }
+        */
+
+        return getProductIdCurrentBasePlan(client, packageName, productId)
+          .then((currentBasePlan: androidpublisher_v3.Schema$BasePlan) => {
+            // https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions#BasePlan
+            /*
+              {
+                  "basePlanId": "p1m",
+                  "regionalConfigs": [
+                      {
+                          "regionCode": "AE",
+                          "newSubscriberAvailability": true,
+                          "price": {
+                              "currencyCode": "AED",
+                              "units": "47",
+                              "nanos": 710000000
+                          }
+                      },
+                      {
+                          "regionCode": "ZM",
+                          "newSubscriberAvailability": true,
+                          "price": {
+                              "currencyCode": "USD",
+                              "units": "12",
+                              "nanos": 990000000
+                          }
+                      },
+                      {
+                          "regionCode": "ZW",
+                          "newSubscriberAvailability": true,
+                          "price": {
+                              "currencyCode": "USD",
+                              "units": "12",
+                              "nanos": 990000000
+                          }
+                      }
+                      (...)
+                  ],
+                  "state": "ACTIVE",
+                  "autoRenewingBasePlanType": {
+                      "billingPeriodDuration": "P1M",
+                      "gracePeriodDuration": "P30D",
+                      "resubscribeState": "RESUBSCRIBE_STATE_ACTIVE",
+                      "prorationMode": "SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE",
+                      "legacyCompatible": true,
+                      "legacyCompatibleSubscriptionOfferId": "offer1month",
+                      "accountHoldDuration": "P30D"
+                  },
+                  "otherRegionsConfig": {
+                      "usdPrice": {
+                          "currencyCode": "USD",
+                          "units": "9",
+                          "nanos": 940000000
+                      },
+                      "eurPrice": {
+                          "currencyCode": "EUR",
+                          "units": "9",
+                          "nanos": 320000000
+                      },
+                      "newSubscriberAvailability": true
+                  }
+              }
+            */
+
+            const regionalPriceMigrationConfigs = currentBasePlan.regionalConfigs?.map((regionalConfig) => {
+
+              /* 
+                regionalConfig =
+                {
+                  "regionCode": "AE",
+                  "newSubscriberAvailability": true,
+                  "price": {
+                      "currencyCode": "AED",
+                      "units": "47",
+                      "nanos": 710000000
+                  }
+                }
+              */
+
+              // And now we want to build a RegionalPriceMigrationConfig
+              // https://developers.google.com/android-publisher/api-ref/rest/v3/RegionalPriceMigrationConfig
+
+              // Required. Region code this configuration applies to, as defined by ISO 3166-2, e.g. "US".
+              const regionCode = regionalConfig.regionCode;
+
+              // Required. Subscribers in all legacy price cohorts before this time will be migrated to the 
+              // current price. Subscribers in any newer price cohorts are unaffected. 
+              // Affected subscribers will receive one or more notifications from Google Play about 
+              // the price change. Price decreases occur at the subscriber's next billing date. 
+              // Price increases occur at the subscriber's next billing date following a notification 
+              // period that varies by region and price increase type.
+              const oldestAllowedPriceVersionTime = (new Date).toISOString(); // We are defaulting to now.
+
+              // priceIncreaseType
+              const priceIncreaseType = "PRICE_INCREASE_TYPE_OPT_OUT";
+
+              return {
+                regionCode,
+                oldestAllowedPriceVersionTime,
+                priceIncreaseType
+              }
+            });
+
+            /*
+              regionalPriceMigrationConfigs = 
+              [
+                  {
+                      "regionCode": "AE",
+                      "oldestAllowedPriceVersionTime": "2025-03-05T00:00:00Z",
+                      "priceIncreaseType": "PRICE_INCREASE_TYPE_OPT_OUT"
+                  },
+                  {
+                      "regionCode": "AT",
+                      "oldestAllowedPriceVersionTime": "2025-03-05T00:00:00Z",
+                      "priceIncreaseType": "PRICE_INCREASE_TYPE_OPT_OUT"
+                  },
+                  {
+                      "regionCode": "AU",
+                      "oldestAllowedPriceVersionTime": "2025-03-05T00:00:00Z",
+                      "priceIncreaseType": "PRICE_INCREASE_TYPE_OPT_OUT"
+                  },
+                  (...)
+
+            */
+
+            const regionalPriceMigrationConfigs2 = regionalPriceMigrationConfigs?.filter((regionalPriceMigrationConfig) => {
+              if (regionalPriceMigrationConfig.regionCode) {
+                return regionsThatAllowOptOut.has(regionalPriceMigrationConfig.regionCode);
+              } else {
+                return false
+              }
+            });
+
+            const request = {
+              packageName,
+              productId,
+              basePlanId: currentBasePlan.basePlanId,
+              regionalPriceMigrations: regionalPriceMigrationConfigs2,
+              regionsVersion: {
+                version: '2025/01'
+              },
+            };
+
+            // https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions.basePlans/batchMigratePrices#MigrateBasePlanPricesRequest
+            const requests: androidpublisher_v3.Schema$MigrateBasePlanPricesRequest[] = [request];
+
+            console.log('migrating', productId);
+
+            if (!DRY_RUN) {
+              // https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions.basePlans/migratePrices
+              // https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions.basePlans/batchMigratePrices
+              
+              return client.monetization.subscriptions.basePlans.batchMigratePrices({
+                packageName,
+                productId,
+                requestBody: {
+                  requests: requests
+                }
+              }).then((response) => {
+                console.log('response', response.data);
+              });
+            }
+          });
+      }),
+    ),
+  )
+  .catch((err) => {
+    console.log('Error:');
+    console.log(err);
+  });

--- a/android-price-rise/yarn.lock
+++ b/android-price-rise/yarn.lock
@@ -10,70 +10,6 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws/dynamodb-auto-marshaller@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@aws/dynamodb-auto-marshaller/-/dynamodb-auto-marshaller-0.7.1.tgz#70676c056e4ecb798c08ec2e398a3d93e703858d"
-  integrity sha512-LeURlf6/avrfFo9+4Yht9J3CUTJ72yoBpm1FOUmlexuHNW4Ka61tG30w3ZDCXXXmCO2rG0k3ywAgNJEo3WPbyw==
-  dependencies:
-    tslib "^1.8.1"
-
-"@aws/dynamodb-batch-iterator@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@aws/dynamodb-batch-iterator/-/dynamodb-batch-iterator-0.7.1.tgz#aa3062b2e7816ddb88ac64575a11476930c990e9"
-  integrity sha512-SdwBFnjN+ncIl+MOogTeEh1/C6O0jAcqD5YA3AujcH5JPWiMescKAefO4VQbgR0Q9ohcYcMnwL3q6mCdUpyJ9w==
-  dependencies:
-    tslib "^1.8.1"
-    utf8-bytes "^0.0.1"
-
-"@aws/dynamodb-data-mapper-annotations@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@aws/dynamodb-data-mapper-annotations/-/dynamodb-data-mapper-annotations-0.7.3.tgz#8c04598a1dd3ec1b69996020afebcecc6f2c41f7"
-  integrity sha512-RROw+6EIJd0bJsl/76wxfvDkv/irY9pfpp/VRlmEIVixKW2UtMqpni+Hs0XuBRtmGKGfFrWB2WGYiikSnfv4FA==
-  dependencies:
-    "@aws/dynamodb-auto-marshaller" "^0.7.1"
-    "@aws/dynamodb-data-mapper" "^0.7.3"
-    "@aws/dynamodb-data-marshaller" "^0.7.3"
-    reflect-metadata "^0.1.10"
-    tslib "^1.8.1"
-    uuid "^3.0.0"
-
-"@aws/dynamodb-data-mapper@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@aws/dynamodb-data-mapper/-/dynamodb-data-mapper-0.7.3.tgz#813aea68590017f27bc706989f8500a3c7869c3b"
-  integrity sha512-2DYHoF2jvO7L2TfwfJoTfdJz0M6qSVJ0wM0zQ97ehrTyVSz/yWDO3GqMA9jsUqf0fZl3CIItHBhiXdddsH5cpA==
-  dependencies:
-    "@aws/dynamodb-auto-marshaller" "^0.7.1"
-    "@aws/dynamodb-batch-iterator" "^0.7.1"
-    "@aws/dynamodb-data-marshaller" "^0.7.3"
-    "@aws/dynamodb-expressions" "^0.7.3"
-    "@aws/dynamodb-query-iterator" "^0.7.1"
-    tslib "^1.8.1"
-
-"@aws/dynamodb-data-marshaller@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@aws/dynamodb-data-marshaller/-/dynamodb-data-marshaller-0.7.3.tgz#6769362551c01396ab224840933432a9db701f5b"
-  integrity sha512-ea9PR19J2uY7lNSUo2bEcbfI8GiD0n66dISoBHZFrHjgCO2ao2P6UlyG/k0EMhr2zNzTWYNd08VYgTSYz5GBAA==
-  dependencies:
-    "@aws/dynamodb-auto-marshaller" "^0.7.1"
-    "@aws/dynamodb-expressions" "^0.7.3"
-    tslib "^1.8.1"
-    utf8-bytes "^0.0.1"
-
-"@aws/dynamodb-expressions@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@aws/dynamodb-expressions/-/dynamodb-expressions-0.7.3.tgz#abfda5dbda54f51c58a3bd038c710b7119fc8949"
-  integrity sha512-63vaCyNKmO8BE/JWlQ3DSFG+qCAWgO5MGif31E5CPdWKaBt5yBG5qnh5w5oFelKRK6/1M6cYKl/Yui08wimUig==
-  dependencies:
-    "@aws/dynamodb-auto-marshaller" "^0.7.1"
-    tslib "^1.8.1"
-
-"@aws/dynamodb-query-iterator@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@aws/dynamodb-query-iterator/-/dynamodb-query-iterator-0.7.1.tgz#d43bbf7644cfee55de0aec273475d680a05f3981"
-  integrity sha512-x28lcgj2HDadxszYEwQjAJyGMrdy3aznLM2TSEeQxqCxKzFT1qewmKxgWSMslH+CiLuuqs9H1FaIwvP15b6UHQ==
-  dependencies:
-    tslib "^1.8.1"
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.2":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
@@ -795,11 +731,6 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
-
-"@types/aws-lambda@8.10.147":
-  version "8.10.147"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.147.tgz#dc5c89aa32f47a9b35e52c32630545c83afa6f2f"
-  integrity sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.20.5"
@@ -5095,11 +5026,6 @@ rechoir@^0.8.0:
   dependencies:
     resolve "^1.20.0"
 
-reflect-metadata@^0.1.10:
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.14.tgz#24cf721fe60677146bb77eeb0e1f9dece3d65859"
-  integrity sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==
-
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz#c629219e78a3316d8b604c765ef68996964e7bf9"
@@ -6087,11 +6013,6 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-utf8-bytes@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/utf8-bytes/-/utf8-bytes-0.0.1.tgz#116b025448c9b500081cdfbf1f4d6c6c37d8837d"
-  integrity sha512-GifWmJAx2qAXT+lZLhbkWhBsy7pr6xWHiPWlVToDiELdWgZwt4Ogjf9tlgvKuALzTFR/d+EPQQI9ogJV3957Jg==
-
 util@^0.12.4:
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
@@ -6107,11 +6028,6 @@ uuid@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
   integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
-
-uuid@^3.0.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
This change upgrade the android-price-rise process to improve the android price migration.

- We now have two scripts `migration1.ts` and `migration2.ts`. The second one performs an operation which was missing in the original work.
- An updated README. 
- We must now specify the filepath of the output file.
- Removed a few dependencies inherited from the script was hosted in mobile-purchases.

I also left some sample data in `migration2` to help future generations of engineers understand better what is happening. Maybe one day, probably in a couple of weeks, I will introduce proper types to capture that information. 


