### PR TITLE
Implement Newspaper2025P1Migration.amendmentOrderPayload (v1)

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitives.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitives.scala
@@ -118,7 +118,10 @@ object ZuoraOrdersApiPrimitives {
     )
   }
 
-  def ratePlanChargesToChargeOverrides(ratePlanCharges: List[ZuoraRatePlanCharge], priceRatio: BigDecimal): Value = {
+  def ratePlanChargesToChargeOverrides(
+      ratePlanCharges: List[ZuoraRatePlanCharge],
+      priceRatio: BigDecimal
+  ): List[Value] = {
     // This functions is a more general case of the previous function (`chargeOverride`)
     // We originally introduced `chargeOverride` for price increases that have a single charge
     // in the rate plan that is being price increased, but cases such as Newspaper2025(P1) and
@@ -138,7 +141,7 @@ object ZuoraOrdersApiPrimitives {
     // price increase ratio (we express the percentage as a ratio, so for instance a 20% increase
     // will be a price ratio of 1.2).
 
-    val rpcs = ratePlanCharges.map { rpc =>
+    ratePlanCharges.map { rpc =>
       Obj(
         "productRatePlanChargeId" -> Str(rpc.productRatePlanChargeId),
         "pricing" -> Obj(
@@ -148,7 +151,6 @@ object ZuoraOrdersApiPrimitives {
         )
       )
     }
-    ujson.Arr(rpcs: _*) // this is the expression to transform a scala array into a json Value array
 
     // [1] The `get` method here *will* cause a runtime exception if it turns out that
     // the rate plan charge didn't have a price attached to it. This will cause the engine to

--- a/lambda/src/main/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitives.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitives.scala
@@ -1,5 +1,7 @@
 package pricemigrationengine.libs
 
+import pricemigrationengine.model.ZuoraRatePlanCharge
+
 import java.time.LocalDate
 import upickle.default._
 import ujson._
@@ -114,6 +116,43 @@ object ZuoraOrdersApiPrimitives {
         )
       )
     )
+  }
+
+  def ratePlanChargesToChargeOverrides(ratePlanCharges: List[ZuoraRatePlanCharge], priceRatio: BigDecimal): Value = {
+    // This functions is a more general case of the previous function (`chargeOverride`)
+    // We originally introduced `chargeOverride` for price increases that have a single charge
+    // in the rate plan that is being price increased, but cases such as Newspaper2025(P1) and
+    // HomeDelivery2025 have rate plans containing charges for each day of the week (or a subset
+    // of days of the week). In those cases we want to provide the set of ZuoraRatePlanCharge
+    // and get a corresponding set of charge overrides objects.
+
+    // An additional complexity is that in the simple case, we know the listing price
+    // which is the price we are moving to. In the case of a migration involving increases
+    // across different charges, we instead are going to provide the effective increase ratio.
+    // For instance if the old price of the entire subscription was £50 and the new price (the price
+    // carried by the cohort item, in other words the price we communicated to the user) is
+    // £60, which corresponds to a 20% increase, and assuming that the individual charges before
+    // price increase are £10, £20, £7 and £13 (note that the sum of values is 50), then the new
+    // post price increase charges should be 10 + 20%, 20 + 20%, 7 +20% and 13 + 20%.
+    // Consequently the signature of this functions include a parameter for the effective
+    // price increase ratio (we express the percentage as a ratio, so for instance a 20% increase
+    // will be a price ratio of 1.2).
+
+    val rpcs = ratePlanCharges.map { rpc =>
+      Obj(
+        "productRatePlanChargeId" -> Str(rpc.productRatePlanChargeId),
+        "pricing" -> Obj(
+          "recurringFlatFee" -> Obj(
+            "listPrice" -> Num((rpc.price.get * priceRatio).doubleValue) // [1]
+          )
+        )
+      )
+    }
+    ujson.Arr(rpcs: _*) // this is the expression to transform a scala array into a json Value array
+
+    // [1] The `get` method here *will* cause a runtime exception if it turns out that
+    // the rate plan charge didn't have a price attached to it. This will cause the engine to
+    // crashland in flames and alarm, but this is what we want.
   }
 
   def addProduct(triggerDateString: String, productRatePlanId: String, chargeOverrides: List[Value]): Value = {

--- a/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
@@ -320,7 +320,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
     )
   }
 
-  test("ratePlanChargesToChargeOverrides") {
+  test("ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides") {
 
     // The following rate plan was taken from the Newspaper2025P1 test suite.
     // We stole it from there to test ratePlanChargesToChargeOverrides
@@ -549,6 +549,5 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |    }
         |]""".stripMargin
     )
-
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
@@ -1,6 +1,9 @@
 package pricemigrationengine.libs
 
+import pricemigrationengine.model.{ZuoraRatePlan, ZuoraRatePlanCharge}
 import ujson.Value
+
+import java.time.LocalDate
 
 class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
 
@@ -315,5 +318,237 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |    }
         |}""".stripMargin
     )
