### PR TITLE
use migration extra attributes to respect marketing lowerbound migration date

### DIFF
--- a/docs/migration-extra-attributes.md
+++ b/docs/migration-extra-attributes.md
@@ -38,3 +38,9 @@ aws dynamodb update-item \
 ```
 
 Pascal uses this tool from Ruby scripts to automate the updates.
+
+### How to use, an exmanple
+
+The first use of `migrationExtraAttributes` was made in this [PR, for GuardianWeekly2025](https://github.com/guardian/price-migration-engine/pull/1150).
+
+

--- a/docs/start-date-computation.md
+++ b/docs/start-date-computation.md
@@ -63,9 +63,11 @@ Step 4: We now need to apply our [no price rise during subscription first year] 
 
 Step 5: We then apply the [no price rise within a year of last price rise] (not price rising a subscription twice within the same 12 months). (This is a policy that is mostly symbolically implemented in the code and has a non trivial evaluation only for the Guardian Weekly 2024, where we protect for subs from the Guardian Weekly 2022 migration from being price risen too soon.) In this case our sub is undergoing its first price rise, so the lowerbound remains to `2024-07-08`.
 
-Step 6: Our spread period is 3 months. Let's assume that the random choice returned 1, We now need to add a month to our previously computed date, which is now `2024-08-08`. 
+Step 6: With GuardianWeekly2025, we were given lower bounds in the Marketing spreadsheet. That was actually the first use of the new cohortItem's migrationExtraAttributes. If we expect a migration to provide it own lowerbound computation, we do it here, otherwise we identity on startDateLowerBound3.
 
-Step 7: We are now ready for the start date. The start date is the next available billing date after `2024-08-08`. Since we have a monthly sub paying on the 27th, the start date is `2024-08-27` 🗓️ 🎉
+Step 7: Our spread period is 3 months. Let's assume that the random choice returned 1, We now need to add a month to our previously computed date, which is now `2024-08-08`. 
+
+Step 8: We are now ready for the start date. The start date is the next available billing date after `2024-08-08`. Since we have a monthly sub paying on the 27th, the start date is `2024-08-27` 🗓️ 🎉
 
 
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -113,6 +113,7 @@ object EstimationHandler extends CohortHandler {
       invoicePreviewTargetDate = cohortSpec.earliestPriceMigrationStartDate.plusMonths(16)
       invoicePreview <- Zuora.fetchInvoicePreview(subscription.accountId, invoicePreviewTargetDate)
       startDateLowerBound <- StartDates.startDateLowerBound(
+        item: CohortItem,
         subscription,
         invoicePreview,
         cohortSpec,

--- a/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
@@ -94,6 +94,7 @@ object StartDates {
   }
 
   def startDateLowerBound(
+      item: CohortItem,
       subscription: ZuoraSubscription,
       invoicePreview: ZuoraInvoiceList,
       cohortSpec: CohortSpec,
@@ -113,6 +114,16 @@ object StartDates {
     // And the policy not to price rise a sub twice within 12 months of any possible price rise
     val startDateLowerBound3 =
       noPriceRiseWithinAYearOfLastPriceRisePolicyUpdate(cohortSpec, subscription, startDateLowerBound2)
+
+    // With GuardianWeekly2025, we were given lower bounds in the Marketing spreadsheet
+    // that was the first use of the new cohortItem's migrationExtraAttributes. If we expect a
+    // migration to provide it own lowerbound computation, we do it here, otherwise we identity
+    // on startDateLowerBound3
+    val startDateLowerBound4 = MigrationType(cohortSpec) match {
+      case SupporterPlus2024  => startDateLowerBound3
+      case GuardianWeekly2025 => GuardianWeekly2025Migration.computeStartDateLowerBound4(startDateLowerBound3, item)
+      case Newspaper2025      => startDateLowerBound3
+    }
 
     // Decide the spread period for this migration
     val spreadPeriod = decideSpreadPeriod(subscription, invoicePreview, cohortSpec)


### PR DESCRIPTION
Context: GuardianWeekly2025

I noticed comparing the start dates for each item in the AWS Dynamo cohort table and that of the spreadsheet from marketing that there are a few subscriptions for which the automatically computed start date (the migration date) happens earlier than what Marketing wished (mostly monthlies which should be migrated a month later than the originally computed start date). I them did two things:

1. Ran a script to update the cohort item in the dynamoDb to move the item back to `ReadyForEstimation` (they will be re-estimated the next time the state machine runs for that migration), as well as setting the `migrationExtraAttributes` attribute to json objects of the form `{ "earliestMigrationDate": "2025-10-06" }` (I could have just set the attribute, which has type String, to the date itself, but the original idea behind those attributes is that they should be extensible in a backward compatible way, hence a json object). See [1] 

2. Made this PR, to extend the processing happening inside the `StartDates` library and gave to GuardianWeekly2025 ways to read that attribute if it is set and contribute to the computation of the `startDate`.

This is the first time we use: https://github.com/guardian/price-migration-engine/pull/1139

[1] 

![10 Screenshot 2025-06-15 at 13 19 23](https://github.com/user-attachments/assets/9a17abb5-35c3-41cc-8aa7-772ea3164d3d)
