### PR TITLE
refactoring: brazeCampaignName to brazeName

### DIFF
--- a/docs/migration-implementation-manual.md
+++ b/docs/migration-implementation-manual.md
@@ -19,7 +19,7 @@ As part of setting up a migration you will want to run some of the lambdas on de
 ```
 {
     "cohortName":"GW2024",
-    "brazeCampaignName":"SV_GW_PriceRise2024Email",
+    "brazeName":"SV_GW_PriceRise2024Email",
     "importStartDate":"2024-02-01",
     "earliestPriceMigrationStartDate":"2024-05-20"
 }
@@ -27,7 +27,7 @@ As part of setting up a migration you will want to run some of the lambdas on de
 {
     "cohortSpec": {
         "cohortName":"GW2024",
-        "brazeCampaignName":"SV_GW_PriceRise2024Email",
+        "brazeName":"SV_GW_PriceRise2024Email",
         "importStartDate":"2024-02-01",
         "earliestPriceMigrationStartDate":"2024-05-20"
     }
@@ -37,7 +37,7 @@ As part of setting up a migration you will want to run some of the lambdas on de
 The difference between the two is that the former is used to run specific lambdas and the latter used to run the state machine itself. They both carry the same information.
 
 * **cohortName**: A unique name to identify the cohort. Must consist of alphanumeric, whitespace, '-' and '_' characters.
-* **brazeCampaignName**: The name that membership-workflow uses to refer to the Braze campaign or canvas for notifying subscribers. Must consist of alphanumeric, whitespace, '-' and '_' characters. This name is given to us by Marketing after they have set up the campaign or canvas in Braze.
+* **brazeName**: The name that membership-workflow uses to refer to the Braze campaign or canvas for notifying subscribers. Must consist of alphanumeric, whitespace, '-' and '_' characters. This name is given to us by Marketing after they have set up the campaign or canvas in Braze.
 * **importStartDate**: Date on which to begin importing participating subscription numbers into the engine. Format is `yyyy-mm-dd`. This key is not of much importance nowadays, because we upload the subscriptions numbers only when the cohort has been determined and ready to be sent to the DynamoDB. It would be fine to decommission this key in the future.
 * **earliestPriceMigrationStartDate**: Earliest date on which a subscription can have its price increased. Increases will always begin on the first day of a billing period on or after this date. Format is `yyyy-mm-dd`.
 

--- a/docs/start-date-computation.md
+++ b/docs/start-date-computation.md
@@ -15,7 +15,7 @@ First we need a cohort spec. Let's assume that the cohort spec is
 ```
 {
     "cohortName":"GW2024",
-    "brazeCampaignName":"SV_GW_PriceRise2024",
+    "brazeName":"SV_GW_PriceRise2024",
     "importStartDate":"2024-02-01",
     "earliestPriceMigrationStartDate":"2024-05-20" 
 }

