### PR TITLE
decommission datalake export (part 1)

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortTableDatalakeExportHandler.scala
@@ -128,18 +128,5 @@ object CohortTableDatalakeExportHandler extends CohortHandler {
       }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] =
-    MigrationType(input) match {
-      case Newspaper2025P1 => ZIO.succeed(HandlerOutput(isComplete = true))
-      case _ => {
-        main(input).provideSome[Logging](
-          EnvConfig.cohortTable.layer,
-          EnvConfig.stage.layer,
-          EnvConfig.export.layer,
-          DynamoDBClientLive.impl,
-          DynamoDBZIOLive.impl,
-          CohortTableLive.impl(input),
-          S3Live.impl
-        )
-      }
-    }
+    ZIO.succeed(HandlerOutput(isComplete = true))
 }


### PR DESCRIPTION
Here we start the decommission of the CohortTableDatalakeExport handler as per request from @NathanielBennett . In this part one, we simply prevent the handler to run, in a later update we will perform a deeper removal of the handler and its supporting infra.