### PR TITLE
HomeDelivery2025: helper functions and tests

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
@@ -101,8 +101,8 @@ object HomeDelivery2025Migration {
   def decideShouldRemoveDiscount(item: CohortItem): Boolean = {
     val flag_opt = (for {
       attributes <- item.migrationExtraAttributes
-      data: Newspaper2025ExtraAttributes =
-        upickle.default.read[Newspaper2025ExtraAttributes](attributes)
+      data: HomeDelivery2025ExtraAttributes =
+        upickle.default.read[HomeDelivery2025ExtraAttributes](attributes)
       removeDiscount <- data.removeDiscount
     } yield removeDiscount)
     flag_opt.getOrElse(false)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
@@ -9,13 +9,13 @@ import ujson._
 import upickle.default._
 import zio.ZIO
 
-sealed trait HomeDelivery2025DeliveryFrequency
-object HomeDelivery2025Everyday extends HomeDelivery2025DeliveryFrequency
-object HomeDelivery2025Sixday extends HomeDelivery2025DeliveryFrequency
-object HomeDelivery2025Weekend extends HomeDelivery2025DeliveryFrequency
-object HomeDelivery2025Saturday extends HomeDelivery2025DeliveryFrequency
+sealed trait HomeDelivery2025DeliveryPattern
+object HomeDelivery2025Everyday extends HomeDelivery2025DeliveryPattern
+object HomeDelivery2025Sixday extends HomeDelivery2025DeliveryPattern
+object HomeDelivery2025Weekend extends HomeDelivery2025DeliveryPattern
+object HomeDelivery2025Saturday extends HomeDelivery2025DeliveryPattern
 
-case class HomeDelivery2025ExtraAttributes(brandTitle: String)
+case class HomeDelivery2025ExtraAttributes(brandTitle: String, removeDiscount: Option[Boolean] = None)
 object HomeDelivery2025ExtraAttributes {
   implicit val reader: Reader[HomeDelivery2025ExtraAttributes] = macroR
 
@@ -27,6 +27,7 @@ object HomeDelivery2025ExtraAttributes {
   // usage
   // val s = """{ "brandTitle": "the Guardian" }"""
   // val s = """{ "brandTitle": "the Guardian and the Observer" }"""
+  // val s = """{ "brandTitle": "the Guardian", "removeDiscount": true }"""
   // val attributes: HomeDelivery2025ExtraAttributes = upickle.default.read[HomeDelivery2025ExtraAttributes](s)
 }
 
@@ -60,7 +61,7 @@ object HomeDelivery2025Migration {
   // to prices not present in the price catalogue)
   // ------------------------------------------------
 
-  val newPrices: Map[(HomeDelivery2025DeliveryFrequency, BillingPeriod), BigDecimal] = Map(
+  val newPrices: Map[(HomeDelivery2025DeliveryPattern, BillingPeriod), BigDecimal] = Map(
     // Everyday
     (HomeDelivery2025Everyday, Monthly) -> BigDecimal(83.99),
     (HomeDelivery2025Everyday, Quarterly) -> BigDecimal(251.97),
@@ -97,6 +98,16 @@ object HomeDelivery2025Migration {
     }
   }
 
+  def decideShouldRemoveDiscount(item: CohortItem): Boolean = {
+    val flag_opt = (for {
+      attributes <- item.migrationExtraAttributes
+      data: Newspaper2025ExtraAttributes =
+        upickle.default.read[Newspaper2025ExtraAttributes](attributes)
+      removeDiscount <- data.removeDiscount
+    } yield removeDiscount)
+    flag_opt.getOrElse(false)
+  }
+
   // (Comment Group: 571dac68)
 
   def getNotificationData(
@@ -124,15 +135,34 @@ object HomeDelivery2025Migration {
   }
 
   def priceLookUp(
-      deliveryFrequency: HomeDelivery2025DeliveryFrequency,
+      deliveryFrequency: HomeDelivery2025DeliveryPattern,
       billingPeriod: BillingPeriod
   ): Option[BigDecimal] = {
     newPrices.get((deliveryFrequency, billingPeriod))
   }
 
   def subscriptionToLastPriceMigrationDate(subscription: ZuoraSubscription): Option[LocalDate] = {
-    // This will be moved to Subscription Introspection
-    ???
+    for {
+      ratePlan <- SI2025RateplanFromSub.determineRatePlan(subscription)
+      date <- SI2025Extractions.determineLastPriceMigrationDate(ratePlan)
+    } yield date
+  }
+
+  def decideDeliveryPattern(ratePlan: ZuoraRatePlan): Option[HomeDelivery2025DeliveryPattern] = {
+    // I have checked every subscription and the only product names that come up are
+    // Newspaper Voucher
+    // Newspaper Digital Voucher
+    // Newspaper Delivery
+    // And I checked with Marketing that the below mapping is correct and in particular there doesn't
+    // seem to be any subscription that uses the [2025 - Price Grid - Sub Card] part of the pricing grid,
+    // what would map to Newspaper2025P1Subcard
+    ratePlan.ratePlanName match {
+      case "Everyday" => Some(HomeDelivery2025Everyday)
+      case "Weekend"  => Some(HomeDelivery2025Weekend)
+      case "Sixday"   => Some(HomeDelivery2025Sixday)
+      case "Saturday" => Some(HomeDelivery2025Saturday)
+      case _          => None
+    }
   }
 
   // ------------------------------------------------

--- a/lambda/src/test/scala/pricemigrationengine/migrations/HomeDelivery2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/HomeDelivery2025MigrationTest.scala
@@ -1,0 +1,215 @@
+package pricemigrationengine.migrations
+
+import pricemigrationengine.model.CohortTableFilter.ReadyForEstimation
+import pricemigrationengine.model._
+import pricemigrationengine.Fixtures
+import pricemigrationengine.libs.SI2025RateplanFromSubAndInvoices
+
+import java.time.LocalDate
+
+class HomeDelivery2025MigrationTest extends munit.FunSuite {
+
+  test("decoding") {
+    val s = """{ "brandTitle": "Label 01" }"""
+    val attribute: Newspaper2025ExtraAttributes = upickle.default.read[Newspaper2025ExtraAttributes](s)
+    assertEquals(attribute, Newspaper2025ExtraAttributes("Label 01"))
+  }
+
+  test("getLabelFromMigrationExtraAttributes (1)") {
+    val cohortItem = CohortItem(
+      subscriptionName = "A-000001",
+      processingStage = ReadyForEstimation,
+      migrationExtraAttributes = Some("""{ "brandTitle": "Label 01" }"""),
+    )
+    val label = HomeDelivery2025Migration.getLabelFromMigrationExtraAttributes(cohortItem)
+    assertEquals(label, Some("Label 01"))
+  }
+
+  test("getLabelFromMigrationExtraAttributes (2)") {
+    val cohortItem = CohortItem(
+      subscriptionName = "A-000001",
+      processingStage = ReadyForEstimation,
+      migrationExtraAttributes = Some("""{ "brandTitle": "Label 01", "removeDiscount": true }"""),
+    )
+    val label = HomeDelivery2025Migration.getLabelFromMigrationExtraAttributes(cohortItem)
+    assertEquals(label, Some("Label 01"))
+  }
+
+  test("decideShouldRemoveDiscount (1)") {
+    val cohortItem = CohortItem(
+      subscriptionName = "A-000001",
+      processingStage = ReadyForEstimation,
+      migrationExtraAttributes = Some("""{ "brandTitle": "Label 01" }"""),
+    )
+    val label = HomeDelivery2025Migration.decideShouldRemoveDiscount(cohortItem)
+    assertEquals(label, false)
+  }
+
+  test("decideShouldRemoveDiscount (2)") {
+    val cohortItem = CohortItem(
+      subscriptionName = "A-000001",
+      processingStage = ReadyForEstimation,
+      migrationExtraAttributes = Some("""{ "brandTitle": "the Guardian", "removeDiscount": true }"""),
+    )
+    val label = HomeDelivery2025Migration.decideShouldRemoveDiscount(cohortItem)
+    assertEquals(label, true)
+  }
+
+  test("decideShouldRemoveDiscount (3)") {
+    val cohortItem = CohortItem(
+      subscriptionName = "A-000001",
+      processingStage = ReadyForEstimation,
+      migrationExtraAttributes = Some("""{ "brandTitle": "the Guardian", "removeDiscount": false }"""),
+    )
+    val label = HomeDelivery2025Migration.decideShouldRemoveDiscount(cohortItem)
+    assertEquals(label, false)
+  }
+
+  test("priceLookUp") {
+    assertEquals(
+      HomeDelivery2025Migration.priceLookUp(HomeDelivery2025Everyday, Monthly),
+      Some(BigDecimal(83.99))
+    )
+
+    assertEquals(
+      HomeDelivery2025Migration.priceLookUp(HomeDelivery2025Sixday, SemiAnnual),
+      Some(BigDecimal(443.94))
+    )
+
+    assertEquals(
+      HomeDelivery2025Migration.priceLookUp(HomeDelivery2025Weekend, Quarterly),
+      Some(BigDecimal(104.97))
+    )
+
+    assertEquals(
+      HomeDelivery2025Migration.priceLookUp(HomeDelivery2025Saturday, Monthly),
+      Some(BigDecimal(20.99))
+    )
+
+    // And we test an undefined combination
+    assertEquals(
+      HomeDelivery2025Migration.priceLookUp(HomeDelivery2025Saturday, SemiAnnual),
+      Some(BigDecimal(125.94))
+    )
+  }
+
+  // ---------------------------------------------------
+  // A-S00252266
+  // Newspaper - Home Delivery
+  // Sixday
+  // Month
+  // val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/A-S00252266/subscription.json")
+  // val account = Fixtures.accountFromJson("Migrations/HomeDelivery2025/A-S00252266/account.json")
+  // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/A-S00252266/invoice-preview.json")
+
+  // ---------------------------------------------------
+  // A-S00256852
+  // Newspaper - Home Delivery
+  // Weekend
+  // Month
+  // val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/A-S00256852/subscription.json")
+  // val account = Fixtures.accountFromJson("Migrations/HomeDelivery2025/A-S00256852/account.json")
+  // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/A-S00256852/invoice-preview.json")
+
+  // ---------------------------------------------------
+  // GA0000464
+  // Newspaper - Home Delivery
+  // Saturday
+  // Quarter
+  // val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/GA0000464/subscription.json")
+  // val account = Fixtures.accountFromJson("Migrations/HomeDelivery2025/GA0000464/account.json")
+  // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/GA0000464/invoice-preview.json")
+
+  // ---------------------------------------------------
+  // GA0004508
+  // Newspaper - Home Delivery
+  // Weekend
+  // Quarter
+  // val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/GA0004508/subscription.json")
+  // val account = Fixtures.accountFromJson("Migrations/HomeDelivery2025/GA0004508/account.json")
+  // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/GA0004508/invoice-preview.json")
+
+  // ---------------------------------------------------
+  // GA0006731
+  // Newspaper - Home Delivery
+  // Saturday
+  // Month
+  // val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/GA0006731/subscription.json")
+  // val account = Fixtures.accountFromJson("Migrations/HomeDelivery2025/GA0006731/account.json")
+  // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/GA0006731/invoice-preview.json")
+
+  test("decideDeliveryPattern (A-S00252266)") {
+    // A-S00252266
+    // Newspaper - Home Delivery
+    // Sixday
+    // Month
+    val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/A-S00252266/subscription.json")
+    val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/A-S00252266/invoice-preview.json")
+
+    val ratePlan = SI2025RateplanFromSubAndInvoices.determineRatePlan(subscription, invoicePreview).get
+    assertEquals(
+      HomeDelivery2025Migration.decideDeliveryPattern(ratePlan),
+      Some(HomeDelivery2025Sixday)
+    )
+  }
+
+  test("decideDeliveryPattern (A-S00256852)") {
+    // A-S00256852
+    // Newspaper - Home Delivery
+    // Weekend
+    // Month
+    val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/A-S00256852/subscription.json")
+    val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/A-S00256852/invoice-preview.json")
+
+    val ratePlan = SI2025RateplanFromSubAndInvoices.determineRatePlan(subscription, invoicePreview).get
+    assertEquals(
+      HomeDelivery2025Migration.decideDeliveryPattern(ratePlan),
+      Some(HomeDelivery2025Weekend)
+    )
+  }
+
+  test("decideDeliveryPattern (GA0000464)") {
+    // GA0000464
+    // Newspaper - Home Delivery
+    // Saturday
+    // Quarter
+    val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/GA0000464/subscription.json")
+    val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/GA0000464/invoice-preview.json")
+
+    val ratePlan = SI2025RateplanFromSubAndInvoices.determineRatePlan(subscription, invoicePreview).get
+    assertEquals(
+      HomeDelivery2025Migration.decideDeliveryPattern(ratePlan),
+      Some(HomeDelivery2025Saturday)
+    )
+  }
+
+  test("decideDeliveryPattern (GA0004508)") {
+    // GA0004508
+    // Newspaper - Home Delivery
+    // Weekend
+    // Quarter
+    val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/GA0004508/subscription.json")
+    val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/GA0004508/invoice-preview.json")
+
+    val ratePlan = SI2025RateplanFromSubAndInvoices.determineRatePlan(subscription, invoicePreview).get
+    assertEquals(
+      HomeDelivery2025Migration.decideDeliveryPattern(ratePlan),
+      Some(HomeDelivery2025Weekend)
+    )
+  }
+
+  test("decideDeliveryPattern (GA0006731)") {
+    // GA0006731
+    // Newspaper - Home Delivery
+    // Saturday
+    // Month
+    val subscription = Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/GA0006731/subscription.json")
+    val invoicePreview = Fixtures.invoiceListFromJson("Migrations/HomeDelivery2025/GA0006731/invoice-preview.json")
+
+    val ratePlan = SI2025RateplanFromSubAndInvoices.determineRatePlan(subscription, invoicePreview).get
+    assertEquals(
+      HomeDelivery2025Migration.decideDeliveryPattern(ratePlan),
+      Some(HomeDelivery2025Saturday)
+    )
+  }
+}


### PR DESCRIPTION
Here we :
- refactor the name of the subscription delivery pattern
- Add an migration extra attribute new parameters: `removeDiscount` (will update the cohort items in AWS using a Ruby script)
- Implement the corresponding test functions, including for the price look up