### PR TITLE
Introduce Newspaper2025

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -94,6 +94,7 @@ object AmendmentHandler extends CohortHandler {
       case GW2024             => true
       case SupporterPlus2024  => false // [1]
       case GuardianWeekly2025 => true
+      case Newspaper2025      => true
     }
 
     // [1] We do not apply the check to the SupporterPlus2024 migration where, due to the way
@@ -143,6 +144,7 @@ object AmendmentHandler extends CohortHandler {
           )
         case SupporterPlus2024  => ZIO.fromEither(Left(ConfigFailure("[53d150d9] Incorrect doAmendment dispatch")))
         case GuardianWeekly2025 => ZIO.fromEither(Left(ConfigFailure("[4feb4a0e] Incorrect doAmendment dispatch")))
+        case Newspaper2025      => ZIO.fromEither(Left(ConfigFailure("[fd244e46] Incorrect doAmendment dispatch")))
       }
 
       _ <- Logging.info(
@@ -242,6 +244,19 @@ object AmendmentHandler extends CohortHandler {
               priceCap = GuardianWeekly2025Migration.priceCap
             )
           )
+        case Newspaper2025 =>
+          ZIO.fromEither(
+            Newspaper2025Migration.amendmentOrderPayload(
+              orderDate = LocalDate.now(),
+              accountNumber = account.basicInfo.accountNumber,
+              subscriptionNumber = subscriptionBeforeUpdate.subscriptionNumber,
+              effectDate = startDate,
+              subscription = subscriptionBeforeUpdate,
+              oldPrice = oldPrice,
+              estimatedNewPrice = estimatedNewPrice,
+              priceCap = Newspaper2025Migration.priceCap
+            )
+          )
       }
       _ <- Logging.info(
         s"Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with order ${order}"
@@ -294,6 +309,12 @@ object AmendmentHandler extends CohortHandler {
           item: CohortItem
         )
       case GuardianWeekly2025 =>
+        doAmendment_ordersApi(
+          cohortSpec: CohortSpec,
+          catalogue: ZuoraProductCatalogue,
+          item: CohortItem
+        )
+      case Newspaper2025 =>
         doAmendment_ordersApi(
           cohortSpec: CohortSpec,
           catalogue: ZuoraProductCatalogue,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -6,7 +6,12 @@ import pricemigrationengine.model.membershipworkflow._
 import pricemigrationengine.services._
 import zio.{Clock, ZIO}
 import com.gu.i18n
-import pricemigrationengine.migrations.{GW2024Migration, GuardianWeekly2025Migration, SupporterPlus2024Migration}
+import pricemigrationengine.migrations.{
+  GW2024Migration,
+  GuardianWeekly2025Migration,
+  Newspaper2025Migration,
+  SupporterPlus2024Migration
+}
 import pricemigrationengine.model.RateplansProbe
 
 import java.time.{LocalDate, ZoneId}
@@ -149,6 +154,8 @@ object NotificationHandler extends CohortHandler {
         case SupporterPlus2024 => s"${currencySymbol}${estimatedNewPrice}"
         case GuardianWeekly2025 =>
           s"${currencySymbol}${PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)}"
+        case Newspaper2025 =>
+          s"${currencySymbol}${PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, Newspaper2025Migration.priceCap)}"
       }
 
       _ <- logMissingEmailAddress(cohortItem, contact)
@@ -287,6 +294,7 @@ object NotificationHandler extends CohortHandler {
       case GW2024             => GW2024Migration.maxLeadTime
       case SupporterPlus2024  => SupporterPlus2024Migration.maxLeadTime
       case GuardianWeekly2025 => GuardianWeekly2025Migration.maxLeadTime
+      case Newspaper2025      => Newspaper2025Migration.maxLeadTime
     }
   }
 
@@ -295,6 +303,7 @@ object NotificationHandler extends CohortHandler {
       case GW2024             => GW2024Migration.minLeadTime
       case SupporterPlus2024  => SupporterPlus2024Migration.minLeadTime
       case GuardianWeekly2025 => GuardianWeekly2025Migration.minLeadTime
+      case Newspaper2025      => Newspaper2025Migration.minLeadTime
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.migrations.{GW2024Migration, GuardianWeekly2025Migration}
+import pricemigrationengine.migrations.{GW2024Migration, GuardianWeekly2025Migration, Newspaper2025Migration}
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiseCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
@@ -86,6 +86,8 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
         case SupporterPlus2024 => estimatedNewPrice // [1]
         case GuardianWeekly2025 =>
           PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)
+        case Newspaper2025 =>
+          PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, Newspaper2025Migration.priceCap)
       }
       // [1]
       // (Comment group: 7992fa98)

--- a/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.libs
 
 import pricemigrationengine.handlers.NotificationHandler
-import pricemigrationengine.migrations.{GW2024Migration, GuardianWeekly2025Migration}
+import pricemigrationengine.migrations.{GW2024Migration, GuardianWeekly2025Migration, Newspaper2025Migration}
 import pricemigrationengine.model._
 import zio.{IO, Random}
 
