### PR TITLE
correction in startdates

### DIFF
--- a/docs/migration-extra-attributes.md
+++ b/docs/migration-extra-attributes.md
@@ -39,7 +39,7 @@ aws dynamodb update-item \
 
 Pascal uses this tool from Ruby scripts to automate the updates.
 
-### How to use, an exmanple
+### How to use, an example
 
 The first use of `migrationExtraAttributes` was made in this [PR, for GuardianWeekly2025](https://github.com/guardian/price-migration-engine/pull/1150).
 

--- a/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
@@ -130,6 +130,6 @@ object StartDates {
 
     for {
       randomFactor <- Random.nextIntBetween(0, spreadPeriod)
-    } yield startDateLowerBound3.plusMonths(randomFactor)
+    } yield startDateLowerBound4.plusMonths(randomFactor)
   }
 }


### PR DESCRIPTION
This is a tiny correction follow up of https://github.com/guardian/price-migration-engine/pull/1150

Although `startDateLowerBound4` is computed correctly, `startDateLowerBound` wasn't taking account of it 🙃 This change corrects it. 