### PR TITLE
Introduce GuardianWeekly2025

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -239,7 +239,7 @@ object AmendmentHandler extends CohortHandler {
               subscription = subscriptionBeforeUpdate,
               oldPrice = oldPrice,
               estimatedNewPrice = estimatedNewPrice,
-              priceCap = SupporterPlus2024Migration.priceCap
+              priceCap = GuardianWeekly2025Migration.priceCap
             )
           )
       }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -6,7 +6,7 @@ import pricemigrationengine.model.membershipworkflow._
 import pricemigrationengine.services._
 import zio.{Clock, ZIO}
 import com.gu.i18n
-import pricemigrationengine.migrations.{GW2024Migration, SupporterPlus2024Migration}
+import pricemigrationengine.migrations.{GW2024Migration, GuardianWeekly2025Migration, SupporterPlus2024Migration}
 import pricemigrationengine.model.RateplansProbe
 
 import java.time.{LocalDate, ZoneId}
@@ -147,6 +147,8 @@ object NotificationHandler extends CohortHandler {
         case GW2024 =>
           s"${currencySymbol}${PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, GW2024Migration.priceCap)}"
         case SupporterPlus2024 => s"${currencySymbol}${estimatedNewPrice}"
+        case GuardianWeekly2025 =>
+          s"${currencySymbol}${PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)}"
       }
 
       _ <- logMissingEmailAddress(cohortItem, contact)