@@ -30,6 +30,7 @@ object StartDates {
       case GW2024             => GW2024Migration.subscriptionToLastPriceMigrationDate(subscription)
       case SupporterPlus2024  => None
       case GuardianWeekly2025 => GuardianWeekly2025Migration.subscriptionToLastPriceMigrationDate(subscription) // [1]
+      case Newspaper2025      => Newspaper2025Migration.subscriptionToLastPriceMigrationDate(subscription) // [1]
     }
     // [1] We are applying the one year since the last price migration policy for GuardianWeekly2025
   }
@@ -87,7 +88,8 @@ object StartDates {
       MigrationType(cohortSpec) match {
         case GW2024             => 3
         case SupporterPlus2024  => 1 // no spread for S+2024 monthlies
-        case GuardianWeekly2025 => 1 // no spread for Guardian Weekly
+        case GuardianWeekly2025 => 1 // no spread for Guardian Weekly 2025
+        case Newspaper2025      => 1 // no spread for Newspaper 2025
       }
     } else 1
   }
@@ -104,6 +106,7 @@ object StartDates {
       case GW2024             => cohortSpecLowerBound(cohortSpec, today)
       case SupporterPlus2024  => cohortSpecLowerBound(cohortSpec, today)
       case GuardianWeekly2025 => cohortSpecLowerBound(cohortSpec, today)
+      case Newspaper2025      => cohortSpecLowerBound(cohortSpec, today)
     }
 
     // We now respect the policy of not increasing members during their first year

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025Migration.scala
@@ -1,0 +1,74 @@
+package pricemigrationengine.migrations
+import pricemigrationengine.model.PriceCap
+import pricemigrationengine.model.ZuoraRatePlan
+import pricemigrationengine.model._
+import pricemigrationengine.libs._
+
+import java.time.LocalDate
+
+object Newspaper2025Migration {
+
+  // ------------------------------------------------
+  // Price capping
+  // ------------------------------------------------
+
+  val priceCap = 1.20 // TODO: Not signed off yet
+
+  // ------------------------------------------------
+  // Notification Timings
+  // ------------------------------------------------
+
+  val maxLeadTime = 37
+  val minLeadTime = 35
+
+  // ------------------------------------------------
+  // Price Grid
+  //
+  // It is now a standard feature of modern migrations that we hardcode the price grid
+  // into the migration. This is a manual step in the setting of the migration, but it has the
+  // advantage of not relying on complex look up of the price catalogue. (In fact we could even migrate
+  // to prices not present in the price catalogue)
+  // ------------------------------------------------
+
+  // Not implemented yet
+
+  // ------------------------------------------------
+  // Helpers
+  // ------------------------------------------------
+
+  def subscriptionToLastPriceMigrationDate(subscription: ZuoraSubscription): Option[LocalDate] = {
+    // This will be moved to Subscription Introspection
+    ???
+  }
+
+  // ------------------------------------------------
+  // Primary Functions:
+  //
+  // The primary functions are the main functions that
+  // are implemented by the *Migration module.
+  //
+  // - priceData is used in the Estimation handler
+  // - amendmentOrderPayload is used in the Amendment handler
+  // ------------------------------------------------
+
+  def priceData(
+      subscription: ZuoraSubscription,
+      invoiceList: ZuoraInvoiceList,
+      account: ZuoraAccount
+  ): Either[DataExtractionFailure, PriceData] = {
+    ???
+  }
+
+  def amendmentOrderPayload(
+      orderDate: LocalDate,
+      accountNumber: String,
+      subscriptionNumber: String,
+      effectDate: LocalDate,
+      subscription: ZuoraSubscription,
+      oldPrice: BigDecimal,
+      estimatedNewPrice: BigDecimal,
+      priceCap: BigDecimal
+  ): Either[Failure, ZuoraAmendmentOrderPayload] = {
+    ???
+  }
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -1,6 +1,11 @@
 package pricemigrationengine.model
 
-import pricemigrationengine.migrations.{GW2024Migration, GuardianWeekly2025Migration, SupporterPlus2024Migration}
+import pricemigrationengine.migrations.{
+  GW2024Migration,
+  GuardianWeekly2025Migration,
+  Newspaper2025Migration,
+  SupporterPlus2024Migration
+}
 import pricemigrationengine.model.ZuoraProductCatalogue.productPricingMap
 
 import java.time.LocalDate
@@ -129,6 +134,7 @@ object AmendmentData {
       case GW2024             => GW2024Migration.priceData(subscription, account)
       case SupporterPlus2024  => SupporterPlus2024Migration.priceData(subscription)
       case GuardianWeekly2025 => GuardianWeekly2025Migration.priceData(subscription, invoiceList, account)
+      case Newspaper2025      => Newspaper2025Migration.priceData(subscription, invoiceList, account)
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
@@ -4,11 +4,13 @@ sealed trait MigrationType
 object GW2024 extends MigrationType
 object SupporterPlus2024 extends MigrationType
 object GuardianWeekly2025 extends MigrationType
+object Newspaper2025 extends MigrationType
 
 object MigrationType {
   def apply(cohortSpec: CohortSpec): MigrationType = cohortSpec.cohortName match {
     case "GW2024"             => GW2024
     case "SupporterPlus2024"  => SupporterPlus2024
     case "GuardianWeekly2025" => GuardianWeekly2025
+    case "Newspaper2025"      => Newspaper2025
   }
 }


### PR DESCRIPTION
This introduces the skeleton code for Newspaper2025. (Another illustration of the minimum amount of changes required to define a new MigrationType)