### PR TITLE
Refactor SubscriptionIntrospection2025

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/libs/SubscriptionLocalisation.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/SubscriptionLocalisation.scala
@@ -30,12 +30,11 @@ object SubscriptionLocalisation {
       account: ZuoraAccount
   ): Option[SubscriptionLocalisation] = {
     for {
-      ratePlanChargeNumber <- SubscriptionIntrospection2025.invoicePreviewToChargeNumber(invoiceList)
-      ratePlan <- SubscriptionIntrospection2025.ratePlanChargeNumberToMatchingRatePlan(
+      ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(
         subscription,
-        ratePlanChargeNumber
+        invoiceList
       )
-      currency <- SubscriptionIntrospection2025.determineCurrency(ratePlan)
+      currency <- SI2025Extractions.determineCurrency(ratePlan)
     } yield {
       val country = account.soldToContact.country
       val isROW = currency == "USD" && country != "United States"

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
@@ -1,5 +1,4 @@
 package pricemigrationengine.migrations
-import pricemigrationengine.libs.SubscriptionIntrospection2025
 import pricemigrationengine.model.PriceCap
 import pricemigrationengine.model.ZuoraRatePlan
 import pricemigrationengine.model._

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlan.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlan.scala
@@ -32,9 +32,12 @@ object ZuoraRatePlan {
     } yield BillingPeriod.fromString(billingPeriod)
   }
 
-  def ratePlanToRatePlanPrice(ratePlan: ZuoraRatePlan): BigDecimal = {
-    ratePlan.ratePlanCharges.foldLeft(BigDecimal(0))((price: BigDecimal, ratePlanCharge: ZuoraRatePlanCharge) =>
-      price + ratePlanCharge.price.getOrElse(BigDecimal(0))
-    )
+  // Sadly `lastChangeType` is not always defined on all rate plans. The situation is:
+  //     - Not defined                    -> Active rate plan
+  //     - Defined and value is "Add"     -> Active rate plan
+  //     - Defined and value is "Removed" -> Non active rate plan
+
+  def ratePlanIsActive(ratePlan: ZuoraRatePlan): Boolean = {
+    !ratePlan.lastChangeType.contains("Removed")
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/libs/SubscriptionIntrospection2025Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/SubscriptionIntrospection2025Test.scala
@@ -122,7 +122,7 @@ class SubscriptionIntrospection2025Test extends munit.FunSuite {
     val invoicePreview =
       Fixtures.invoiceListFromJson("libs/SubscriptionIntrospection2025/subscription1/invoice-preview.json")
     val chargeNumber =
-      SubscriptionIntrospection2025.invoicePreviewToChargeNumber(invoicePreview)
+      SI2025RateplanFromSubAndInvoices.invoicePreviewToChargeNumber(invoicePreview)
     assertEquals(chargeNumber, Some("C-05719965"))
   }
 
@@ -131,7 +131,7 @@ class SubscriptionIntrospection2025Test extends munit.FunSuite {
       Fixtures.subscriptionFromJson("libs/SubscriptionIntrospection2025/subscription1/subscription.json")
 
     val ratePlan =
-      SubscriptionIntrospection2025.ratePlanChargeNumberToMatchingRatePlan(
+      SI2025RateplanFromSubAndInvoices.ratePlanChargeNumberToMatchingRatePlan(
         subscription,
         "C-05719965" // <- value from the previous test, otherwise can be read from the fixture data.
       )
@@ -203,7 +203,7 @@ class SubscriptionIntrospection2025Test extends munit.FunSuite {
       ),
       lastChangeType = Some("Add")
     )
-    val currency = SubscriptionIntrospection2025.determineCurrency(ratePlan)
+    val currency = SI2025Extractions.determineCurrency(ratePlan)
     assertEquals(currency, Some("USD"))
   }
 
@@ -238,7 +238,7 @@ class SubscriptionIntrospection2025Test extends munit.FunSuite {
       ),
       lastChangeType = Some("Add")
     )
-    val billingPeriod = SubscriptionIntrospection2025.determineBillingPeriod(ratePlan)
+    val billingPeriod = SI2025Extractions.determineBillingPeriod(ratePlan)
     assertEquals(billingPeriod, Some(Quarterly))
   }
 
@@ -273,7 +273,7 @@ class SubscriptionIntrospection2025Test extends munit.FunSuite {
       ),
       lastChangeType = Some("Add")
     )
-    val price = SubscriptionIntrospection2025.determineOldPrice(ratePlan)
+    val price = SI2025Extractions.determineOldPrice(ratePlan)
     assertEquals(price, BigDecimal(90.0))
   }
 
@@ -282,7 +282,7 @@ class SubscriptionIntrospection2025Test extends munit.FunSuite {
       Fixtures.subscriptionFromJson("libs/SubscriptionIntrospection2025/subscription1/subscription.json")
     val invoicePreview =
       Fixtures.invoiceListFromJson("libs/SubscriptionIntrospection2025/subscription1/invoice-preview.json")
-    val priceData = SubscriptionIntrospection2025.priceData(subscription, invoicePreview)
+    val priceData = SI2025Templates.priceData(subscription, invoicePreview)
     assertEquals(priceData, Right(PriceData("USD", BigDecimal(90.0), BigDecimal(2.71), "Quarter")))
   }
 }


### PR DESCRIPTION
We recently ( https://github.com/guardian/price-migration-engine/pull/1131 ) introduced the library SubscriptionIntrospection2025, and here we mostly perform a little refactoring of it.

1. We split it in `SI2025RateplanFromSubAndInvoices` (which performs rate plan extraction using a subscription and an invoice preview), `SI2025RateplanFromSub` which also performs rate plan extraction only using a subscription under some conditions, `SI2025Extractions`, which expose the extractions functions, all of the form `ratePlan -> Option[Something]`, and `SI2025Templates` which contains the educational templates. This is essentially name spacing management, for clarity and learning. Among other things, this notably helps exposing two different `determineRatePlan` under different objects (for different contexts). 

2. We no longer need `ZuoraRatePlan.ratePlanToRatePlanPrice`. 

3. We introduce `ZuoraRatePlan.ratePlanIsActive` which has somehow never been made a function. 