### PR TITLE
decommission CohortSpec's importStartDate

### DIFF
--- a/docs/migration-implementation-manual.md
+++ b/docs/migration-implementation-manual.md
@@ -20,7 +20,6 @@ As part of setting up a migration you will want to run some of the lambdas on de
 {
     "cohortName":"GW2024",
     "brazeName":"SV_GW_PriceRise2024Email",
-    "importStartDate":"2024-02-01",
     "earliestPriceMigrationStartDate":"2024-05-20"
 }
 
@@ -28,7 +27,6 @@ As part of setting up a migration you will want to run some of the lambdas on de
     "cohortSpec": {
         "cohortName":"GW2024",
         "brazeName":"SV_GW_PriceRise2024Email",
-        "importStartDate":"2024-02-01",
         "earliestPriceMigrationStartDate":"2024-05-20"
     }
 }
@@ -38,7 +36,6 @@ The difference between the two is that the former is used to run specific lambda
 
 * **cohortName**: A unique name to identify the cohort. Must consist of alphanumeric, whitespace, '-' and '_' characters.
 * **brazeName**: The name that membership-workflow uses to refer to the Braze campaign or canvas for notifying subscribers. Must consist of alphanumeric, whitespace, '-' and '_' characters. This name is given to us by Marketing after they have set up the campaign or canvas in Braze.
-* **importStartDate**: Date on which to begin importing participating subscription numbers into the engine. Format is `yyyy-mm-dd`. This key is not of much importance nowadays, because we upload the subscriptions numbers only when the cohort has been determined and ready to be sent to the DynamoDB. It would be fine to decommission this key in the future.
 * **earliestPriceMigrationStartDate**: Earliest date on which a subscription can have its price increased. Increases will always begin on the first day of a billing period on or after this date. Format is `yyyy-mm-dd`.
 
 ## Subscription numbers upload to the DynamoDB tables