@@ -282,15 +284,17 @@ object NotificationHandler extends CohortHandler {
 
   def maxLeadTime(cohortSpec: CohortSpec): Int = {
     MigrationType(cohortSpec) match {
-      case GW2024            => GW2024Migration.maxLeadTime
-      case SupporterPlus2024 => SupporterPlus2024Migration.maxLeadTime
+      case GW2024             => GW2024Migration.maxLeadTime
+      case SupporterPlus2024  => SupporterPlus2024Migration.maxLeadTime
+      case GuardianWeekly2025 => GuardianWeekly2025Migration.maxLeadTime
     }
   }
 
   def minLeadTime(cohortSpec: CohortSpec): Int = {
     MigrationType(cohortSpec) match {
-      case GW2024            => GW2024Migration.minLeadTime
-      case SupporterPlus2024 => SupporterPlus2024Migration.minLeadTime
+      case GW2024             => GW2024Migration.minLeadTime
+      case SupporterPlus2024  => SupporterPlus2024Migration.minLeadTime
+      case GuardianWeekly2025 => GuardianWeekly2025Migration.minLeadTime
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.migrations.GW2024Migration
+import pricemigrationengine.migrations.{GW2024Migration, GuardianWeekly2025Migration}
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiseCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
@@ -84,6 +84,8 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
       val estimatedPriceWithOptionalCapping = MigrationType(cohortSpec) match {
         case GW2024 => PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, GW2024Migration.priceCap)
         case SupporterPlus2024 => estimatedNewPrice // [1]
+        case GuardianWeekly2025 =>
+          PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)
       }
       // [1]
       // (Comment group: 7992fa98)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
@@ -1,0 +1,140 @@
+package pricemigrationengine.migrations
+import pricemigrationengine.libs.SubscriptionIntrospection2025
+import pricemigrationengine.model.PriceCap
+import pricemigrationengine.model.ZuoraRatePlan
+import pricemigrationengine.model._
+import pricemigrationengine.libs._
+
+import java.time.LocalDate
+
+object GuardianWeekly2025Migration {
+
+  // ------------------------------------------------
+  // Price capping
+  // ------------------------------------------------
+
+  val priceCap = 1.20 // 20%
+
+  // ------------------------------------------------
+  // Notification Timings
+  // ------------------------------------------------
+
+  val maxLeadTime = 49
+  val minLeadTime = 36
+
+  // ------------------------------------------------
+  // Price Grid
+  //
+  // It is now a standard feature of modern migrations that we hardcode the price grid
+  // into the migration. This is a manual step in the setting of the migration, but it has the
+  // advantage of not relying on complex look up of the price catalogue. (In fact we could even migrate
+  // to prices not present in the price catalogue)
+  // ------------------------------------------------
+
+  val pricesMonthlyDomestic: Map[String, BigDecimal] = Map(
+    "GBP" -> BigDecimal(16.5), // 15 to 16.5
+    "USD" -> BigDecimal(30), // 30 remains 30
+    "CAD" -> BigDecimal(36), // 33 to 36
+    "AUD" -> BigDecimal(44), // 40 to 44
+    "NZD" -> BigDecimal(55), // 50 to 55
+    "EUR" -> BigDecimal(29), // 26.5 to 29
+  )
+
+  val pricesQuarterlyDomestic: Map[String, BigDecimal] = Map(
+    "GBP" -> BigDecimal(49.5), // 45 to 49.5
+    "USD" -> BigDecimal(90), // 90 remains 90
+    "CAD" -> BigDecimal(108), // 99 to 108
+    "AUD" -> BigDecimal(132), // 120 to 132
+    "NZD" -> BigDecimal(165), // 150 to 165
+    "EUR" -> BigDecimal(87), // 79.5 to 87
+  )
+
+  val pricesAnnualDomestic: Map[String, BigDecimal] = Map(
+    "GBP" -> BigDecimal(198), // 180 to 198
+    "USD" -> BigDecimal(360), // 360 remains 360
+    "CAD" -> BigDecimal(432), // 396 to 432
+    "AUD" -> BigDecimal(528), // 480 to 528
+    "NZD" -> BigDecimal(660), // 600 to 660
+    "EUR" -> BigDecimal(348), // 318 to 348
+  )
+
+  val pricesMonthlyRestOfWorld: Map[String, BigDecimal] = Map(
+    "GBP" -> BigDecimal(28), // 24.8 to 28
+    "USD" -> BigDecimal(36), // 33 to 36
+  )
+
+  val pricesQuarterlyRestOfWorld: Map[String, BigDecimal] = Map(
+    "GBP" -> BigDecimal(83.9), // 74.4 to 83.9
+    "USD" -> BigDecimal(108), // 99 to 108
+  )
+
+  val pricesAnnualRestOfWorld: Map[String, BigDecimal] = Map(
+    "GBP" -> BigDecimal(336), // 297.6 to 336
+    "USD" -> BigDecimal(432), // 396 to 432
+  )
+
+  // ------------------------------------------------
+  // Helpers
+  // ------------------------------------------------
+
+  def priceLookUp(
+      localisation: SubscriptionLocalisation,
+      billingPeriod: BillingPeriod,
+      currency: String
+  ): Option[BigDecimal] = {
+    localisation match {
+      case Domestic => {
+        billingPeriod match {
+          case Monthly    => pricesMonthlyDomestic.get(currency)
+          case Quarterly  => pricesQuarterlyDomestic.get(currency)
+          case SemiAnnual => None
+          case Annual     => pricesAnnualDomestic.get(currency)
+        }
+      }
+      case RestOfWorld => {
+        billingPeriod match {
+          case Monthly    => pricesMonthlyRestOfWorld.get(currency)
+          case Quarterly  => pricesQuarterlyRestOfWorld.get(currency)
+          case SemiAnnual => None
+          case Annual     => pricesAnnualRestOfWorld.get(currency)
+        }
+      }
+    }
+  }
+
+  def subscriptionToLastPriceMigrationDate(subscription: ZuoraSubscription): Option[LocalDate] = {
+    // This will be moved to Subscription Introspection
+    ???
+  }
+
+  // ------------------------------------------------
+  // Primary Functions:
+  //
+  // The primary functions are the main functions that
+  // are implemented by the *Migration module.
+  //
+  // - priceData is used in the Estimation handler
+  // - amendmentOrderPayload is used in the Amendment handler
+  // ------------------------------------------------
+
+  def priceData(
+      subscription: ZuoraSubscription,
+      invoiceList: ZuoraInvoiceList,
+      account: ZuoraAccount
+  ): Either[DataExtractionFailure, PriceData] = {
+    ???
+  }
+
+  def amendmentOrderPayload(
+      orderDate: LocalDate,
+      accountNumber: String,
+      subscriptionNumber: String,
+      effectDate: LocalDate,
+      subscription: ZuoraSubscription,
+      oldPrice: BigDecimal,
+      estimatedNewPrice: BigDecimal,
+      priceCap: BigDecimal
+  ): Either[Failure, ZuoraAmendmentOrderPayload] = {
+    ???
+  }
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.model
 
-import pricemigrationengine.migrations.{GW2024Migration, SupporterPlus2024Migration}
+import pricemigrationengine.migrations.{GW2024Migration, GuardianWeekly2025Migration, SupporterPlus2024Migration}
 import pricemigrationengine.model.ZuoraProductCatalogue.productPricingMap
 
 import java.time.LocalDate
@@ -122,11 +122,13 @@ object AmendmentData {
       account: ZuoraAccount,
       subscription: ZuoraSubscription,
       cohortSpec: CohortSpec,
+      invoiceList: ZuoraInvoiceList,
   ): Either[Failure, PriceData] = {
 
     MigrationType(cohortSpec) match {
-      case GW2024            => GW2024Migration.priceData(subscription, account)
-      case SupporterPlus2024 => SupporterPlus2024Migration.priceData(subscription)
+      case GW2024             => GW2024Migration.priceData(subscription, account)
+      case SupporterPlus2024  => SupporterPlus2024Migration.priceData(subscription)
+      case GuardianWeekly2025 => GuardianWeekly2025Migration.priceData(subscription, invoiceList, account)
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -32,7 +32,7 @@ object EstimationResult {
   ): Either[Failure, EstimationData] = {
     for {
       startDate <- AmendmentData.nextServiceStartDate(invoiceList, subscription, startDateLowerBound)
-      priceData <- AmendmentData.priceData(account, subscription, cohortSpec)
+      priceData <- AmendmentData.priceData(account, subscription, cohortSpec, invoiceList)
     } yield EstimationData(
       subscription.subscriptionNumber,
       startDate,

--- a/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
@@ -3,10 +3,12 @@ package pricemigrationengine.model
 sealed trait MigrationType
 object GW2024 extends MigrationType
 object SupporterPlus2024 extends MigrationType
+object GuardianWeekly2025 extends MigrationType
 
 object MigrationType {
   def apply(cohortSpec: CohortSpec): MigrationType = cohortSpec.cohortName match {
-    case "GW2024"            => GW2024
-    case "SupporterPlus2024" => SupporterPlus2024
+    case "GW2024"             => GW2024
+    case "SupporterPlus2024"  => SupporterPlus2024
+    case "GuardianWeekly2025" => GuardianWeekly2025
   }
 }


### PR DESCRIPTION
This introduces the skeleton for Guardian Weekly 2025. At the moment the migration's  `priceData` and `amendmentOrderPayload` functions are left not implemented. 

The price grid has been defined.

![Screenshot 2025-05-29 at 14 44 07](https://github.com/user-attachments/assets/034e4f34-fb71-403e-9a58-cf4da590ebd5)

We also have confirmation of the notification window (same as last year when we did GW 2024), and the capping is active and set to 20%

One thing to note is how the `AmendmentData` 's `priceData` functions has been extended to take a `ZuoraInvoiceList`. That is because, invoice lists are now important for migration implementations since we are going to start using the SubscriptionIntrospection library I introduced yesterday (which uses ZuoraInvoiceList to try and identify the rate plan we are moving from).

