### PR TITLE
Bring back shouldPerformFinalPriceCheck

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -255,6 +255,17 @@ object AmendmentHandler extends CohortHandler {
           )
         )
 
+      _ <-
+        if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec) && (newPrice > estimatedNewPrice)) {
+          ZIO.fail(
+            DataExtractionFailure(
+              s"[e9054daa] Item ${item} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice}"
+            )
+          )
+        } else {
+          ZIO.succeed(())
+        }
+
       whenDone <- Clock.instant
     } yield SuccessfulAmendmentResult(
       item.subscriptionName,


### PR DESCRIPTION
Because SupporterPlus2024 doesn't do final price check, when we decommissioned GW2024 ( https://github.com/guardian/price-migration-engine/pull/1138 ), we lost the only surviving occurrence of `shouldPerformFinalPriceCheck` (which was here: https://github.com/guardian/price-migration-engine/pull/1138/files#diff-08e263aaef20ae4282366ea2197186c15204e89877b665f448620e19a17e7fc7L170). In this change we bring it back.

