### PR TITLE
Add GuardianWeekly2025Migration.priceData (EUR-annual1) test

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitives.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitives.scala
@@ -62,7 +62,7 @@ object ZuoraOrdersApiPrimitives {
       singletonDate("CustomerAcceptance", datestr)
     )
   }
-  def removeProduct(triggerDatesStr: String, ratePlanId: String): Value = {
+  def removeProduct(triggerDateString: String, subscriptionRatePlanId: String): Value = {
     /*
       {
         "type": "RemoveProduct",
@@ -87,14 +87,14 @@ object ZuoraOrdersApiPrimitives {
      */
     Obj(
       "type" -> Str("RemoveProduct"),
-      "triggerDates" -> triggerDates(triggerDatesStr: String),
+      "triggerDates" -> triggerDates(triggerDateString: String),
       "removeProduct" -> Obj(
-        "ratePlanId" -> Str(ratePlanId)
+        "ratePlanId" -> Str(subscriptionRatePlanId)
       )
     )
   }
 
-  def chargeOverride(productRatePlanChargeId: String, listPrice: Int): Value = {
+  def chargeOverride(productRatePlanChargeId: String, listPrice: BigDecimal): Value = {
     /*
         {
             "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
@@ -109,13 +109,13 @@ object ZuoraOrdersApiPrimitives {
       "productRatePlanChargeId" -> Str(productRatePlanChargeId),
       "pricing" -> Obj(
         "recurringFlatFee" -> Obj(
-          "listPrice" -> Num(listPrice)
+          "listPrice" -> Num(listPrice.doubleValue)
         )
       )
     )
   }
 
-  def addProduct(triggerDatesStr: String, productRatePlanId: String, chargeOverrides: List[Value]): Value = {
+  def addProduct(triggerDateString: String, productRatePlanId: String, chargeOverrides: List[Value]): Value = {
     /*
       {
           "type": "AddProduct",
@@ -158,7 +158,7 @@ object ZuoraOrdersApiPrimitives {
      */
     Obj(
       "type" -> Str("AddProduct"),
-      "triggerDates" -> triggerDates(triggerDatesStr: String),
+      "triggerDates" -> triggerDates(triggerDateString),
       "addProduct" -> Obj(
         "productRatePlanId" -> Str(productRatePlanId),
         "chargeOverrides" -> chargeOverrides

--- a/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
@@ -140,6 +140,86 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
     )
   }
 
+  test("subscription") {
+    val removeProduct = ZuoraOrdersApiPrimitives.removeProduct("2025-05-19", "8a12867e92c341870192c7c46bdb47d6")
+    val addProduct = ZuoraOrdersApiPrimitives.addProduct(
+      "2025-05-20",
+      "8a128ed885fc6ded018602296ace3eb8",
+      List(
+        ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12),
+        ZuoraOrdersApiPrimitives.chargeOverride("8a128d7085fc6dec01860234cd075270", 0)
+      )
+    )
+    val json = ZuoraOrdersApiPrimitives.subscription("a1809f5e84dd", removeProduct: Value, addProduct: Value)
+    val jsonstrpp = ujson.write(json, indent = 4)
+    assertEquals(
+      jsonstrpp,
+      """{
+        |    "subscriptionNumber": "a1809f5e84dd",
+        |    "orderActions": [
+        |        {
+        |            "type": "RemoveProduct",
+        |            "triggerDates": [
+        |                {
+        |                    "name": "ContractEffective",
+        |                    "triggerDate": "2025-05-19"
+        |                },
+        |                {
+        |                    "name": "ServiceActivation",
+        |                    "triggerDate": "2025-05-19"
+        |                },
+        |                {
+        |                    "name": "CustomerAcceptance",
+        |                    "triggerDate": "2025-05-19"
+        |                }
+        |            ],
+        |            "removeProduct": {
+        |                "ratePlanId": "8a12867e92c341870192c7c46bdb47d6"
+        |            }
+        |        },
+        |        {
+        |            "type": "AddProduct",
+        |            "triggerDates": [
+        |                {
+        |                    "name": "ContractEffective",
+        |                    "triggerDate": "2025-05-20"
+        |                },
+        |                {
+        |                    "name": "ServiceActivation",
+        |                    "triggerDate": "2025-05-20"
+        |                },
+        |                {
+        |                    "name": "CustomerAcceptance",
+        |                    "triggerDate": "2025-05-20"
+        |                }
+        |            ],
+        |            "addProduct": {
+        |                "productRatePlanId": "8a128ed885fc6ded018602296ace3eb8",
+        |                "chargeOverrides": [
+        |                    {
+        |                        "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
+        |                        "pricing": {
+        |                            "recurringFlatFee": {
+        |                                "listPrice": 12
+        |                            }
+        |                        }
+        |                    },
+        |                    {
+        |                        "productRatePlanChargeId": "8a128d7085fc6dec01860234cd075270",
+        |                        "pricing": {
+        |                            "recurringFlatFee": {
+        |                                "listPrice": 0
+        |                            }
+        |                        }
+        |                    }
+        |                ]
+        |            }
+        |        }
+        |    ]
+        |}""".stripMargin
+    )
+  }
+
   test("replace_a_product_in_a_subscription") {
     val removeProduct = ZuoraOrdersApiPrimitives.removeProduct("2025-05-19", "8a12867e92c341870192c7c46bdb47d6")
     val addProduct = ZuoraOrdersApiPrimitives.addProduct(
@@ -236,85 +316,4 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |}""".stripMargin
     )
   }
-
-  test("subscription") {
-    val removeProduct = ZuoraOrdersApiPrimitives.removeProduct("2025-05-19", "8a12867e92c341870192c7c46bdb47d6")
-    val addProduct = ZuoraOrdersApiPrimitives.addProduct(
-      "2025-05-20",
-      "8a128ed885fc6ded018602296ace3eb8",
-      List(
-        ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12),
-        ZuoraOrdersApiPrimitives.chargeOverride("8a128d7085fc6dec01860234cd075270", 0)
-      )
-    )
-    val json = ZuoraOrdersApiPrimitives.subscription("a1809f5e84dd", removeProduct: Value, addProduct: Value)
-    val jsonstrpp = ujson.write(json, indent = 4)
-    assertEquals(
-      jsonstrpp,
-      """{
-        |    "subscriptionNumber": "a1809f5e84dd",
-        |    "orderActions": [
-        |        {
-        |            "type": "RemoveProduct",
-        |            "triggerDates": [
-        |                {
-        |                    "name": "ContractEffective",
-        |                    "triggerDate": "2025-05-19"
-        |                },
-        |                {
-        |                    "name": "ServiceActivation",
-        |                    "triggerDate": "2025-05-19"
-        |                },
-        |                {
-        |                    "name": "CustomerAcceptance",
-        |                    "triggerDate": "2025-05-19"
-        |                }
-        |            ],
-        |            "removeProduct": {
-        |                "ratePlanId": "8a12867e92c341870192c7c46bdb47d6"
-        |            }
-        |        },
-        |        {
-        |            "type": "AddProduct",
-        |            "triggerDates": [
-        |                {
-        |                    "name": "ContractEffective",
-        |                    "triggerDate": "2025-05-20"
-        |                },
-        |                {
-        |                    "name": "ServiceActivation",
-        |                    "triggerDate": "2025-05-20"
-        |                },
-        |                {
-        |                    "name": "CustomerAcceptance",
-        |                    "triggerDate": "2025-05-20"
-        |                }
-        |            ],
-        |            "addProduct": {
-        |                "productRatePlanId": "8a128ed885fc6ded018602296ace3eb8",
-        |                "chargeOverrides": [
-        |                    {
-        |                        "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
-        |                        "pricing": {
-        |                            "recurringFlatFee": {
-        |                                "listPrice": 12
-        |                            }
-        |                        }
-        |                    },
-        |                    {
-        |                        "productRatePlanChargeId": "8a128d7085fc6dec01860234cd075270",
-        |                        "pricing": {
-        |                            "recurringFlatFee": {
-        |                                "listPrice": 0
-        |                            }
-        |                        }
-        |                    }
-        |                ]
-        |            }
-        |        }
-        |    ]
-        |}""".stripMargin
-    )
-  }
-
 }

--- a/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
@@ -76,4 +76,20 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
     )
   }
 
+  test("GuardianWeekly2025Migration.priceData (EUR-annual1)") {
+    val subscription = Fixtures.subscriptionFromJson("Migrations/GuardianWeekly2025/EUR-annual1/subscription.json")
+    val account = Fixtures.accountFromJson("Migrations/GuardianWeekly2025/EUR-annual1/account.json")
+    val invoicePreview = Fixtures.invoiceListFromJson("Migrations/GuardianWeekly2025/EUR-annual1/invoice-preview.json")
+
+    // Currency from subscription: "currency": "EUR"
+    // Old price from currency: active rate plan, one single rate plan charge: "price": 318
+    // price lookup (new price): (Annual, "EUR") -> BigDecimal(348)
+    // Billing frequency from currency: active rate plan, rate plan charge: "billingPeriod": "Annual"
+
+    assertEquals(
+      GuardianWeekly2025Migration.priceData(subscription, invoicePreview, account),
+      Right(PriceData("EUR", BigDecimal(318), BigDecimal(348), "Annual"))
+    )
+  }
+
 }


### PR DESCRIPTION
Performs two changes

1. Add GuardianWeekly2025Migration.priceData (EUR-annual1) test
2. Some cosmetic refactorings in `ZuoraOrdersApiPrimitives` and `ZuoraOrdersApiPrimitivesTest` (to simplify the next PR)