### PR TITLE
Simplify PriceCap

### DIFF
--- a/docs/the-art-of-the-cap.md
+++ b/docs/the-art-of-the-cap.md
@@ -1,111 +1,21 @@
 
 # The art of the cap
 
-In this chapter we explain the reasons for the current logic of the price capping function of the engine, which is currently found in the PriceCap object.
+Price capping was originally introduced in late 2022 to implement the newly introduced policy of not price rising customers by more than 20%. For instance, if the pre price rise value of the subscription was 100 and the estimated price was 130, then we would artificially set the price of the subscription to 120. 
 
-Price capping was originally introduced in late 2022 to implement the newly introduced policy of not price rising customers by more than 20%. For instance, if the pre price rise value of the subscription was 100 and the estimated price was 130, then we would artificially set the price of the subscription to 120. This policy was originally introduced as a core function of the engine (which was a mistake -- hence its [recent re-introduction as a library](https://github.com/guardian/price-migration-engine/pull/1006)), and also was not applied to the 2023 digital migrations (hence, recent code modifications to make it migration specific).
-
-## The `ZuoraSubscriptionUpdate` data type
-
-The mechanism by which we can set subscription prices on a subscription basis relies on what actually happens during a price rise. During a price rise we either migrate the subscription to a new rate plan or force the subscription to adopt the new pricing of the subscription it already had. In either case the target rate plan is the one defined in the product catalogue.
-
-The important thing to understand is that when a subscription adopts a rate plan (or readaopts it), this is not represented in Zuora as a link from the subscription to the rate plan in the product catalogue. Instead, Zuora makes a copy of the product catalogue rate plan and attach it to the subscription. This is the moment one can override the product catalogue price and set whatever we want, including a price that has been capped.
-
-When we perform the price rise update, we submit the following data type to Zuora
-
-```
-case class ZuoraSubscriptionUpdate(
-    add: Seq[AddZuoraRatePlan],
-    remove: Seq[RemoveZuoraRatePlan],
-    currentTerm: Option[Int],
-    currentTermPeriodType: Option[String]
-)
-```
-
-The `RemoveZuoraRatePlan` essentially carries the id of the particular rate plan the subscription was carrying. The `AddZuoraRatePlan` indicates the id of the rate plan in the product catalogue (that rate plan is going to be copied as we said earlier and will then be given its own individual id). 
-
-The exact shape of a `AddZuoraRatePlan` is
-
-```
-case class AddZuoraRatePlan(
-    productRatePlanId: String,
-    contractEffectiveDate: LocalDate,
-    chargeOverrides: Seq[ChargeOverride] = Nil
-)
-```
-
-and the important bit for price capping is `ChargeOverride`. If `chargeOverrides` is null then the rate plan given to the subscription will carry the price from the product catalogue. But if provided `ChargeOverride` carries the prices we want to apply. 
-
-Note that the rest of this chapter conly applies to migration where we apply a price cap.
+1. This policy was originally introduced as a core function of the engine, which was a [big mistake](https://github.com/guardian/price-migration-engine/pull/781).
+1. Was not applied to the 2023 digital migrations (hence, related code modifications to make it migration specific).
+1. Been reintroduced in 2024 [as a library](https://github.com/guardian/price-migration-engine/pull/1006))
+1. Updated in [2025](https://github.com/guardian/price-migration-engine/pull/1147)
 
 ## Logic of a price cap
 
 After the Estimation step a cohort item has the current price of the subscription, which the engine learnt from Zuora, but also the estimated new price, the price Zuora indicated the subscription will have after the price rise amendment. This price is obviously the uncapped price.
 
-Now one must resist the temptation of capping the estimated new price and storing that in the cohort item. It's a very bad idea that caused us a lot of problems in the past. In the updated logic we store the uncapped price, and only perform the capping, when needed, at specific places.
+Now one must resist the temptation of capping the estimated new price and storing that in the cohort item. It's a very bad idea that caused us a [lot of problems](https://github.com/guardian/price-migration-engine/pull/781) in the past. We now store the uncapped price, and only perform the capping, when needed, at specific places.
 
-To fully understand why the capping is the way it is, we need to work with a rate plan that has more than one charge. (In the case of one charge the trivial approach works).
-
-So let's consider a print product with Saturday and Sunday deliveries and the rate plan (called "Week End") has two charged, like this
-
-```
-Week End 
-    - Saturday: 12
-    - Sunday  : 15
-```
-
-Zuora is going to say that the current price of the subscription is 27, but let's also assume that it says that the price after price rise would be 40, and that we have a 25% price increase cap. Since  27 + 25% (of 27) is 33.75, the price is going to be capped. As indicated above we do not store 33.75 in the cohort item as estimated new price we store 40. So at this point the cohort item is 
-
-```
-Item
-
-    - current price      : 27
-    - estimated new price: 40
-```
-
-and, very important, note that the cohort item doesn't know that the subscription has two charges
-
-### At the Notification step
-
-The first time we are going to call PriceCap is during the notification step. We are going to call the function 
-
-```
-priceCapForNotification(oldPrice: BigDecimal, newPrice: BigDecimal, cap: BigDecimal): BigDecimal
-```
-
-like this 
-
-```
-priceCapForNotification(27, 40, 1.25)
-```
-
-The returned value, 33.75, is the price we are going to tell the customer that they are going to pay. Note that the engine doesn't know, and doesn't care, that the old price and the new price come from two charges.
-
-### At the SalesforcePriceRiseCreationHandler
-
-The second time we are going to call `PriceCap` is inside the SalesforcePriceRiseCreationHandler, and we call `priceCapForNotification` again. We are informing Salesforce of the new price the users was told they are going to pay.
-
-### At the Amendment step
-
-At the Amendment step, we call `PriceCap` again but a different function. We call 
-
-```
-priceCapForAmendment(
-    oldPrice: BigDecimal,
-    newPrice: BigDecimal,
-    cap: BigDecimal,
-    zuoraUpdate: ZuoraSubscriptionUpdate
-)
-```
-
-The logic of this function is that we provide it with the information we have, the old and new (uncapped) prices, the cap (which is a paramter of the migration) and the original `ZuoraSubscriptionUpdate`. The return value will be a modified `ZuoraSubscriptionUpdate`, where all the charges inside the `AddZuoraRatePlan` will be updated so that their sum end up being the capped price 🎉
-
-And this is why we needed to work with the uncapped price. The updated charged are computed by applying a correction factor to the product catalogue charges, but that correction factor is a function of the old price and the uncapped new price. If we only had the old price and the capped price we would not be able to compute the correction factor, and would not be able to construct a correct `ZuoraSubscriptionUpdate`.
-
-## Conclusion
-
-The above should provide a clear explanation of why PriceCap has those two functions, `priceCapForNotification` and `priceCapForAmendment`, and why their signatures are the way they are. Note that we did not use `priceCapForAmendment` in GW2024, because we used `priceCapForNotification` directly in the construction of `ZuoraSubscriptionUpdate` (which was possible because we only have one charge). In any case, and as long as the existing library presents itself thise way, if a migration needs capping, one must make sure that capping happens at these three places:
+One must make sure that capping happens at these three places:
 
 1. The Estimation step.
 2. The Salesforce price rise creation step.
-3. The Amendment step.
+3. The Amendment step (from inside the migration module, when returning the Zuora Order)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -6,6 +6,7 @@ import pricemigrationengine.model.membershipworkflow._
 import pricemigrationengine.services._
 import zio.{Clock, ZIO}
 import com.gu.i18n
+import pricemigrationengine.libs.PriceCap
 import pricemigrationengine.migrations.{GuardianWeekly2025Migration, Newspaper2025Migration, SupporterPlus2024Migration}
 import pricemigrationengine.model.RateplansProbe
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -152,9 +152,9 @@ object NotificationHandler extends CohortHandler {
       priceWithOptionalCappingWithCurrencySymbol = MigrationType(cohortSpec) match {
         case SupporterPlus2024 => s"${currencySymbol}${estimatedNewPrice}"
         case GuardianWeekly2025 =>
-          s"${currencySymbol}${PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)}"
+          s"${currencySymbol}${PriceCap.cappedPrice(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)}"
         case Newspaper2025 =>
-          s"${currencySymbol}${PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, Newspaper2025Migration.priceCap)}"
+          s"${currencySymbol}${PriceCap.cappedPrice(oldPrice, estimatedNewPrice, Newspaper2025Migration.priceCap)}"
       }
 
       _ <- logMissingEmailAddress(cohortItem, contact)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -84,9 +84,9 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
       val estimatedPriceWithOptionalCapping = MigrationType(cohortSpec) match {
         case SupporterPlus2024 => estimatedNewPrice // [1]
         case GuardianWeekly2025 =>
-          PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)
+          PriceCap.cappedPrice(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)
         case Newspaper2025 =>
-          PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, Newspaper2025Migration.priceCap)
+          PriceCap.cappedPrice(oldPrice, estimatedNewPrice, Newspaper2025Migration.priceCap)
       }
       // [1]
       // (Comment group: 7992fa98)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -1,5 +1,6 @@
 package pricemigrationengine.handlers
 
+import pricemigrationengine.libs.PriceCap
 import pricemigrationengine.migrations.{GuardianWeekly2025Migration, Newspaper2025Migration}
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiseCreationComplete}
 import pricemigrationengine.model._

--- a/lambda/src/main/scala/pricemigrationengine/libs/PriceCap.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/PriceCap.scala
@@ -1,4 +1,4 @@
-package pricemigrationengine.model
+package pricemigrationengine.libs
 
 object PriceCap {
 

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
@@ -1,6 +1,5 @@
 package pricemigrationengine.migrations
 import pricemigrationengine.libs.SI2025Extractions
-import pricemigrationengine.model.PriceCap
 import pricemigrationengine.model.ZuoraRatePlan
 import pricemigrationengine.model._
 import pricemigrationengine.libs._

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025Migration.scala
@@ -1,5 +1,4 @@
 package pricemigrationengine.migrations
-import pricemigrationengine.model.PriceCap
 import pricemigrationengine.model.ZuoraRatePlan
 import pricemigrationengine.model._
 import pricemigrationengine.libs._

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
@@ -1,4 +1,5 @@
 package pricemigrationengine.migrations
+import pricemigrationengine.libs.PriceCap
 import pricemigrationengine.model.ZuoraRatePlan
 import pricemigrationengine.model._
 

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
@@ -355,7 +355,7 @@ object SupporterPlus2024Migration {
       productRatePlanId = existingRatePlan.productRatePlanId,
       existingBaseProductRatePlanChargeId = existingBaseRatePlanCharge.productRatePlanChargeId,
       existingContributionRatePlanChargeId = existingContributionRatePlanCharge.productRatePlanChargeId,
-      newBaseAmount = PriceCap.priceCapForNotification(oldPrice, estimatedNewPrice, priceCap),
+      newBaseAmount = PriceCap.cappedPrice(oldPrice, estimatedNewPrice, priceCap),
       newContributionAmount = existingContributionPrice
     )
   }

--- a/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
@@ -5,77 +5,12 @@ object PriceCap {
   // Directive:
   // If you edit this file, please keep docs/the-art-of-the-cap.md up to date.
 
-  // --------------------------------------------------------
-  // Part 1
-
-  private val priceCappingMultiplier = 1.2 // old price + 20%
-  def priceCapLegacy(
+  def cappedPrice(
       oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal
+      uncappedNewPrice: BigDecimal,
+      priceCappingMultiplier: BigDecimal
   ): BigDecimal = {
-    List(estimatedNewPrice, oldPrice * priceCappingMultiplier).min
-  }
-
-  // --------------------------------------------------------
-  // Part 2
-
-  // We have separate functions for determining the
-  // estimated new price and for computing the adjusted ZuoraSubscriptionUpdate. Unlike the now obsolete part 1
-  // We design those functions with the signature that is actually useful for price cap, where we will need to apply it
-  // 1. The SalesforcePriceRiseCreationHandler (priceCapForNotification), and
-  // 2. The notification handler (priceCapForNotification), and
-  // 3. The amendment handler (priceCapForAmendment)
-
-  // Note: We should not apply capping during the estimation step and capped prices should not be written in the
-  // migration dynamo tables !
-
-  // Note: These functions work better for simple price migrations where the subscription has one price
-  // that we update. In the case of SupporterPlus subscriptions, with their base price and extra optional
-  // contribution (see example of the SupporterPlus2024 price migration), the base price is price risen and
-  // capped, but the subscription price is the sum of that new price together with the contribution. In a
-  // case like that we just implemented the price capping in the migration code itself, without messing around
-  // with this code.
-
-  def priceCapForNotification(oldPrice: BigDecimal, newPrice: BigDecimal, cap: BigDecimal): BigDecimal = {
-    // The cap is the price cap expressed as a multiple of the old price. For instance for a price cap
-    // of 20%, we will use a cap equal to 1.2
-    (oldPrice * cap).min(newPrice)
-  }
-
-  def priceCorrectionFactor(oldPrice: BigDecimal, newPrice: BigDecimal, cap: BigDecimal) = {
-    if (newPrice < oldPrice * cap) 1.0
-    else
-      (oldPrice * cap).toDouble / newPrice.toDouble
-  }
-
-  def updateChargeOverride(chargeOverride: ChargeOverride, correctionFactor: Double): ChargeOverride = {
-    chargeOverride.copy(price = chargeOverride.price * correctionFactor)
-  }
-
-  def updateAddZuoraRatePlan(addZuoraRatePlan: AddZuoraRatePlan, correctionFactor: Double): AddZuoraRatePlan = {
-    addZuoraRatePlan.copy(chargeOverrides =
-      addZuoraRatePlan.chargeOverrides.map(chargeOverride =>
-        updateChargeOverride(chargeOverride: ChargeOverride, correctionFactor: Double)
-      )
-    )
-  }
-
-  def priceCapForAmendment(
-      oldPrice: BigDecimal,
-      newPrice: BigDecimal,
-      cap: BigDecimal,
-      zuoraUpdate: ZuoraSubscriptionUpdate
-  ): ZuoraSubscriptionUpdate = {
-    val shouldApplyCapping: Boolean = (oldPrice * cap) < newPrice
-    if (shouldApplyCapping) {
-      val correctionFactor = priceCorrectionFactor(oldPrice, newPrice, cap)
-      zuoraUpdate.copy(add =
-        zuoraUpdate.add.map(addZuoraRatePlan =>
-          updateAddZuoraRatePlan(addZuoraRatePlan: AddZuoraRatePlan, correctionFactor: Double)
-        )
-      )
-    } else {
-      zuoraUpdate
-    }
+    // For a price cap of 20%, the priceCappingMultiplier is set to 1.2
+    List(uncappedNewPrice, oldPrice * priceCappingMultiplier).min
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -22,9 +22,6 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
   private val oldPrice = BigDecimal(10.00)
 
   private val estimatedNewPrice = BigDecimal(15.00)
-  test("For legacy migrations, we need the estimatedNewPrice to be higher than the capped price") {
-    assert(PriceCap.priceCapLegacy(oldPrice, estimatedNewPrice) < estimatedNewPrice)
-  }
 
   private val currentTime = Instant.parse("2020-05-21T15:16:37Z")
 

--- a/lambda/src/test/scala/pricemigrationengine/libs/PriceCapTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/PriceCapTest.scala
@@ -1,8 +1,4 @@
-package pricemigrationengine.model
-
-import pricemigrationengine.model.PriceCap
-
-import java.time.LocalDate
+package pricemigrationengine.libs
 
 class PriceCapTest extends munit.FunSuite {
 

--- a/lambda/src/test/scala/pricemigrationengine/model/PriceCapTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/PriceCapTest.scala
@@ -6,12 +6,18 @@ import java.time.LocalDate
 
 class PriceCapTest extends munit.FunSuite {
 
-  test("The price legacy capping function works correctly") {
+  test("cappedPrice is computed correctly") {
     val oldPrice = BigDecimal(100)
-    val cappedPrice = BigDecimal(120)
-    val uncappedPrice = BigDecimal(156)
-    // Note the implicit price capping at 20%
-    assertEquals(cappedPrice, PriceCap.priceCapLegacy(oldPrice, uncappedPrice))
+    val uncappedNewPrice = BigDecimal(156)
+    val priceCappingMultiplier = BigDecimal(1.2)
+    assertEquals(
+      PriceCap.cappedPrice(
+        oldPrice,
+        uncappedNewPrice,
+        priceCappingMultiplier
+      ),
+      BigDecimal(120)
+    )
   }
 
   test("priceCapNotification (no need to apply)") {
@@ -19,7 +25,7 @@ class PriceCapTest extends munit.FunSuite {
     val newPrice = BigDecimal(110)
     val cap = 1.25
     assertEquals(
-      PriceCap.priceCapForNotification(oldPrice, newPrice, cap),
+      PriceCap.cappedPrice(oldPrice, newPrice, cap),
       BigDecimal(110)
     )
   }
@@ -29,154 +35,8 @@ class PriceCapTest extends munit.FunSuite {
     val newPrice = BigDecimal(250)
     val cap = 1.25
     assertEquals(
-      PriceCap.priceCapForNotification(oldPrice, newPrice, cap),
+      PriceCap.cappedPrice(oldPrice, newPrice, cap),
       BigDecimal(125)
     )
   }
-
-  test("priceCorrectionFactor (trivial case)") {
-    // The new price is lower than the old price multiplied by the price cap multiplier.
-    // We expect a correction factor equal to 1, for price invariance
-    assertEquals(
-      PriceCap.priceCorrectionFactor(BigDecimal(50), BigDecimal(55), BigDecimal(1.2)),
-      1.0
-    )
-  }
-
-  test("priceCorrectionFactor") {
-    // The capped price is 50 * 1.2 = 60
-    // The new price is 120, which wee need to multiply by 0.5 to get to the capped price
-    // Therefore the price correction factor is 0.5
-    assertEquals(
-      PriceCap.priceCorrectionFactor(BigDecimal(50), BigDecimal(120), BigDecimal(1.2)),
-      0.5
-    )
-  }
-
-  test("updateChargeOverride") {
-    val chargeOverride = ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(200))
-    val correctionFactor = 0.9
-    assertEquals(
-      PriceCap.updateChargeOverride(chargeOverride, correctionFactor),
-      ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(180))
-    )
-  }
-
-  test("updateAddZuoraRatePlan (no ChargeOverrides)") {
-    val chargeOverride = ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(200))
-    val addZuoraRatePlan = AddZuoraRatePlan("productRatePlanId", LocalDate.of(2024, 3, 11), Nil)
-    val correctionFactor = 0.9
-
-    // We do not actually expect any change here, because the chargeOverrides are not specified
-    // This would be a mistake in the migration code, but nothing to do with the updateAddZuoraRatePlan
-    // function itself which must be invariant in this case
-
-    assertEquals(
-      PriceCap.updateAddZuoraRatePlan(addZuoraRatePlan, correctionFactor),
-      addZuoraRatePlan
-    )
-  }
-
-  test("updateAddZuoraRatePlan (with two)") {
-    val chargeOverride1 = ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(200))
-    val chargeOverride2 = ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(100))
-    val addZuoraRatePlan =
-      AddZuoraRatePlan("productRatePlanId", LocalDate.of(2024, 3, 11), List(chargeOverride1, chargeOverride2))
-    val correctionFactor = 0.9
-
-    assertEquals(
-      PriceCap.updateAddZuoraRatePlan(addZuoraRatePlan, correctionFactor),
-      AddZuoraRatePlan(
-        "productRatePlanId",
-        LocalDate.of(2024, 3, 11),
-        List(
-          ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(180)),
-          ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(90))
-        )
-      )
-    )
-  }
-
-  test("priceCapForAmendment (without correction)") {
-
-    val chargeOverride1 = ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(25))
-    val chargeOverride2 = ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(30))
-    val addZuoraRatePlan =
-      AddZuoraRatePlan("productRatePlanId", LocalDate.of(2024, 3, 11), List(chargeOverride1, chargeOverride2))
-    val zuoraUpdate = ZuoraSubscriptionUpdate(
-      add = List(addZuoraRatePlan),
-      remove = List(),
-      currentTerm = None,
-      currentTermPeriodType = None
-    )
-
-    // The charges in chargeOverride1, and chargeOverride2 were chosen to equal 55, the (uncapped) new price.
-
-    val oldPrice = BigDecimal(50)
-    val newPrice = BigDecimal(55)
-    val cap = BigDecimal(1.2)
-
-    // We expect a correction factor equal to 1, resulting in no change in the zuoraUpdate
-
-    assertEquals(
-      PriceCap.priceCorrectionFactor(oldPrice, newPrice, cap),
-      1.0
-    )
-
-    // With a correction factor of 0.5, we have 45 and 15 as corrected prices in the charges
-
-    assertEquals(
-      PriceCap.priceCapForAmendment(oldPrice, newPrice, cap, zuoraUpdate),
-      zuoraUpdate
-    )
-  }
-
-  test("priceCapForAmendment (with correction)") {
-
-    val chargeOverride1 = ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(90))
-    val chargeOverride2 = ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(30))
-    val addZuoraRatePlan =
-      AddZuoraRatePlan("productRatePlanId", LocalDate.of(2024, 3, 11), List(chargeOverride1, chargeOverride2))
-    val zuoraUpdate = ZuoraSubscriptionUpdate(
-      add = List(addZuoraRatePlan),
-      remove = List(),
-      currentTerm = None,
-      currentTermPeriodType = None
-    )
-
-    // The charges in chargeOverride1, and chargeOverride2 were chosen to equal 120, the (uncapped) new price.
-
-    val oldPrice = BigDecimal(50)
-    val newPrice = BigDecimal(120)
-    val cap = BigDecimal(1.2)
-
-    // We expect a correction factor equal to 0.5
-
-    assertEquals(
-      PriceCap.priceCorrectionFactor(oldPrice, newPrice, cap),
-      0.5
-    )
-
-    // With a correction factor of 0.5, we have 45 and 15 as corrected prices in the charges
-
-    assertEquals(
-      PriceCap.priceCapForAmendment(oldPrice, newPrice, cap, zuoraUpdate),
-      ZuoraSubscriptionUpdate(
-        add = List(
-          AddZuoraRatePlan(
-            "productRatePlanId",
-            LocalDate.of(2024, 3, 11),
-            List(
-              ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(45)),
-              ChargeOverride("productRatePlanChargeId", "Monthly", BigDecimal(15))
-            )
-          )
-        ),
-        remove = List(),
-        currentTerm = None,
-        currentTermPeriodType = None
-      )
-    )
-  }
-
 }


### PR DESCRIPTION
This change Simplifies PriceCap. We no longer need the complex code that was supporting the embedding of capping deep inside into `ZuoraSubscriptionUpdate`. We also move it to libraries, with documentation update. 