### PR TITLE
prevent accidental firing of migrations steps

### DIFF
--- a/docs/migration-implementation-manual.md
+++ b/docs/migration-implementation-manual.md
@@ -71,6 +71,10 @@ We used the Guardian Weekly 2024 migration as a teaching opportunity and split t
 6. [The User Notification Step](https://github.com/guardian/price-migration-engine/pull/1023)
 7. [The Amendment Step](https://github.com/guardian/price-migration-engine/pull/996)
 
+## Prevent accidental firing of migration steps
+
+There are situations where you have already implemented and excecuted the first steps of a migrations, but do not yet want to see the later steps being executed, or if, for some reasons, you want to permanently disable a step of a given migration, [as we did for SupporterPlus 2024](https://github.com/guardian/price-migration-engine/blob/2da72b6d02aa96c42781ea8a70b3431895f95af4/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala#L116). A very simple way to perform this is simply to add guards in the handlers. [See an example](https://github.com/guardian/price-migration-engine/pull/1141).
+
 ## Downloading the Cohort Tables
 
 As part of preparing / running a migratition, it is often useful to run processes on the entire cohort table. It is not easy to query Dynamo tables directly but you can download the entirety of the records as JSON objects. Here is the command that Pascal has been using: (You only need the Janus credentials, also in this case given for the PriceMigration-PROD-GW2024 table)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -228,14 +228,20 @@ object AmendmentHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    main(input).provideSome[Logging](
-      EnvConfig.cohortTable.layer,
-      EnvConfig.zuora.layer,
-      EnvConfig.stage.layer,
-      DynamoDBZIOLive.impl,
-      DynamoDBClientLive.impl,
-      CohortTableLive.impl(input),
-      ZuoraLive.impl
-    )
+    MigrationType(input) match {
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025      => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ => {
+        main(input).provideSome[Logging](
+          EnvConfig.cohortTable.layer,
+          EnvConfig.zuora.layer,
+          EnvConfig.stage.layer,
+          DynamoDBZIOLive.impl,
+          DynamoDBClientLive.impl,
+          CohortTableLive.impl(input),
+          ZuoraLive.impl
+        )
+      }
+    }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableCreationHandler.scala
@@ -1,6 +1,6 @@
 package pricemigrationengine.handlers
 
-import pricemigrationengine.model.{CohortSpec, Failure, HandlerOutput}
+import pricemigrationengine.model.{CohortSpec, Failure, GuardianWeekly2025, HandlerOutput, MigrationType, Newspaper2025}
 import pricemigrationengine.services._
 import zio.ZIO
 
@@ -21,9 +21,15 @@ object CohortTableCreationHandler extends CohortHandler {
       .as(HandlerOutput(isComplete = true))
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
-    main(input).provideSome[Logging](
-      EnvConfig.stage.layer,
-      DynamoDBClientLive.impl,
-      CohortTableDdlLive.impl
-    )
+    MigrationType(input) match {
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025      => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ => {
+        main(input).provideSome[Logging](
+          EnvConfig.stage.layer,
+          DynamoDBClientLive.impl,
+          CohortTableDdlLive.impl
+        )
+      }
+    }
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -128,13 +128,19 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
       }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
-    main(input).provideSome[Logging](
-      EnvConfig.cohortTable.layer,
-      EnvConfig.stage.layer,
-      EnvConfig.export.layer,
-      DynamoDBClientLive.impl,
-      DynamoDBZIOLive.impl,
-      CohortTableLive.impl(input),
-      S3Live.impl
-    )
+    MigrationType(input) match {
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025      => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ => {
+        main(input).provideSome[Logging](
+          EnvConfig.cohortTable.layer,
+          EnvConfig.stage.layer,
+          EnvConfig.export.layer,
+          DynamoDBClientLive.impl,
+          DynamoDBZIOLive.impl,
+          CohortTableLive.impl(input),
+          S3Live.impl
+        )
+      }
+    }
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -125,14 +125,20 @@ object EstimationHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    main(input).provideSome[Logging](
-      EnvConfig.cohortTable.layer,
-      EnvConfig.zuora.layer,
-      EnvConfig.stage.layer,
-      DynamoDBZIOLive.impl,
-      DynamoDBClientLive.impl,
-      CohortTableLive.impl(input),
-      ZuoraLive.impl
-    )
+    MigrationType(input) match {
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025      => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ => {
+        main(input).provideSome[Logging](
+          EnvConfig.cohortTable.layer,
+          EnvConfig.zuora.layer,
+          EnvConfig.stage.layer,
+          DynamoDBZIOLive.impl,
+          DynamoDBClientLive.impl,
+          CohortTableLive.impl(input),
+          ZuoraLive.impl
+        )
+      }
+    }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -27,19 +27,25 @@ object NotificationHandler extends CohortHandler {
   val Cancelled_Status = "Cancelled"
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    main(input).provideSome[Logging](
-      EnvConfig.salesforce.layer,
-      EnvConfig.cohortTable.layer,
-      EnvConfig.emailSender.layer,
-      EnvConfig.zuora.layer,
-      EnvConfig.stage.layer,
-      DynamoDBClientLive.impl,
-      DynamoDBZIOLive.impl,
-      CohortTableLive.impl(input),
-      SalesforceClientLive.impl,
-      EmailSenderLive.impl,
-      ZuoraLive.impl
-    )
+    MigrationType(input) match {
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025      => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ => {
+        main(input).provideSome[Logging](
+          EnvConfig.salesforce.layer,
+          EnvConfig.cohortTable.layer,
+          EnvConfig.emailSender.layer,
+          EnvConfig.zuora.layer,
+          EnvConfig.stage.layer,
+          DynamoDBClientLive.impl,
+          DynamoDBZIOLive.impl,
+          CohortTableLive.impl(input),
+          SalesforceClientLive.impl,
+          EmailSenderLive.impl,
+          ZuoraLive.impl
+        )
+      }
+    }
   }
 
   def main(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -65,14 +65,20 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
       .toRight(SalesforcePriceRiseWriteFailure(s"$cohortItem does not have a newSubscriptionId field"))
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    main(input).provideSome[Logging](
-      EnvConfig.cohortTable.layer,
-      EnvConfig.salesforce.layer,
-      EnvConfig.stage.layer,
-      DynamoDBZIOLive.impl,
-      DynamoDBClientLive.impl,
-      CohortTableLive.impl(input),
-      SalesforceClientLive.impl
-    )
+    MigrationType(input) match {
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025      => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ => {
+        main(input).provideSome[Logging](
+          EnvConfig.cohortTable.layer,
+          EnvConfig.salesforce.layer,
+          EnvConfig.stage.layer,
+          DynamoDBZIOLive.impl,
+          DynamoDBClientLive.impl,
+          CohortTableLive.impl(input),
+          SalesforceClientLive.impl
+        )
+      }
+    }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
@@ -74,14 +74,20 @@ object SalesforceNotificationDateUpdateHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    main(input).provideSome[Logging](
-      EnvConfig.cohortTable.layer,
-      EnvConfig.salesforce.layer,
-      EnvConfig.stage.layer,
-      DynamoDBZIOLive.impl,
-      DynamoDBClientLive.impl,
-      CohortTableLive.impl(input),
-      SalesforceClientLive.impl
-    )
+    MigrationType(input) match {
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025      => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ => {
+        main(input).provideSome[Logging](
+          EnvConfig.cohortTable.layer,
+          EnvConfig.salesforce.layer,
+          EnvConfig.stage.layer,
+          DynamoDBZIOLive.impl,
+          DynamoDBClientLive.impl,
+          CohortTableLive.impl(input),
+          SalesforceClientLive.impl
+        )
+      }
+    }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -117,7 +117,9 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
     // to perform the Salesforce price rise creation, due to the extra computation required to compute
     // the correct price.
     MigrationType(input) match {
-      case SupporterPlus2024 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case SupporterPlus2024  => ZIO.succeed(HandlerOutput(isComplete = true))
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025      => ZIO.succeed(HandlerOutput(isComplete = true))
       case _ =>
         main(input).provideSome[Logging](
           EnvConfig.cohortTable.layer,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
@@ -89,13 +89,19 @@ object SubscriptionIdUploadHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    main(input).provideSome[Logging](
-      EnvConfig.cohortTable.layer,
-      EnvConfig.stage.layer,
-      DynamoDBClientLive.impl,
-      DynamoDBZIOLive.impl,
-      CohortTableLive.impl(input),
-      S3Live.impl
-    )
+    MigrationType(input) match {
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025      => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ => {
+        main(input).provideSome[Logging](
+          EnvConfig.cohortTable.layer,
+          EnvConfig.stage.layer,
+          DynamoDBClientLive.impl,
+          DynamoDBZIOLive.impl,
+          CohortTableLive.impl(input),
+          S3Live.impl
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
Here we install guards to prevent the accidental firing of steps of the GuardianWeekly2025 and Newspaper2025 migrations. This is not strictly necessary but this can help phasing the start of a migration safely. 

We also use this PR to update the documentation.