--- a/docs/start-date-computation.md
+++ b/docs/start-date-computation.md
@@ -16,7 +16,6 @@ First we need a cohort spec. Let's assume that the cohort spec is
 {
     "cohortName":"GW2024",
     "brazeName":"SV_GW_PriceRise2024",
-    "importStartDate":"2024-02-01",
     "earliestPriceMigrationStartDate":"2024-05-20" 
 }
 ```

--- a/docs/subscription-numbers-upload.md
+++ b/docs/subscription-numbers-upload.md
@@ -38,7 +38,6 @@ Do not forget to set the correct cohort specifications (see example below, but u
 {
     "cohortName":"migration-name",
     "brazeName":"any-name",
-    "importStartDate":"2024-02-01",
     "earliestPriceMigrationStartDate":"2024-05-20" 
 }
 ```

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -119,7 +119,6 @@ Individual lambdas like the `EstimationLambda` and the `AmendmentLambda` can be 
 {
   "cohortName": "EchoLegacyTesting",
   "brazeName": "cmp123",
-  "importStartDate": "2020-07-01",
   "earliestPriceMigrationStartDate": "2022-08-02"
 }
 ```

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
@@ -62,7 +62,6 @@ trait CohortHandler extends ZIOAppDefault with RequestStreamHandler {
     *     "cohortSpec":{
     *         "cohortName":"M2023",
     *         "brazeName":"SV_MB_M2023",
-    *         "importStartDate":"2023-01-01",
     *         "earliestPriceMigrationStartDate":"2023-01-02"
     *     }
     * }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
@@ -35,12 +35,7 @@ object SubscriptionIdUploadHandler extends CohortHandler {
       cohortSpec: CohortSpec
   ): ZIO[CohortTable with S3 with StageConfig with Logging, Failure, HandlerOutput] =
     (for {
-      today <- Clock.currentDateTime.map(_.toLocalDate)
-      _ <-
-        if (today.isBefore(cohortSpec.importStartDate))
-          Logging.info(s"No action. Import start date ${cohortSpec.importStartDate} is in the future.").unit
-        else
-          importCohortAndCleanUp(cohortSpec)
+      _ <- importCohortAndCleanUp(cohortSpec)
     } yield HandlerOutput(isComplete = true))
       .tapError(e => Logging.error(e.toString))
 

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -15,8 +15,6 @@ import java.util
   *   Name of the Braze campaign, or Braze canvas for this cohort.
   *   Mapping to environment-specific Braze campaign ID is provided by membership-workflow:
   *   See https://github.com/guardian/membership-workflow/blob/master/conf/PROD.public.conf#L39
-  * @param importStartDate
-  *   Date on which to start importing data from the source S3 bucket.
   * @param earliestPriceMigrationStartDate
   *   Earliest date on which any sub in the cohort can have price migrated. The actual date for any sub will depend on
   *   its billing dates.
@@ -26,7 +24,6 @@ import java.util
 case class CohortSpec(
     cohortName: String,
     brazeName: String,
-    importStartDate: LocalDate,
     earliestPriceMigrationStartDate: LocalDate,
     migrationCompleteDate: Option[LocalDate] = None
 ) {
@@ -39,26 +36,23 @@ object CohortSpec {
   implicit val rw: ReadWriter[CohortSpec] = macroRW
 
   def isActive(spec: CohortSpec)(date: LocalDate): Boolean =
-    !spec.importStartDate.isAfter(date) && spec.migrationCompleteDate.forall(_.isAfter(date))
+    spec.migrationCompleteDate.forall(_.isAfter(date))
 
   def isValid(spec: CohortSpec): Boolean = {
     def isValidStringValue(s: String) = s.trim == s && s.nonEmpty && s.matches("[A-Za-z0-9-_ ]+")
     isValidStringValue(spec.cohortName) &&
-    isValidStringValue(spec.brazeName) &&
-    spec.earliestPriceMigrationStartDate.isAfter(spec.importStartDate)
+    isValidStringValue(spec.brazeName)
   }
 
   def fromDynamoDbItem(values: util.Map[String, AttributeValue]): Either[CohortSpecFetchFailure, CohortSpec] =
     (for {
       cohortName <- getStringFromResults(values, "cohortName")
       brazeName <- getStringFromResults(values, "brazeName")
-      importStartDate <- getDateFromResults(values, "importStartDate")
       earliestPriceMigrationStartDate <- getDateFromResults(values, "earliestPriceMigrationStartDate")
       migrationCompleteDate <- getOptionalDateFromResults(values, "migrationCompleteDate")
     } yield CohortSpec(
       cohortName,
       brazeName,
-      importStartDate,
       earliestPriceMigrationStartDate,
       migrationCompleteDate
     )).left.map(e => CohortSpecFetchFailure(e))

--- a/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/CohortTableExportHandlerTest.scala
@@ -66,7 +66,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
 
   test("CohortTableExportHandler should write cohort items to s3 as CSV") {
     val cohortName = "expected cohort name"
-    val cohortSpec = new CohortSpec(cohortName, "", LocalDate.now(), LocalDate.now())
+    val cohortSpec = new CohortSpec(cohortName, "", LocalDate.now())
     val uploadedFiles = ArrayBuffer[(S3Location, String)]()
     val stubS3 = createStubS3(uploadedFiles)
 
@@ -116,7 +116,7 @@ class CohortTableExportHandlerTest extends munit.FunSuite {
   }
   test("CohortTableExportHandler should write cohort items with missing optional values to s3 as CSV") {
     val cohortName = "expected cohort name"
-    val cohortSpec = new CohortSpec(cohortName, "", LocalDate.now(), LocalDate.now())
+    val cohortSpec = new CohortSpec(cohortName, "", LocalDate.now())
     val uploadedFiles = ArrayBuffer[(S3Location, String)]()
     val stubS3 = createStubS3(uploadedFiles)
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -82,7 +82,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
     val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
 
     val cohortSpec: CohortSpec =
-      CohortSpec("cohortName", "brazeName", LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 1), None)
+      CohortSpec("cohortName", "brazeName", LocalDate.of(2022, 1, 1), None)
 
     val cohortItem = CohortItem(
       subscriptionName = subscriptionName,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -69,7 +69,6 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
             CohortSpec(
               cohortName = "cohortName",
               brazeName = "cmp123",
-              importStartDate = LocalDate.of(2020, 1, 1),
               earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1)
             )
           )

--- a/lambda/src/test/scala/pricemigrationengine/libs/StartDatesTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/StartDatesTest.scala
@@ -23,7 +23,6 @@ class StartDatesTest extends munit.FunSuite {
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
       brazeName = "BrazeName",
-      importStartDate = LocalDate.of(2025, 1, 1),
       earliestPriceMigrationStartDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 
@@ -118,7 +117,6 @@ class StartDatesTest extends munit.FunSuite {
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
       brazeName = "BrazeName",
-      importStartDate = LocalDate.of(2025, 1, 1),
       earliestPriceMigrationStartDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
@@ -683,7 +683,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
     val account = Fixtures.accountFromJson("Migrations/SupporterPlus2024/monthly/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("Migrations/SupporterPlus2024/monthly/catalogue.json")
 
-    val cohortSpec = CohortSpec("SupporterPlus2024", "", LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 9))
+    val cohortSpec = CohortSpec("SupporterPlus2024", "", LocalDate.of(2024, 9, 9))
 
     val startDateLowerBound = LocalDate.of(2024, 9, 9)
 
@@ -709,7 +709,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
     val account = Fixtures.accountFromJson("Migrations/SupporterPlus2024/annual/account.json")
     val catalogue = Fixtures.productCatalogueFromJson("Migrations/SupporterPlus2024/annual/catalogue.json")
 
-    val cohortSpec = CohortSpec("SupporterPlus2024", "", LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 9))
+    val cohortSpec = CohortSpec("SupporterPlus2024", "", LocalDate.of(2024, 9, 9))
 
     val startDateLowerBound = LocalDate.of(2024, 9, 9)
 

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -189,7 +189,6 @@ class AmendmentDataTest extends munit.FunSuite {
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
       brazeName = "BrazeName",
-      importStartDate = LocalDate.of(2025, 1, 1),
       earliestPriceMigrationStartDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -8,13 +8,11 @@ import scala.jdk.CollectionConverters._
 
 class CohortSpecTest extends munit.FunSuite {
 
-  private val importStartDate = LocalDate.of(2020, 5, 1)
   private val migrationCompleteDate = LocalDate.of(2020, 6, 18)
 
   private val cohortSpec = CohortSpec(
     cohortName = "Home Delivery 2018",
     brazeName = "cmp123",
-    importStartDate = LocalDate.of(2020, 1, 1),
     earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 2),
     migrationCompleteDate = None
   )
@@ -27,23 +25,10 @@ class CohortSpecTest extends munit.FunSuite {
       CohortSpec(
         cohortName = "name",
         brazeName = "cmp123",
-        importStartDate,
         earliestPriceMigrationStartDate = LocalDate.of(2021, 1, 1),
         migrationComplete
       )
     )(onDay)
-
-  test("isActive: should be false when given date is before import start date") {
-    assertFalse(isActive(importStartDate.minusDays(3)))
-  }
-
-  test("isActive: should be true when given date is import start date") {
-    assertTrue(isActive(importStartDate))
-  }
-
-  test("isActive: should be true when given date is between import start date and migration complete date") {
-    assertTrue(isActive(importStartDate.plusDays(3)))
-  }
 
   test("isActive: should be false when given date is on migration complete date") {
     assertFalse(isActive(migrationCompleteDate))
@@ -51,10 +36,6 @@ class CohortSpecTest extends munit.FunSuite {
 
   test("isActive: should be false when given date is after migration complete date") {
     assertFalse(isActive(migrationCompleteDate.plusDays(3)))
-  }
-
-  test("isActive: should be true when given date is after import start date and migration isn't complete") {
-    assertTrue(isActive(importStartDate.plusDays(3), migrationComplete = None))
   }
 
   test("tableName: should be transformed cohort name") {
@@ -68,7 +49,6 @@ class CohortSpecTest extends munit.FunSuite {
     val item = Map(
       "cohortName" -> AttributeValue.builder.s("Home Delivery 2018").build(),
       "brazeName" -> AttributeValue.builder.s("cmp123").build(),
-      "importStartDate" -> AttributeValue.builder.s("2020-01-01").build(),
       "earliestPriceMigrationStartDate" -> AttributeValue.builder.s("2020-01-02").build()
     ).asJava
     assertEquals(
@@ -87,9 +67,5 @@ class CohortSpecTest extends munit.FunSuite {
 
   test("isValid: should be false when the campaign name contains an illegal character") {
     assertFalse(isValid(cohortSpec.copy(brazeName = "vc:ppr321")))
-  }
-
-  test("isValid: should be false when the import date is not before the earliest migration start date") {
-    assertFalse(isValid(cohortSpec.copy(earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1))))
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -20,7 +20,6 @@ class CohortTableLiveTest extends munit.FunSuite {
   private val cohortSpec = CohortSpec(
     cohortName = "name",
     brazeName = "cmp123",
-    importStartDate = LocalDate.of(2020, 1, 1),
     earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 1)
   )
 


### PR DESCRIPTION
The `CohortSpec`'s `importStartDate` is a vestige of an old, pre modern era, mode of preparing migrations which has never actually been used, and I always set it to a random value anyway. Here we decommission it.