### PR TITLE
Implement the Newspaper 2025 price grid

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025Migration.scala
@@ -6,6 +6,15 @@ import pricemigrationengine.libs._
 
 import java.time.LocalDate
 
+sealed trait Newspaper2025ProductType
+object Voucher extends Newspaper2025ProductType
+object Subcard extends Newspaper2025ProductType
+object HomeDelivery extends Newspaper2025ProductType
+
+sealed trait Newspaper2025Frequency
+object EverydayPlus extends Newspaper2025Frequency
+object SixdayPlus extends Newspaper2025Frequency
+
 object Newspaper2025Migration {
 
   // ------------------------------------------------
@@ -30,11 +39,68 @@ object Newspaper2025Migration {
   // to prices not present in the price catalogue)
   // ------------------------------------------------
 
-  // Not implemented yet
+  val pricesVouncherEverydayPlus: Map[BillingPeriod, BigDecimal] = Map(
+    Monthly -> BigDecimal(69.99),
+    Quarterly -> BigDecimal(209.97),
+    SemiAnnual -> BigDecimal(419.94),
+    Annual -> BigDecimal(839.88),
+  )
+
+  val pricesVouncherSixdayPlus: Map[BillingPeriod, BigDecimal] = Map(
+    Monthly -> BigDecimal(61.99),
+    Quarterly -> BigDecimal(185.97),
+    SemiAnnual -> BigDecimal(371.94),
+    Annual -> BigDecimal(743.88),
+  )
+
+  val pricesSubCardEverydayPlus: Map[BillingPeriod, BigDecimal] = Map(
+    Monthly -> BigDecimal(69.99),
+    Quarterly -> BigDecimal(209.97),
+  )
+
+  val pricesSubCardSixdayPlus: Map[BillingPeriod, BigDecimal] = Map(
+    Monthly -> BigDecimal(61.99),
+    Quarterly -> BigDecimal(185.97),
+  )
+
+  val pricesHomeDeliveryEverydayPlus: Map[BillingPeriod, BigDecimal] = Map(
+    Monthly -> BigDecimal(83.99),
+  )
+
+  val pricesHomeDeliverySixdayPlus: Map[BillingPeriod, BigDecimal] = Map(
+    Monthly -> BigDecimal(73.99),
+  )
 
   // ------------------------------------------------
   // Helpers
   // ------------------------------------------------
+
+  def priceLookUp(
+      productType: Newspaper2025ProductType,
+      frequency: Newspaper2025Frequency,
+      billingPeriod: BillingPeriod
+  ): Option[BigDecimal] = {
+    productType match {
+      case Voucher => {
+        frequency match {
+          case EverydayPlus => pricesVouncherEverydayPlus.get(billingPeriod)
+          case SixdayPlus   => pricesVouncherSixdayPlus.get(billingPeriod)
+        }
+      }
+      case Subcard => {
+        frequency match {
+          case EverydayPlus => pricesSubCardEverydayPlus.get(billingPeriod)
+          case SixdayPlus   => pricesSubCardSixdayPlus.get(billingPeriod)
+        }
+      }
+      case HomeDelivery => {
+        frequency match {
+          case EverydayPlus => pricesHomeDeliveryEverydayPlus.get(billingPeriod)
+          case SixdayPlus   => pricesHomeDeliverySixdayPlus.get(billingPeriod)
+        }
+      }
+    }
+  }
 
   def subscriptionToLastPriceMigrationDate(subscription: ZuoraSubscription): Option[LocalDate] = {
     // This will be moved to Subscription Introspection

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025MigrationTest.scala
@@ -1,0 +1,37 @@
+package pricemigrationengine.migrations
+
+import pricemigrationengine.model._
+
+import java.time.LocalDate
+
+class Newspaper2025MigrationTest extends munit.FunSuite {
+
+  test("priceLookUp") {
+    assertEquals(
+      Newspaper2025Migration.priceLookUp(Voucher, EverydayPlus, Monthly),
+      Some(BigDecimal(69.99))
+    )
+
+    assertEquals(
+      Newspaper2025Migration.priceLookUp(Voucher, SixdayPlus, SemiAnnual),
+      Some(BigDecimal(371.94))
+    )
+
+    assertEquals(
+      Newspaper2025Migration.priceLookUp(Subcard, EverydayPlus, Quarterly),
+      Some(BigDecimal(209.97))
+    )
+
+    assertEquals(
+      Newspaper2025Migration.priceLookUp(HomeDelivery, SixdayPlus, Monthly),
+      Some(BigDecimal(73.99))
+    )
+
+    // And we test an undefined combination
+    assertEquals(
+      Newspaper2025Migration.priceLookUp(HomeDelivery, SixdayPlus, SemiAnnual),
+      None
+    )
+  }
+
+}


### PR DESCRIPTION
Previous step: https://github.com/guardian/price-migration-engine/pull/1136

Here we encode the Newspaper2025 price grid, which has now been signed off.
 
![02 Price Grid](https://github.com/user-attachments/assets/cf2b5a66-8f8d-4660-b1e5-064d9470837c)
