### PR TITLE
resolve vulnerability: SslHandler doesn't correctly validate packets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ lazy val lambda = (project in file("lambda"))
   .enablePlugins(RiffRaffArtifact, BuildInfoPlugin)
   .settings(
     name := "price-migration-engine-lambda",
+    dependencyOverrides += "io.netty" % "netty-handler" % "4.1.118.Final", // https://github.com/guardian/price-migration-engine/security/dependabot/4
     libraryDependencies ++= Seq(
       zio,
       zioStreams,


### PR DESCRIPTION
resolve vulnerability: SslHandler doesn't correctly validate packets
Reported here: https://github.com/guardian/price-migration-engine/security/dependabot/4

Thanks @charleycampbell for reporting 🙏

After effect: 
```
price-migration-engine % sbt dependencyTree | grep netty-handler

[info]   | | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | | +-io.netty:netty-handler:4.1.118.Final
[info]   | | +-io.netty:netty-handler:4.1.118.Final
[info]     | | | +-io.netty:netty-handler:4.1.118.Final
[info]     | | +-io.netty:netty-handler:4.1.118.Final
[info]     | | +-io.netty:netty-handler:4.1.118.Final
[info]     | +-io.netty:netty-handler:4.1.118.Final
```