+  }
+
+  test("ratePlanChargesToChargeOverrides") {
+
+    // The following rate plan was taken from the Newspaper2025P1 test suite.
+    // We stole it from there to test ratePlanChargesToChargeOverrides
+    val ratePlan = ZuoraRatePlan(
+      id = "8a12910195aa4f620195b0e2bc0c139d",
+      productName = "Newspaper Voucher",
+      productRatePlanId = "2c92a0fc56fe26ba0157040c5ea17f6a",
+      ratePlanName = "Sixday+",
+      ratePlanCharges = List(
+        ZuoraRatePlanCharge(
+          productRatePlanChargeId = "2c92a0ff56fe33f5015709cdedbd246b",
+          name = "Tuesday",
+          number = "C-05403277",
+          currency = "GBP",
+          price = Some(BigDecimal(8.96)),
+          billingPeriod = Some("Month"),
+          chargedThroughDate = Some(LocalDate.of(2025, 7, 8)),
+          processedThroughDate = Some(LocalDate.of(2025, 6, 8)),
+          specificBillingPeriod = None,
+          endDateCondition = Some("Subscription_End"),
+          upToPeriodsType = None,
+          upToPeriods = None,
+          billingDay = Some("ChargeTriggerDay"),
+          triggerEvent = Some("CustomerAcceptance"),
+          triggerDate = None,
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2024, 3, 29)),
+          effectiveStartDate = Some(LocalDate.of(2024, 5, 8)),
+          effectiveEndDate = Some(LocalDate.of(2025, 9, 8))
+        ),
+        ZuoraRatePlanCharge(
+          productRatePlanChargeId = "2c92a0ff56fe33f3015709d10a436f52",
+          name = "Digipack",
+          number = "C-05403276",
+          currency = "GBP",
+          price = Some(BigDecimal(2.0)),
+          billingPeriod = Some("Month"),
+          chargedThroughDate = Some(LocalDate.of(2025, 7, 8)),
+          processedThroughDate = Some(LocalDate.of(2025, 6, 8)),
+          specificBillingPeriod = None,
+          endDateCondition = Some("Subscription_End"),
+          upToPeriodsType = None,
+          upToPeriods = None,
+          billingDay = Some("ChargeTriggerDay"),
+          triggerEvent = Some("CustomerAcceptance"),
+          triggerDate = None,
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2024, 3, 29)),
+          effectiveStartDate = Some(LocalDate.of(2024, 5, 8)),
+          effectiveEndDate = Some(LocalDate.of(2025, 9, 8))
+        ),
+        ZuoraRatePlanCharge(
+          productRatePlanChargeId = "2c92a0fe56fe33ff015704325d87494c",
+          name = "Monday",
+          number = "C-05403275",
+          currency = "GBP",
+          price = Some(BigDecimal(8.96)),
+          billingPeriod = Some("Month"),
+          chargedThroughDate = Some(LocalDate.of(2025, 7, 8)),
+          processedThroughDate = Some(LocalDate.of(2025, 6, 8)),
+          specificBillingPeriod = None,
+          endDateCondition = Some("Subscription_End"),
+          upToPeriodsType = None,
+          upToPeriods = None,
+          billingDay = Some("ChargeTriggerDay"),
+          triggerEvent = Some("CustomerAcceptance"),
+          triggerDate = None,
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2024, 3, 29)),
+          effectiveStartDate = Some(LocalDate.of(2024, 5, 8)),
+          effectiveEndDate = Some(LocalDate.of(2025, 9, 8))
+        ),
+        ZuoraRatePlanCharge(
+          productRatePlanChargeId = "2c92a0fd56fe26b6015709d078df4a80",
+          name = "Saturday",
+          number = "C-05403274",
+          currency = "GBP",
+          price = Some(BigDecimal(12.19)),
+          billingPeriod = Some("Month"),
+          chargedThroughDate = Some(LocalDate.of(2025, 7, 8)),
+          processedThroughDate = Some(LocalDate.of(2025, 6, 8)),
+          specificBillingPeriod = None,
+          endDateCondition = Some("Subscription_End"),
+          upToPeriodsType = None,
+          upToPeriods = None,
+          billingDay = Some("ChargeTriggerDay"),
+          triggerEvent = Some("CustomerAcceptance"),
+          triggerDate = None,
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2024, 3, 29)),
+          effectiveStartDate = Some(LocalDate.of(2024, 5, 8)),
+          effectiveEndDate = Some(LocalDate.of(2025, 9, 8))
+        ),
+        ZuoraRatePlanCharge(
+          productRatePlanChargeId = "2c92a0fd56fe26b6015709cfc1500a2e",
+          name = "Friday",
+          number = "C-05403273",
+          currency = "GBP",
+          price = Some(BigDecimal(8.96)),
+          billingPeriod = Some("Month"),
+          chargedThroughDate = Some(LocalDate.of(2025, 7, 8)),
+          processedThroughDate = Some(LocalDate.of(2025, 6, 8)),
+          specificBillingPeriod = None,
+          endDateCondition = Some("Subscription_End"),
+          upToPeriodsType = None,
+          upToPeriods = None,
+          billingDay = Some("ChargeTriggerDay"),
+          triggerEvent = Some("CustomerAcceptance"),
+          triggerDate = None,
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2024, 3, 29)),
+          effectiveStartDate = Some(LocalDate.of(2024, 5, 8)),
+          effectiveEndDate = Some(LocalDate.of(2025, 9, 8))
+        ),
+        ZuoraRatePlanCharge(
+          productRatePlanChargeId = "2c92a0fd56fe26b6015709ced61a032e",
+          name = "Wednesday",
+          number = "C-05403272",
+          currency = "GBP",
+          price = Some(BigDecimal(8.96)),
+          billingPeriod = Some("Month"),
+          chargedThroughDate = Some(LocalDate.of(2025, 7, 8)),
+          processedThroughDate = Some(LocalDate.of(2025, 6, 8)),
+          specificBillingPeriod = None,
+          endDateCondition = Some("Subscription_End"),
+          upToPeriodsType = None,
+          upToPeriods = None,
+          billingDay = Some("ChargeTriggerDay"),
+          triggerEvent = Some("CustomerAcceptance"),
+          triggerDate = None,
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2024, 3, 29)),
+          effectiveStartDate = Some(LocalDate.of(2024, 5, 8)),
+          effectiveEndDate = Some(LocalDate.of(2025, 9, 8))
+        ),
+        ZuoraRatePlanCharge(
+          productRatePlanChargeId = "2c92a0fc56fe26ba015709cf4bbd3d1c",
+          name = "Thursday",
+          number = "C-05403271",
+          currency = "GBP",
+          price = Some(BigDecimal(8.96)),
+          billingPeriod = Some("Month"),
+          chargedThroughDate = Some(LocalDate.of(2025, 7, 8)),
+          processedThroughDate = Some(LocalDate.of(2025, 6, 8)),
+          specificBillingPeriod = None,
+          endDateCondition = Some("Subscription_End"),
+          upToPeriodsType = None,
+          upToPeriods = None,
+          billingDay = Some("ChargeTriggerDay"),
+          triggerEvent = Some("CustomerAcceptance"),
+          triggerDate = None,
+          discountPercentage = None,
+          originalOrderDate = Some(LocalDate.of(2024, 3, 29)),
+          effectiveStartDate = Some(LocalDate.of(2024, 5, 8)),
+          effectiveEndDate = Some(LocalDate.of(2025, 9, 8))
+        )
+      ),
+      lastChangeType = Some("Add")
+    )
+
+    val json = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
+      ratePlan.ratePlanCharges,
+      BigDecimal(1.5)
+    )
+
+    val jsonstrpp = ujson.write(json, indent = 4)
+
+    assertEquals(
+      jsonstrpp,
+      """[
+        |    {
+        |        "productRatePlanChargeId": "2c92a0ff56fe33f5015709cdedbd246b",
+        |        "pricing": {
+        |            "recurringFlatFee": {
+        |                "listPrice": 13.44
+        |            }
+        |        }
+        |    },
+        |    {
+        |        "productRatePlanChargeId": "2c92a0ff56fe33f3015709d10a436f52",
+        |        "pricing": {
+        |            "recurringFlatFee": {
+        |                "listPrice": 3
+        |            }
+        |        }
+        |    },
+        |    {
+        |        "productRatePlanChargeId": "2c92a0fe56fe33ff015704325d87494c",
+        |        "pricing": {
+        |            "recurringFlatFee": {
+        |                "listPrice": 13.44
+        |            }
+        |        }
+        |    },
+        |    {
+        |        "productRatePlanChargeId": "2c92a0fd56fe26b6015709d078df4a80",
+        |        "pricing": {
+        |            "recurringFlatFee": {
+        |                "listPrice": 18.285
+        |            }
+        |        }
+        |    },
+        |    {
+        |        "productRatePlanChargeId": "2c92a0fd56fe26b6015709cfc1500a2e",
+        |        "pricing": {
+        |            "recurringFlatFee": {
+        |                "listPrice": 13.44
+        |            }
+        |        }
+        |    },
+        |    {
+        |        "productRatePlanChargeId": "2c92a0fd56fe26b6015709ced61a032e",
+        |        "pricing": {
+        |            "recurringFlatFee": {
+        |                "listPrice": 13.44
+        |            }
+        |        }
+        |    },
+        |    {
+        |        "productRatePlanChargeId": "2c92a0fc56fe26ba015709cf4bbd3d1c",
+        |        "pricing": {
+        |            "recurringFlatFee": {
+        |                "listPrice": 13.44
+        |            }
+        |        }
+        |    }
+        |]""".stripMargin
+    )
+
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
 
