### PR TITLE
Introduce SubscriptionLocalisation

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/libs/SubscriptionLocalisation.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/SubscriptionLocalisation.scala
@@ -1,0 +1,49 @@
+package pricemigrationengine.libs
+
+import pricemigrationengine.model._
+
+import java.time.LocalDate
+
+/*
+
+  Date: 28th May 2025
+  Author: Pascal
+
+  Localisation is mostly a Guardian Weekly concept but it does show up regularly
+  and I also just agreed with Marketing that the definition we used last year
+  should become permanent. This object facilitates the determination.
+
+  It uses the same approach as SubscriptionIntrospection2025:
+  using the invoice preview to determine the rate plan and derive the currency.
+  The location is read from the account
+
+ */
+
+sealed trait SubscriptionLocalisation
+object Domestic extends SubscriptionLocalisation
+object RestOfWorld extends SubscriptionLocalisation
+
+object SubscriptionLocalisation {
+  def determineSubscriptionLocalisation(
+      subscription: ZuoraSubscription,
+      invoiceList: ZuoraInvoiceList,
+      account: ZuoraAccount
+  ): Option[SubscriptionLocalisation] = {
+    for {
+      ratePlanChargeNumber <- SubscriptionIntrospection2025.invoicePreviewToChargeNumber(invoiceList)
+      ratePlan <- SubscriptionIntrospection2025.ratePlanChargeNumberToMatchingRatePlan(
+        subscription,
+        ratePlanChargeNumber
+      )
+      currency <- SubscriptionIntrospection2025.determineCurrency(ratePlan)
+    } yield {
+      val country = account.soldToContact.country
+      val isROW = currency == "USD" && country != "United States"
+      if (isROW) {
+        RestOfWorld
+      } else {
+        Domestic
+      }
+    }
+  }
+}

--- a/lambda/src/test/resources/libs/SubscriptionIntrospection2025/subscription1/account.json
+++ b/lambda/src/test/resources/libs/SubscriptionIntrospection2025/subscription1/account.json
@@ -41,7 +41,7 @@
   },
   "billToContact" : null,
   "soldToContact" : {
-    "country" : "United States",
+    "country" : "United States"
   },
   "taxInfo" : null,
   "success" : true

--- a/lambda/src/test/scala/pricemigrationengine/libs/SubscriptionLocalisationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/SubscriptionLocalisationTest.scala
@@ -1,0 +1,30 @@
+package pricemigrationengine.libs
+
+import pricemigrationengine.Fixtures
+import pricemigrationengine.model._
+import java.time.LocalDate
+
+// This module reuse the fixtures we introduced for SubscriptionIntrospection2025
+// located here: test/resources/libs/SubscriptionIntrospection2025/
+
+// val subscription = Fixtures.subscriptionFromJson("libs/SubscriptionIntrospection2025/subscription1/subscription.json")
+// val account = Fixtures.accountFromJson("libs/SubscriptionIntrospection2025/subscription1/account.json")
+// val invoicePreview = Fixtures.invoiceListFromJson("libs/SubscriptionIntrospection2025/subscription1/invoice-preview.json")
+// val catalogue = Fixtures.productCatalogueFromJson("libs/SubscriptionIntrospection2025/subscription1/catalogue.json")
+
+class SubscriptionLocalisationTest extends munit.FunSuite {
+  test("determineSubscriptionLocalisation") {
+    val subscription =
+      Fixtures.subscriptionFromJson("libs/SubscriptionIntrospection2025/subscription1/subscription.json")
+    val account = Fixtures.accountFromJson("libs/SubscriptionIntrospection2025/subscription1/account.json")
+    val invoicePreview =
+      Fixtures.invoiceListFromJson("libs/SubscriptionIntrospection2025/subscription1/invoice-preview.json")
+    val localization = SubscriptionLocalisation.determineSubscriptionLocalisation(
+      subscription,
+      invoicePreview,
+      account
+    )
+    // In this case, we have a USD subscription in the US, so we get Domestic
+    assertEquals(localization, Some(Domestic))
+  }
+}


### PR DESCRIPTION
Localisation is mostly a Guardian Weekly concept but it does show up regularly and I also just agreed with Marketing that the definition we used last year should become permanent. This object facilitates the determination.