### PR TITLE
reduce estimation batch size

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -15,7 +15,7 @@ import java.time.LocalDate
   */
 object EstimationHandler extends CohortHandler {
 
-  private val batchSize = 150
+  private val batchSize = 100
 
   def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora, Failure, HandlerOutput] =
     for {


### PR DESCRIPTION
This reduces the batch size of the estimation handler from 150 to 100, because, at least for Newspaper2025, we are getting very close to and sometimes overrun the AWS lambda 15 mins run limit.  