-  test("singletonDate") {
+  test("ZuoraOrdersApiPrimitives.singletonDate") {
     val singletonDate = ZuoraOrdersApiPrimitives.singletonDate("ContractEffective", "2024-11-28")
     val jsonstr = singletonDate.render()
     assertEquals(jsonstr, """{"name":"ContractEffective","triggerDate":"2024-11-28"}""")
@@ -23,7 +23,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
     )
   }
 
-  test("triggerDates") {
+  test("ZuoraOrdersApiPrimitives.triggerDates") {
     val triggerDates = ZuoraOrdersApiPrimitives.triggerDates("2024-11-28")
     val jsonstrpp = ujson.write(triggerDates, indent = 4)
     assertEquals(
@@ -45,7 +45,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
     )
   }
 
-  test("removeProduct") {
+  test("ZuoraOrdersApiPrimitives.removeProduct") {
     val removeProduct = ZuoraOrdersApiPrimitives.removeProduct("2024-11-28", "8a12867e92c341870192c7c46bdb47d6")
     val jsonstrpp = ujson.write(removeProduct, indent = 4)
     assertEquals(
@@ -73,7 +73,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
     )
   }
 
-  test("chargeOverride") {
+  test("ZuoraOrdersApiPrimitives.chargeOverride") {
     val chargeOverride = ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12)
     val jsonstrpp = ujson.write(chargeOverride, indent = 4)
     assertEquals(
@@ -89,7 +89,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
     )
   }
 
-  test("addProduct") {
+  test("ZuoraOrdersApiPrimitives.addProduct") {
     val chargeOverrides = List(
       ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12),
       ZuoraOrdersApiPrimitives.chargeOverride("8a128d7085fc6dec01860234cd075270", 0)
@@ -97,7 +97,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
     val addProduct = ZuoraOrdersApiPrimitives.addProduct(
       "2024-11-28",
       "8a128ed885fc6ded018602296ace3eb8",
-      chargeOverrides: List[Value]
+      chargeOverrides
     )
     val jsonstrpp = ujson.write(addProduct, indent = 4)
     assertEquals(
@@ -143,7 +143,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
     )
   }
 
-  test("subscription") {
+  test("ZuoraOrdersApiPrimitives.subscription") {
     val removeProduct = ZuoraOrdersApiPrimitives.removeProduct("2025-05-19", "8a12867e92c341870192c7c46bdb47d6")
     val addProduct = ZuoraOrdersApiPrimitives.addProduct(
       "2025-05-20",
@@ -223,7 +223,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
     )
   }
 
-  test("replace_a_product_in_a_subscription") {
+  test("ZuoraOrdersApiPrimitives.replace_a_product_in_a_subscription") {
     val removeProduct = ZuoraOrdersApiPrimitives.removeProduct("2025-05-19", "8a12867e92c341870192c7c46bdb47d6")
     val addProduct = ZuoraOrdersApiPrimitives.addProduct(
       "2025-05-20",

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
@@ -665,7 +665,55 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                "productRatePlanChargeId": "2c92a0ff56fe33f5015709cdedbd246b",
              |                                "pricing": {
              |                                    "recurringFlatFee": {
-             |                                        "listPrice": 81
+             |                                        "listPrice": 11.548444444444444
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0ff56fe33f3015709d10a436f52",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 2.577777777777778
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0fe56fe33ff015704325d87494c",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 11.548444444444444
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0fd56fe26b6015709d078df4a80",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 15.711555555555556
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0fd56fe26b6015709cfc1500a2e",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 11.548444444444444
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0fd56fe26b6015709ced61a032e",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 11.548444444444444
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0fc56fe26ba015709cf4bbd3d1c",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 11.548444444444444
              |                                    }
              |                                }
              |                            }

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
@@ -565,4 +565,124 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
     )
   }
 
+  test("Newspaper2025P1Migration.amendmentOrderPayload (276579)") {
+
+    // We start with the same subscription that we started priceData with. The one with the fully
+    // detailed ratePlan (that we also used for ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides)
+
+    // Subscription fixture: 276579
+    // 276579; Newspaper - Voucher Book; Sixday+; Month
+
+    val subscription = Fixtures.subscriptionFromJson("Migrations/Newspaper2025P1/276579/subscription.json")
+    val account = Fixtures.accountFromJson("Migrations/Newspaper2025P1/276579/account.json")
+    val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P1/276579/invoice-preview.json")
+
+    val startDate = LocalDate.of(2025, 8, 5)
+    val oldPrice = BigDecimal(67.5)
+    val estimatedNewPrice = BigDecimal(87.0)
+
+    val cohortItem = CohortItem(
+      subscriptionName = subscription.subscriptionNumber,
+      processingStage = CohortTableFilter.NotificationSendDateWrittenToSalesforce,
+      startDate = Some(startDate),
+      currency = Some("EUR"),
+      oldPrice = Some(oldPrice),
+      estimatedNewPrice = Some(estimatedNewPrice),
+      billingPeriod = Some("Quarter"),
+      migrationExtraAttributes = None
+    )
+
+    // We now collect the arguments of Newspaper2025P1Migration.amendmentOrderPayload
+
+    val orderDate = LocalDate.of(2025, 7, 16) // LocalDate.now()
+    val accountNumber = subscription.accountNumber
+    val subscriptionNumber = subscription.subscriptionNumber
+    val effectDate = startDate
+    val priceCap = 1.2
+
+    assertEquals(
+      Newspaper2025P1Migration.amendmentOrderPayload(
+        cohortItem,
+        orderDate,
+        accountNumber,
+        subscriptionNumber,
+        effectDate,
+        subscription,
+        oldPrice,
+        estimatedNewPrice,
+        priceCap,
+        invoicePreview
+      ),
+      Right(
+        ujson.read(
+          s"""{
+             |    "orderDate": "2025-07-16",
+             |    "existingAccountNumber": "ACCOUNT-NUMBER",
+             |    "subscriptions": [
+             |        {
+             |            "subscriptionNumber": "SUBSCRIPTION-NUMBER",
+             |            "orderActions": [
+             |                {
+             |                    "type": "RemoveProduct",
+             |                    "triggerDates": [
+             |                        {
+             |                            "name": "ContractEffective",
+             |                            "triggerDate": "2025-08-05"
+             |                        },
+             |                        {
+             |                            "name": "ServiceActivation",
+             |                            "triggerDate": "2025-08-05"
+             |                        },
+             |                        {
+             |                            "name": "CustomerAcceptance",
+             |                            "triggerDate": "2025-08-05"
+             |                        }
+             |                    ],
+             |                    "removeProduct": {
+             |                        "ratePlanId": "8a12910195aa4f620195b0e2bc0c139d"
+             |                    }
+             |                },
+             |                {
+             |                    "type": "AddProduct",
+             |                    "triggerDates": [
+             |                        {
+             |                            "name": "ContractEffective",
+             |                            "triggerDate": "2025-08-05"
+             |                        },
+             |                        {
+             |                            "name": "ServiceActivation",
+             |                            "triggerDate": "2025-08-05"
+             |                        },
+             |                        {
+             |                            "name": "CustomerAcceptance",
+             |                            "triggerDate": "2025-08-05"
+             |                        }
+             |                    ],
+             |                    "addProduct": {
+             |                        "productRatePlanId": "2c92a0fc56fe26ba0157040c5ea17f6a",
+             |                        "chargeOverrides": [
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0ff56fe33f5015709cdedbd246b",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 81
+             |                                    }
+             |                                }
+             |                            }
+             |                        ]
+             |                    }
+             |                }
+             |            ]
+             |        }
+             |    ],
+             |    "processingOptions": {
+             |        "runBilling": false,
+             |        "collectPayment": false
+             |    }
+             |}""".stripMargin
+        )
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
Here we implement the missing amendment payload of Newspaper2025P1. 

That functions was still missing because unlike SupporterPlus2024 and GuardianWeekly2025 which both construct an Orders API payload with one or two hardcoded charges, in the case of Newspaper2025, the rate plan has up to as many rate plan charges as days in the week. 

The first step is to implement a new functions in `ZuoraOrdersApiPrimitives` with signature 

```
(ratePlanCharges: List[ZuoraRatePlanCharge], priceRatio: BigDecimal): List[Value]
```

... which comes with a compregensive test, and then, to use it to implement `Newspaper2025P1Migration.amendmentOrderPayload`.

This is only the first implementation of `Newspaper2025P1Migration.amendmentOrderPayload`, in the next change we are going to upgrade it to support discount removal, and then we will port this over to HomeDelivery2025, after which we will unlock the two Amendment steps.