--- a/docs/subscription-numbers-upload.md
+++ b/docs/subscription-numbers-upload.md
@@ -37,7 +37,7 @@ Do not forget to set the correct cohort specifications (see example below, but u
 ```
 {
     "cohortName":"migration-name",
-    "brazeCampaignName":"any-name",
+    "brazeName":"any-name",
     "importStartDate":"2024-02-01",
     "earliestPriceMigrationStartDate":"2024-05-20" 
 }

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -115,7 +115,15 @@ Individual lambdas like the `EstimationLambda` and the `AmendmentLambda` can be 
 * zuoraClientSecret=`personal clientSecret`
 
 ##### Input Cohort Spec Example
-` {     "cohortName": "EchoLegacyTesting",     "brazeCampaignName": "cmp123",     "importStartDate": "2020-07-01",     "earliestPriceMigrationStartDate": "2022-08-02"  }`
+``` 
+{
+  "cohortName": "EchoLegacyTesting",
+  "brazeName": "cmp123",
+  "importStartDate": "2020-07-01",
+  "earliestPriceMigrationStartDate": "2022-08-02"
+}
+```
+
 Note the above is different to the input JSON that the lambda admits 
 
 ## Importing subscription id for a price migration

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
@@ -61,7 +61,7 @@ trait CohortHandler extends ZIOAppDefault with RequestStreamHandler {
     * {
     *     "cohortSpec":{
     *         "cohortName":"M2023",
-    *         "brazeCampaignName":"SV_MB_M2023",
+    *         "brazeName":"SV_MB_M2023",
     *         "importStartDate":"2023-01-01",
     *         "earliestPriceMigrationStartDate":"2023-01-02"
     *     }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -487,7 +487,7 @@ object NotificationHandler extends CohortHandler {
   // email templates in Braze to serve communication to the users.
 
   // Traditionally the name of the campaign or canvas has been part of the CohortSpec, making
-  // `cohortSpec.brazeCampaignName` the default carrier of this information, but in the case of SupporterPlus 2024
+  // `cohortSpec.brazeName` the default carrier of this information, but in the case of SupporterPlus 2024
   // we have two canvases and need to decide one depending on the structure of the subscription. Once
   // SupporterPlus2024 finished, we may decide to go back to a simpler format, or keep that function, depending
   // on the likelihood of Marketing adopting this variation in the future.
@@ -500,7 +500,7 @@ object NotificationHandler extends CohortHandler {
           bn <- ZIO.fromEither(SupporterPlus2024Migration.brazeName(subscription))
         } yield bn
       }
-      case _ => ZIO.succeed(cohortSpec.brazeCampaignName)
+      case _ => ZIO.succeed(cohortSpec.brazeName)
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -11,10 +11,10 @@ import java.util
   *
   * @param cohortName
   *   Name that uniquely identifies a cohort, eg. "Vouchers 2020"
-  * @param brazeCampaignName
-  *   Name of the Braze campaign for this cohort.<br /> Mapping to environment-specific Braze campaign ID is provided by
-  *   membership-workflow:<br /> See
-  *   https://github.com/guardian/membership-workflow/blob/master/conf/PROD.public.conf#L39
+  * @param brazeName
+  *   Name of the Braze campaign, or Braze canvas for this cohort.
+  *   Mapping to environment-specific Braze campaign ID is provided by membership-workflow:
+  *   See https://github.com/guardian/membership-workflow/blob/master/conf/PROD.public.conf#L39
   * @param importStartDate
   *   Date on which to start importing data from the source S3 bucket.
   * @param earliestPriceMigrationStartDate
@@ -25,7 +25,7 @@ import java.util
   */
 case class CohortSpec(
     cohortName: String,
-    brazeCampaignName: String,
+    brazeName: String,
     importStartDate: LocalDate,
     earliestPriceMigrationStartDate: LocalDate,
     migrationCompleteDate: Option[LocalDate] = None
@@ -44,20 +44,20 @@ object CohortSpec {
   def isValid(spec: CohortSpec): Boolean = {
     def isValidStringValue(s: String) = s.trim == s && s.nonEmpty && s.matches("[A-Za-z0-9-_ ]+")
     isValidStringValue(spec.cohortName) &&
-    isValidStringValue(spec.brazeCampaignName) &&
+    isValidStringValue(spec.brazeName) &&
     spec.earliestPriceMigrationStartDate.isAfter(spec.importStartDate)
   }
 
   def fromDynamoDbItem(values: util.Map[String, AttributeValue]): Either[CohortSpecFetchFailure, CohortSpec] =
     (for {
       cohortName <- getStringFromResults(values, "cohortName")
-      brazeCampaignName <- getStringFromResults(values, "brazeCampaignName")
+      brazeName <- getStringFromResults(values, "brazeName")
       importStartDate <- getDateFromResults(values, "importStartDate")
       earliestPriceMigrationStartDate <- getDateFromResults(values, "earliestPriceMigrationStartDate")
       migrationCompleteDate <- getOptionalDateFromResults(values, "migrationCompleteDate")
     } yield CohortSpec(
       cohortName,
-      brazeCampaignName,
+      brazeName,
       importStartDate,
       earliestPriceMigrationStartDate,
       migrationCompleteDate

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -82,7 +82,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
     val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
 
     val cohortSpec: CohortSpec =
-      CohortSpec("cohortName", "brazeCampaignName", LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 1), None)
+      CohortSpec("cohortName", "brazeName", LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 1), None)
 
     val cohortItem = CohortItem(
       subscriptionName = subscriptionName,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -68,7 +68,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
           .main(
             CohortSpec(
               cohortName = "cohortName",
-              brazeCampaignName = "cmp123",
+              brazeName = "cmp123",
               importStartDate = LocalDate.of(2020, 1, 1),
               earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1)
             )

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -13,7 +13,7 @@ class CohortSpecTest extends munit.FunSuite {
 
   private val cohortSpec = CohortSpec(
     cohortName = "Home Delivery 2018",
-    brazeCampaignName = "cmp123",
+    brazeName = "cmp123",
     importStartDate = LocalDate.of(2020, 1, 1),
     earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 2),
     migrationCompleteDate = None
@@ -26,7 +26,7 @@ class CohortSpecTest extends munit.FunSuite {
     CohortSpec.isActive(
       CohortSpec(
         cohortName = "name",
-        brazeCampaignName = "cmp123",
+        brazeName = "cmp123",
         importStartDate,
         earliestPriceMigrationStartDate = LocalDate.of(2021, 1, 1),
         migrationComplete
@@ -67,7 +67,7 @@ class CohortSpecTest extends munit.FunSuite {
   test("fromDynamoDbItem: should include all fields") {
     val item = Map(
       "cohortName" -> AttributeValue.builder.s("Home Delivery 2018").build(),
-      "brazeCampaignName" -> AttributeValue.builder.s("cmp123").build(),
+      "brazeName" -> AttributeValue.builder.s("cmp123").build(),
       "importStartDate" -> AttributeValue.builder.s("2020-01-01").build(),
       "earliestPriceMigrationStartDate" -> AttributeValue.builder.s("2020-01-02").build()
     ).asJava
@@ -86,7 +86,7 @@ class CohortSpecTest extends munit.FunSuite {
   }
 
   test("isValid: should be false when the campaign name contains an illegal character") {
-    assertFalse(isValid(cohortSpec.copy(brazeCampaignName = "vc:ppr321")))
+    assertFalse(isValid(cohortSpec.copy(brazeName = "vc:ppr321")))
   }
 
   test("isValid: should be false when the import date is not before the earliest migration start date") {

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -19,7 +19,7 @@ class CohortTableLiveTest extends munit.FunSuite {
 
   private val cohortSpec = CohortSpec(
     cohortName = "name",
-    brazeCampaignName = "cmp123",
+    brazeName = "cmp123",
     importStartDate = LocalDate.of(2020, 1, 1),
     earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1)
   )


### PR DESCRIPTION
This performs a small naming refactoring `brazeCampaignname` to `brazeName` to reflect the fact that nowadays we are mostly using Canvas for engine user communication in Braze. 

Both the code and the documentation have been updated and I have also rebuild the `price-migration-engine-cohort-spec-PROD` table in AWS (there currently is only one migration running)

![Screenshot 2025-06-09 at 11 26 19](https://github.com/user-attachments/assets/dca72362-9ac1-49c7-aecf-2c7e4770d455)
