### PR TITLE
Newspaper Phase3: Implement main migration functions

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
@@ -316,7 +316,6 @@ object Newspaper2025P1Migration {
           )
         }
       }
-
     }
 
     order_opt match {

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -148,6 +148,16 @@ object Newspaper2025P3Migration {
     } yield date
   }
 
+  def decideDeliveryPattern(ratePlan: ZuoraRatePlan): Option[Newspaper2025P3DeliveryPattern] = {
+    ratePlan.ratePlanName.trim match {
+      case "Everyday" => Some(Newspaper2025P3Everyday)
+      case "Weekend"  => Some(Newspaper2025P3Weekend)
+      case "Sixday"   => Some(Newspaper2025P3Sixday)
+      case "Saturday" => Some(Newspaper2025P3Saturday)
+      case _          => None
+    }
+  }
+
   // ------------------------------------------------
   // Primary Functions:
   //
@@ -163,7 +173,23 @@ object Newspaper2025P3Migration {
       invoiceList: ZuoraInvoiceList,
       account: ZuoraAccount
   ): Either[DataExtractionFailure, PriceData] = {
-    ???
+    val priceDataOpt: Option[PriceData] = for {
+      ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(subscription, invoiceList)
+      currency <- SI2025Extractions.determineCurrency(ratePlan)
+      oldPrice = SI2025Extractions.determineOldPrice(ratePlan)
+      billingPeriod <- SI2025Extractions.determineBillingPeriod(ratePlan)
+      deliveryPattern <- decideDeliveryPattern(ratePlan)
+      newPrice <- priceLookUp(deliveryPattern, billingPeriod)
+    } yield PriceData(currency, oldPrice, newPrice, BillingPeriod.toString(billingPeriod))
+    priceDataOpt match {
+      case Some(pricedata) => Right(pricedata)
+      case None =>
+        Left(
+          DataExtractionFailure(
+            s"[a149987a] Could not determine PriceData for subscription ${subscription.subscriptionNumber}"
+          )
+        )
+    }
   }
 
   def amendmentOrderPayload(
@@ -178,6 +204,79 @@ object Newspaper2025P3Migration {
       priceCap: BigDecimal,
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {
-    ???
+
+    // This version of `amendmentOrderPayload`, applied to subscriptions with the active rate plan having
+    // several charges (one per delivery day), is using ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides
+    // which maps the rate plan's rate plan charges to an array of charge overrides json objects.
+
+    // The important preliminary here, which wasn't needed in the simpler case of a single rate plan charge
+    // in the case of GuardianWeekly2025, for instance, is the price ratio from the old price to the new price
+    // (both carried by the cohort item).
+
+    // Note that we do use `get` here. The cohort items always get them from the estimation step, but in the
+    // abnormal case it would not, we want the process to error and alarm.
+    val priceRatio = estimatedNewPrice / oldPrice
+
+    val order_opt = {
+      if (!decideShouldRemoveDiscount(cohortItem)) {
+        for {
+          ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
+        } yield {
+          val subscriptionRatePlanId = ratePlan.id
+          val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)
+          val triggerDateString = effectDate.toString
+          val productRatePlanId = ratePlan.productRatePlanId // We are upgrading on the same rate plan.
+          val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
+            ratePlan.ratePlanCharges,
+            priceRatio
+          )
+          val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
+          val order_subscription =
+            ZuoraOrdersApiPrimitives.subscription(subscriptionNumber, List(removeProduct), List(addProduct))
+          ZuoraOrdersApiPrimitives.replace_a_product_in_a_subscription(
+            orderDate.toString,
+            accountNumber,
+            order_subscription
+          )
+        }
+      } else {
+        for {
+          ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
+          discount <- SI2025Extractions.getDiscount(zuora_subscription, "Percentage")
+        } yield {
+          val subscriptionRatePlanId = ratePlan.id
+          val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)
+          val removeDiscount = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, discount.id)
+          val triggerDateString = effectDate.toString
+          val productRatePlanId = ratePlan.productRatePlanId // We are upgrading on the same rate plan.
+          val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
+            ratePlan.ratePlanCharges,
+            priceRatio
+          )
+          val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
+          val order_subscription =
+            ZuoraOrdersApiPrimitives.subscription(
+              subscriptionNumber,
+              List(removeProduct, removeDiscount),
+              List(addProduct)
+            )
+          ZuoraOrdersApiPrimitives.replace_a_product_in_a_subscription(
+            orderDate.toString,
+            accountNumber,
+            order_subscription
+          )
+        }
+      }
+    }
+
+    order_opt match {
+      case Some(order) => Right(order)
+      case None =>
+        Left(
+          DataExtractionFailure(
+            s"[9f480e70] Could not compute amendmentOrderPayload for subscription ${zuora_subscription.subscriptionNumber}"
+          )
+        )
+    }
   }
 }


### PR DESCRIPTION
Here we implement  `priceData` and `amendmentOrderPayload` for Newspaper2025 (Phase 3), using the patterns we developed for the last there migrations ( GuardianWeekly2025, Newspaper2025P1 and HomeDelivery2025).