### PR TITLE
Introduce HomeDelivery2025 and its price grid

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -96,6 +96,7 @@ object AmendmentHandler extends CohortHandler {
       case SupporterPlus2024  => false // [1]
       case GuardianWeekly2025 => true
       case Newspaper2025P1    => true
+      case HomeDelivery2025   => true
     }
 
     // [1] We do not apply the check to the SupporterPlus2024 migration where, due to the way
@@ -148,6 +149,8 @@ object AmendmentHandler extends CohortHandler {
           ZIO.fail(MigrationRoutingFailure("GuardianWeekly2025 should not use doAmendment_ordersApi_typed_deprecated"))
         case Newspaper2025P1 =>
           ZIO.fail(MigrationRoutingFailure("Newspaper2025 should not use doAmendment_ordersApi_typed_deprecated"))
+        case HomeDelivery2025 =>
+          ZIO.fail(MigrationRoutingFailure("HomeDelivery2025 should not use doAmendment_ordersApi_typed_deprecated"))
       }
       _ <- Logging.info(
         s"Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with order ${order}"
@@ -243,6 +246,20 @@ object AmendmentHandler extends CohortHandler {
               invoiceList = invoicePreviewBeforeUpdate
             )
           )
+        case HomeDelivery2025 =>
+          ZIO.fromEither(
+            HomeDelivery2025Migration.amendmentOrderPayload(
+              orderDate = LocalDate.now(),
+              accountNumber = account.basicInfo.accountNumber,
+              subscriptionNumber = subscriptionBeforeUpdate.subscriptionNumber,
+              effectDate = startDate,
+              subscription = subscriptionBeforeUpdate,
+              oldPrice = oldPrice,
+              estimatedNewPrice = estimatedNewPrice,
+              priceCap = Newspaper2025P1Migration.priceCap,
+              invoiceList = invoicePreviewBeforeUpdate
+            )
+          )
       }
       _ <- Logging.info(
         s"[6e6da544] Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with order ${order}"
@@ -307,6 +324,12 @@ object AmendmentHandler extends CohortHandler {
           item: CohortItem
         )
       case Newspaper2025P1 =>
+        doAmendment_ordersApi_json_values(
+          cohortSpec: CohortSpec,
+          catalogue: ZuoraProductCatalogue,
+          item: CohortItem
+        )
+      case HomeDelivery2025 =>
         doAmendment_ordersApi_json_values(
           cohortSpec: CohortSpec,
           catalogue: ZuoraProductCatalogue,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -9,6 +9,7 @@ import com.gu.i18n
 import pricemigrationengine.libs.PriceCap
 import pricemigrationengine.migrations.{
   GuardianWeekly2025Migration,
+  HomeDelivery2025Migration,
   Newspaper2025P1Migration,
   SupporterPlus2024Migration,
   SupporterPlus2024NotificationData
@@ -28,7 +29,8 @@ object NotificationHandler extends CohortHandler {
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
     MigrationType(input) match {
-      case Newspaper2025P1 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025P1  => ZIO.succeed(HandlerOutput(isComplete = true))
+      case HomeDelivery2025 => ZIO.succeed(HandlerOutput(isComplete = true))
       case _ => {
         main(input).provideSome[Logging](
           EnvConfig.salesforce.layer,
@@ -155,6 +157,8 @@ object NotificationHandler extends CohortHandler {
           s"${currencySymbol}${PriceCap.cappedPrice(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)}"
         case Newspaper2025P1 =>
           s"${currencySymbol}${PriceCap.cappedPrice(oldPrice, estimatedNewPrice, Newspaper2025P1Migration.priceCap)}"
+        case HomeDelivery2025 =>
+          s"${currencySymbol}${PriceCap.cappedPrice(oldPrice, estimatedNewPrice, HomeDelivery2025Migration.priceCap)}"
       }
 
       _ <- logMissingEmailAddress(cohortItem, contact)
@@ -187,6 +191,15 @@ object NotificationHandler extends CohortHandler {
       // Newspaper2025P1 decommissioning.
 
       newspaper2025P1NotificationData <- Newspaper2025P1Migration.getNotificationData(cohortSpec, cohortItem)
+      // ----------------------------------------------------
+
+      // ----------------------------------------------------
+      // Data for HomeDelivery2025
+
+      // This section and the corresponding section below should be removed as part of the
+      // HomeDelivery2025 decommissioning.
+
+      homedelivery2025NotificationData <- HomeDelivery2025Migration.getNotificationData(cohortSpec, cohortItem)
       // ----------------------------------------------------
 
       brazeName <- brazeName(cohortSpec, cohortItem.subscriptionName)
@@ -240,6 +253,15 @@ object NotificationHandler extends CohortHandler {
                 // Newspaper2025P1 decommissioning.
 
                 newspaper2025_brand_title = Some(newspaper2025P1NotificationData.brandTitle),
+                // -------------------------------------------------------------
+
+                // -------------------------------------------------------------
+                // HomeDelivery2025 extension
+
+                // This section and the corresponding section above should be removed as part of the
+                // HomeDelivery decommissioning.
+
+                homedelivery2025_brand_title = Some(homedelivery2025NotificationData.brandTitle),
                 // -------------------------------------------------------------
 
               )
@@ -324,6 +346,7 @@ object NotificationHandler extends CohortHandler {
       case SupporterPlus2024  => SupporterPlus2024Migration.maxLeadTime
       case GuardianWeekly2025 => GuardianWeekly2025Migration.maxLeadTime
       case Newspaper2025P1    => Newspaper2025P1Migration.maxLeadTime
+      case HomeDelivery2025   => HomeDelivery2025Migration.maxLeadTime
     }
   }
 
@@ -333,6 +356,7 @@ object NotificationHandler extends CohortHandler {
       case SupporterPlus2024  => SupporterPlus2024Migration.minLeadTime
       case GuardianWeekly2025 => GuardianWeekly2025Migration.minLeadTime
       case Newspaper2025P1    => Newspaper2025P1Migration.minLeadTime
+      case HomeDelivery2025   => HomeDelivery2025Migration.minLeadTime
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -1,7 +1,11 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.libs.PriceCap
-import pricemigrationengine.migrations.{GuardianWeekly2025Migration, Newspaper2025P1Migration}
+import pricemigrationengine.migrations.{
+  GuardianWeekly2025Migration,
+  HomeDelivery2025Migration,
+  Newspaper2025P1Migration
+}
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiseCreationComplete}
 import pricemigrationengine.model._
 import pricemigrationengine.services._
@@ -89,6 +93,8 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
           PriceCap.cappedPrice(oldPrice, estimatedNewPrice, GuardianWeekly2025Migration.priceCap)
         case Newspaper2025P1 =>
           PriceCap.cappedPrice(oldPrice, estimatedNewPrice, Newspaper2025P1Migration.priceCap)
+        case HomeDelivery2025 =>
+          PriceCap.cappedPrice(oldPrice, estimatedNewPrice, HomeDelivery2025Migration.priceCap)
       }
       // [1]
       // (Comment group: 7992fa98)
@@ -121,6 +127,7 @@ object SalesforcePriceRiseCreationHandler extends CohortHandler {
     MigrationType(input) match {
       case SupporterPlus2024 => ZIO.succeed(HandlerOutput(isComplete = true))
       case Newspaper2025P1   => ZIO.succeed(HandlerOutput(isComplete = true))
+      case HomeDelivery2025  => ZIO.succeed(HandlerOutput(isComplete = true))
       case _ =>
         main(input).provideSome[Logging](
           EnvConfig.cohortTable.layer,

--- a/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
@@ -1,10 +1,14 @@
 package pricemigrationengine.libs
 
 import pricemigrationengine.handlers.NotificationHandler
-import pricemigrationengine.migrations.{GuardianWeekly2025Migration, Newspaper2025P1Migration}
+import pricemigrationengine.migrations.{
+  GuardianWeekly2025Migration,
+  HomeDelivery2025Migration,
+  Newspaper2025P1Migration
+}
 import pricemigrationengine.model._
-import scala.util.Random
 
+import scala.util.Random
 import java.time.LocalDate
 
 /*
@@ -31,6 +35,7 @@ object StartDates {
       case SupporterPlus2024  => None
       case GuardianWeekly2025 => GuardianWeekly2025Migration.subscriptionToLastPriceMigrationDate(subscription) // [1]
       case Newspaper2025P1    => Newspaper2025P1Migration.subscriptionToLastPriceMigrationDate(subscription) // [2]
+      case HomeDelivery2025   => HomeDelivery2025Migration.subscriptionToLastPriceMigrationDate(subscription)
     }
     // [1 & 2] We are applying the "one year since the last price migration" policy for
     // GuardianWeekly2025 and Newspaper2025
@@ -91,6 +96,7 @@ object StartDates {
         case SupporterPlus2024  => 1 // no spread for S+2024 monthlies
         case GuardianWeekly2025 => 1 // no spread for Guardian Weekly 2025
         case Newspaper2025P1    => 1 // no spread for Newspaper 2025
+        case HomeDelivery2025   => 1 // no spread for Home Delivery 2025
       }
     } else 1
   }
@@ -109,6 +115,7 @@ object StartDates {
       case SupporterPlus2024  => cohortSpecLowerBound(cohortSpec, today)
       case GuardianWeekly2025 => cohortSpecLowerBound(cohortSpec, today)
       case Newspaper2025P1    => cohortSpecLowerBound(cohortSpec, today)
+      case HomeDelivery2025   => cohortSpecLowerBound(cohortSpec, today)
     }
 
     // We now respect the policy of not increasing members during their first year
@@ -127,6 +134,7 @@ object StartDates {
       case SupporterPlus2024  => startDateLowerBound3
       case GuardianWeekly2025 => GuardianWeekly2025Migration.computeStartDateLowerBound4(startDateLowerBound3, item)
       case Newspaper2025P1    => startDateLowerBound3
+      case HomeDelivery2025   => startDateLowerBound3
     }
 
     // [1]

--- a/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
@@ -1,0 +1,169 @@
+package pricemigrationengine.migrations
+import pricemigrationengine.model.ZuoraRatePlan
+import pricemigrationengine.model._
+import pricemigrationengine.libs._
+import pricemigrationengine.services.Zuora
+
+import java.time.LocalDate
+import ujson._
+import upickle.default._
+import zio.ZIO
+
+sealed trait HomeDelivery2025DeliveryFrequency
+object HomeDelivery2025Everyday extends HomeDelivery2025DeliveryFrequency
+object HomeDelivery2025Sixday extends HomeDelivery2025DeliveryFrequency
+object HomeDelivery2025Weekend extends HomeDelivery2025DeliveryFrequency
+object HomeDelivery2025Saturday extends HomeDelivery2025DeliveryFrequency
+
+case class HomeDelivery2025ExtraAttributes(brandTitle: String)
+object HomeDelivery2025ExtraAttributes {
+  implicit val reader: Reader[HomeDelivery2025ExtraAttributes] = macroR
+
+  // Each item of the migration is going to have a migration extended attributes object
+  // with a brandTitle key. The value of this key is to be sent to Braze, during the
+  // notification handler to decide the labelling to the entity in the email. At that point the
+  // attribute will be called `brand_title`
+
+  // usage
+  // val s = """{ "brandTitle": "the Guardian" }"""
+  // val s = """{ "brandTitle": "the Guardian and the Observer" }"""
+  // val attributes: HomeDelivery2025ExtraAttributes = upickle.default.read[HomeDelivery2025ExtraAttributes](s)
+}
+
+// (Comment Group: 571dac68)
+
+case class HomeDelivery2025NotificationData(
+    brandTitle: String,
+)
+
+object HomeDelivery2025Migration {
+
+  // ------------------------------------------------
+  // Price capping
+  // ------------------------------------------------
+
+  val priceCap = 1.20
+
+  // ------------------------------------------------
+  // Notification Timings
+  // ------------------------------------------------
+
+  val maxLeadTime = 35
+  val minLeadTime = 33
+
+  // ------------------------------------------------
+  // Price Grid
+  //
+  // It is now a standard feature of modern migrations that we hardcode the price grid
+  // into the migration. This is a manual step in the setting of the migration, but it has the
+  // advantage of not relying on complex look up of the price catalogue. (In fact we could even migrate
+  // to prices not present in the price catalogue)
+  // ------------------------------------------------
+
+  val newPrices: Map[(HomeDelivery2025DeliveryFrequency, BillingPeriod), BigDecimal] = Map(
+    // Everyday
+    (HomeDelivery2025Everyday, Monthly) -> BigDecimal(83.99),
+    (HomeDelivery2025Everyday, Quarterly) -> BigDecimal(251.97),
+    (HomeDelivery2025Everyday, SemiAnnual) -> BigDecimal(503.94),
+    (HomeDelivery2025Everyday, Annual) -> BigDecimal(1007.88),
+    // Sixday
+    (HomeDelivery2025Sixday, Monthly) -> BigDecimal(73.99),
+    (HomeDelivery2025Sixday, Quarterly) -> BigDecimal(221.97),
+    (HomeDelivery2025Sixday, SemiAnnual) -> BigDecimal(443.94),
+    (HomeDelivery2025Sixday, Annual) -> BigDecimal(887.88),
+    // Weekend
+    (HomeDelivery2025Weekend, Monthly) -> BigDecimal(34.99),
+    (HomeDelivery2025Weekend, Quarterly) -> BigDecimal(104.97),
+    (HomeDelivery2025Weekend, SemiAnnual) -> BigDecimal(209.94),
+    (HomeDelivery2025Weekend, Annual) -> BigDecimal(419.88),
+    // Saturday
+    (HomeDelivery2025Saturday, Monthly) -> BigDecimal(20.99),
+    (HomeDelivery2025Saturday, Quarterly) -> BigDecimal(62.97),
+    (HomeDelivery2025Saturday, SemiAnnual) -> BigDecimal(125.94),
+    (HomeDelivery2025Saturday, Annual) -> BigDecimal(251.88),
+  )
+
+  // ------------------------------------------------
+  // Helpers
+  // ------------------------------------------------
+
+  def getLabelFromMigrationExtraAttributes(item: CohortItem): Option[String] = {
+    for {
+      attributes <- item.migrationExtraAttributes
+    } yield {
+      val data: HomeDelivery2025ExtraAttributes =
+        upickle.default.read[HomeDelivery2025ExtraAttributes](attributes)
+      data.brandTitle
+    }
+  }
+
+  // (Comment Group: 571dac68)
+
+  def getNotificationData(
+      cohortSpec: CohortSpec,
+      item: CohortItem
+  ): ZIO[Zuora, Failure, HomeDelivery2025NotificationData] = {
+    MigrationType(cohortSpec) match {
+      case HomeDelivery2025 => {
+        (for {
+          brandTitle <- getLabelFromMigrationExtraAttributes(item)
+        } yield HomeDelivery2025NotificationData(
+          brandTitle
+        )) match {
+          case None =>
+            ZIO.fail(
+              DataExtractionFailure(
+                s"Could not build HomeDelivery2025NotificationData for item ${item.toString}"
+              )
+            )
+          case Some(d) => ZIO.succeed(d)
+        }
+      }
+      case _ => ZIO.succeed(HomeDelivery2025NotificationData(""))
+    }
+  }
+
+  def priceLookUp(
+      deliveryFrequency: HomeDelivery2025DeliveryFrequency,
+      billingPeriod: BillingPeriod
+  ): Option[BigDecimal] = {
+    newPrices.get((deliveryFrequency, billingPeriod))
+  }
+
+  def subscriptionToLastPriceMigrationDate(subscription: ZuoraSubscription): Option[LocalDate] = {
+    // This will be moved to Subscription Introspection
+    ???
+  }
+
+  // ------------------------------------------------
+  // Primary Functions:
+  //
+  // The primary functions are the main functions that
+  // are implemented by the *Migration module.
+  //
+  // - priceData is used in the Estimation handler
+  // - amendmentOrderPayload is used in the Amendment handler
+  // ------------------------------------------------
+
+  def priceData(
+      subscription: ZuoraSubscription,
+      invoiceList: ZuoraInvoiceList,
+      account: ZuoraAccount
+  ): Either[DataExtractionFailure, PriceData] = {
+    ???
+  }
+
+  def amendmentOrderPayload(
+      orderDate: LocalDate,
+      accountNumber: String,
+      subscriptionNumber: String,
+      effectDate: LocalDate,
+      subscription: ZuoraSubscription,
+      oldPrice: BigDecimal,
+      estimatedNewPrice: BigDecimal,
+      priceCap: BigDecimal,
+      invoiceList: ZuoraInvoiceList,
+  ): Either[Failure, Value] = {
+    ???
+  }
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -2,6 +2,7 @@ package pricemigrationengine.model
 
 import pricemigrationengine.migrations.{
   GuardianWeekly2025Migration,
+  HomeDelivery2025Migration,
   Newspaper2025P1Migration,
   SupporterPlus2024Migration
 }
@@ -133,6 +134,7 @@ object AmendmentData {
       case SupporterPlus2024  => SupporterPlus2024Migration.priceData(subscription)
       case GuardianWeekly2025 => GuardianWeekly2025Migration.priceData(subscription, invoiceList, account)
       case Newspaper2025P1    => Newspaper2025P1Migration.priceData(subscription, invoiceList, account)
+      case HomeDelivery2025   => HomeDelivery2025Migration.priceData(subscription, invoiceList, account)
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
@@ -5,6 +5,7 @@ object Test1 extends MigrationType // This is the Migration Type to use in tests
 object SupporterPlus2024 extends MigrationType
 object GuardianWeekly2025 extends MigrationType
 object Newspaper2025P1 extends MigrationType
+object HomeDelivery2025 extends MigrationType
 
 object MigrationType {
   def apply(cohortSpec: CohortSpec): MigrationType = cohortSpec.cohortName match {
@@ -12,5 +13,6 @@ object MigrationType {
     case "SupporterPlus2024"  => SupporterPlus2024
     case "GuardianWeekly2025" => GuardianWeekly2025
     case "Newspaper2025P1"    => Newspaper2025P1
+    case "HomeDelivery2025"   => HomeDelivery2025
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/membershipworkflow/EmailMessage.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/membershipworkflow/EmailMessage.scala
@@ -31,6 +31,10 @@ case class EmailPayloadSubscriberAttributes(
     // Newspaper2025P1 (extension)
     // (Comment Group: 571dac68)
     newspaper2025_brand_title: Option[String] = None,
+
+    // -----------------------------------------------
+    // HomeDelivery2025 (extension)
+    homedelivery2025_brand_title: Option[String] = None,
 )
 
 /*


### PR DESCRIPTION
Introduce HomeDelivery2025 and its price grid.

This is a prelude to the main PR, here we introduce the new migrationType and the price grid.

![Screenshot 2025-07-07 at 15 52 19](https://github.com/user-attachments/assets/fdec9e66-c5b2-4358-84e8-315a94ace45c)
