### PR TITLE
Newspaper2025P3

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -29,23 +29,19 @@ object NotificationHandler extends CohortHandler {
   val Cancelled_Status = "Cancelled"
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    MigrationType(input) match {
-      case Newspaper2025P3 => ZIO.succeed(HandlerOutput(isComplete = true))
-      case _ =>
-        main(input).provideSome[Logging](
-          EnvConfig.salesforce.layer,
-          EnvConfig.cohortTable.layer,
-          EnvConfig.emailSender.layer,
-          EnvConfig.zuora.layer,
-          EnvConfig.stage.layer,
-          DynamoDBClientLive.impl,
-          DynamoDBZIOLive.impl,
-          CohortTableLive.impl(input),
-          SalesforceClientLive.impl,
-          EmailSenderLive.impl,
-          ZuoraLive.impl
-        )
-    }
+    main(input).provideSome[Logging](
+      EnvConfig.salesforce.layer,
+      EnvConfig.cohortTable.layer,
+      EnvConfig.emailSender.layer,
+      EnvConfig.zuora.layer,
+      EnvConfig.stage.layer,
+      DynamoDBClientLive.impl,
+      DynamoDBZIOLive.impl,
+      CohortTableLive.impl(input),
+      SalesforceClientLive.impl,
+      EmailSenderLive.impl,
+      ZuoraLive.impl
+    )
   }
 
   def main(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -29,19 +29,23 @@ object NotificationHandler extends CohortHandler {
   val Cancelled_Status = "Cancelled"
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    main(input).provideSome[Logging](
-      EnvConfig.salesforce.layer,
-      EnvConfig.cohortTable.layer,
-      EnvConfig.emailSender.layer,
-      EnvConfig.zuora.layer,
-      EnvConfig.stage.layer,
-      DynamoDBClientLive.impl,
-      DynamoDBZIOLive.impl,
-      CohortTableLive.impl(input),
-      SalesforceClientLive.impl,
-      EmailSenderLive.impl,
-      ZuoraLive.impl
-    )
+    MigrationType(input) match {
+      case Newspaper2025P3 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ =>
+        main(input).provideSome[Logging](
+          EnvConfig.salesforce.layer,
+          EnvConfig.cohortTable.layer,
+          EnvConfig.emailSender.layer,
+          EnvConfig.zuora.layer,
+          EnvConfig.stage.layer,
+          DynamoDBClientLive.impl,
+          DynamoDBZIOLive.impl,
+          CohortTableLive.impl(input),
+          SalesforceClientLive.impl,
+          EmailSenderLive.impl,
+          ZuoraLive.impl
+        )
+    }
   }
 
   def main(

--- a/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/StartDates.scala
@@ -137,7 +137,7 @@ object StartDates {
       case GuardianWeekly2025 => GuardianWeekly2025Migration.computeStartDateLowerBound4(startDateLowerBound3, item)
       case Newspaper2025P1    => startDateLowerBound3
       case HomeDelivery2025   => startDateLowerBound3
-      case Newspaper2025P3    => startDateLowerBound3
+      case Newspaper2025P3    => Newspaper2025P3Migration.computeStartDateLowerBound4(startDateLowerBound3, item)
     }
 
     // [1]

--- a/lambda/src/main/scala/pricemigrationengine/libs/SubscriptionIntrospection2025.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/SubscriptionIntrospection2025.scala
@@ -135,7 +135,7 @@ object SI2025Extractions {
     } yield date
   }
 
-  def getDiscount(subscription: ZuoraSubscription, ratePlanName: String): Option[ZuoraRatePlan] = {
+  def getDiscountByRatePlanName(subscription: ZuoraSubscription, ratePlanName: String): Option[ZuoraRatePlan] = {
     // The product name is always "Discount", but the ratePlanName is more freeform.
     // I have noticed
     // ratePlanName: "Percentage"
@@ -144,6 +144,7 @@ object SI2025Extractions {
     subscription.ratePlans
       .find(ratePlan => ratePlan.productName == "Discounts" && ratePlan.ratePlanName.contains(ratePlanName))
   }
+
 }
 
 object SI2025Templates {

--- a/lambda/src/main/scala/pricemigrationengine/libs/SubscriptionIntrospection2025.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/SubscriptionIntrospection2025.scala
@@ -145,6 +145,17 @@ object SI2025Extractions {
       .find(ratePlan => ratePlan.productName == "Discounts" && ratePlan.ratePlanName.contains(ratePlanName))
   }
 
+  def getPercentageOrAdjustementDiscount(subscription: ZuoraSubscription): Option[ZuoraRatePlan] = {
+    // This function will extract a "Percentage" or a "Adjustment" ratePlan, whichever is present
+
+    // Note that the choice of values "Percentage" and "Adjustment" comes from the metadata
+    // in Marketing spreadsheets and as we have highlighted in the body of function `getDiscountByRatePlanName`
+    // those are not even always equal to the rate plan names but may appear as substring.
+
+    var a = getDiscountByRatePlanName(subscription: ZuoraSubscription, "Percentage")
+    var b = getDiscountByRatePlanName(subscription: ZuoraSubscription, "Adjustment")
+    a.orElse(b)
+  }
 }
 
 object SI2025Templates {

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
@@ -243,7 +243,7 @@ object GuardianWeekly2025Migration {
       } else {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
-          discount <- SI2025Extractions.getDiscount(zuora_subscription, "Percentage")
+          discount <- SI2025Extractions.getDiscountByRatePlanName(zuora_subscription, "Percentage")
         } yield {
           val subscriptionRatePlanId = ratePlan.id
           val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
@@ -249,7 +249,7 @@ object HomeDelivery2025Migration {
       } else {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
-          discount <- SI2025Extractions.getDiscount(zuora_subscription, "Percentage")
+          discount <- SI2025Extractions.getDiscountByRatePlanName(zuora_subscription, "Percentage")
         } yield {
           val subscriptionRatePlanId = ratePlan.id
           val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
@@ -291,7 +291,7 @@ object Newspaper2025P1Migration {
       } else {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
-          discount <- SI2025Extractions.getDiscount(zuora_subscription, "Adjustment")
+          discount <- SI2025Extractions.getDiscountByRatePlanName(zuora_subscription, "Adjustment")
         } yield {
           val subscriptionRatePlanId = ratePlan.id
           val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -242,7 +242,7 @@ object Newspaper2025P3Migration {
       } else {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
-          discount <- SI2025Extractions.getDiscount(zuora_subscription, "Percentage")
+          discount <- SI2025Extractions.getDiscountByRatePlanName(zuora_subscription, "Percentage")
         } yield {
           val subscriptionRatePlanId = ratePlan.id
           val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -242,7 +242,7 @@ object Newspaper2025P3Migration {
       } else {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
-          discount <- SI2025Extractions.getDiscountByRatePlanName(zuora_subscription, "Percentage")
+          discount <- SI2025Extractions.getPercentageOrAdjustementDiscount(zuora_subscription)
         } yield {
           val subscriptionRatePlanId = ratePlan.id
           val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -15,7 +15,11 @@ object Newspaper2025P3Sixday extends Newspaper2025P3DeliveryPattern
 object Newspaper2025P3Weekend extends Newspaper2025P3DeliveryPattern
 object Newspaper2025P3Saturday extends Newspaper2025P3DeliveryPattern
 
-case class Newspaper2025P3ExtraAttributes(brandTitle: String, removeDiscount: Option[Boolean] = None)
+case class Newspaper2025P3ExtraAttributes(
+    brandTitle: String,
+    removeDiscount: Option[Boolean] = None,
+    earliestMigrationDate: Option[LocalDate] = None
+)
 object Newspaper2025P3ExtraAttributes {
   implicit val reader: Reader[Newspaper2025P3ExtraAttributes] = macroR
 
@@ -30,6 +34,7 @@ object Newspaper2025P3ExtraAttributes {
   // val s = """{ "brandTitle": "the Guardian" }"""
   // val s = """{ "brandTitle": "the Guardian and the Observer" }"""
   // val s = """{ "brandTitle": "the Guardian", "removeDiscount": true }"""
+  // val s = """{ "brandTitle": "the Guardian", "earliestMigrationDate": "2025-10-06" }"""
   // val attributes: Newspaper2025P3ExtraAttributes = upickle.default.read[Newspaper2025P3ExtraAttributes](s)
 }
 
@@ -88,7 +93,22 @@ object Newspaper2025P3Migration {
   // Helpers
   // ------------------------------------------------
 
-  // (Comment Group: 571dac68)
+  def getEarliestMigrationDateFromMigrationExtraAttributes(item: CohortItem): Option[LocalDate] = {
+    for {
+      attributes <- item.migrationExtraAttributes
+      data: Newspaper2025P3ExtraAttributes =
+        upickle.default.read[Newspaper2025P3ExtraAttributes](attributes)
+      date <- data.earliestMigrationDate
+    } yield date
+  }
+
+  def computeStartDateLowerBound4(lowerBound: LocalDate, item: CohortItem): LocalDate = {
+    val dateFromCohortItem = getEarliestMigrationDateFromMigrationExtraAttributes(item)
+    dateFromCohortItem match {
+      case Some(date) => Date.datesMax(lowerBound, date)
+      case None       => lowerBound
+    }
+  }
 
   def getLabelFromMigrationExtraAttributes(item: CohortItem): Option[String] = {
     for {

--- a/lambda/src/test/scala/pricemigrationengine/libs/SubscriptionIntrospection2025Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/SubscriptionIntrospection2025Test.scala
@@ -384,7 +384,7 @@ class SI2025ExtractionsTest extends munit.FunSuite {
     val subscription =
       Fixtures.subscriptionFromJson("libs/SubscriptionIntrospection2025/subscription3-with-discount/subscription.json")
     assertEquals(
-      SI2025Extractions.getDiscount(subscription, "Percentage"),
+      SI2025Extractions.getDiscountByRatePlanName(subscription, "Percentage"),
       Some(
         ZuoraRatePlan(
           id = "8a129ce595aa3a180195c130cca57d19",
@@ -426,7 +426,7 @@ class SI2025ExtractionsTest extends munit.FunSuite {
         "libs/SubscriptionIntrospection2025/subscription4-511760-Discount-Adjustment/subscription.json"
       )
     assertEquals(
-      SI2025Extractions.getDiscount(subscription, "Adjustment"),
+      SI2025Extractions.getDiscountByRatePlanName(subscription, "Adjustment"),
       Some(
         ZuoraRatePlan(
           id = "8a128efc91a138d30191bb00a80c281f",

--- a/lambda/src/test/scala/pricemigrationengine/libs/SubscriptionIntrospection2025Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/SubscriptionIntrospection2025Test.scala
@@ -380,7 +380,7 @@ class SI2025ExtractionsTest extends munit.FunSuite {
     )
   }
 
-  test("SI2025Extractions.determineLastPriceMigrationDate") {
+  test("SI2025Extractions.getDiscountByRatePlanName") {
     val subscription =
       Fixtures.subscriptionFromJson("libs/SubscriptionIntrospection2025/subscription3-with-discount/subscription.json")
     assertEquals(
@@ -420,13 +420,101 @@ class SI2025ExtractionsTest extends munit.FunSuite {
     )
   }
 
-  test("SI2025Extractions.determineLastPriceMigrationDate") {
+  test("SI2025Extractions.getDiscountByRatePlanName") {
     val subscription =
       Fixtures.subscriptionFromJson(
         "libs/SubscriptionIntrospection2025/subscription4-511760-Discount-Adjustment/subscription.json"
       )
     assertEquals(
       SI2025Extractions.getDiscountByRatePlanName(subscription, "Adjustment"),
+      Some(
+        ZuoraRatePlan(
+          id = "8a128efc91a138d30191bb00a80c281f",
+          productName = "Discounts",
+          productRatePlanId = "2c92a0ff5e09bd67015e0a93efe86d2e",
+          ratePlanName = "Customer Experience Adjustment - Voucher",
+          ratePlanCharges = List(
+            ZuoraRatePlanCharge(
+              productRatePlanChargeId = "2c92a0ff5e09bd67015e0a93f0026d34",
+              name = "Adjustment charge",
+              number = "C-01103430",
+              currency = "GBP",
+              price = Some(-4.15),
+              billingPeriod = Some("Month"),
+              chargedThroughDate = Some(LocalDate.of(2025, 8, 4)),
+              processedThroughDate = Some(LocalDate.of(2025, 7, 4)),
+              specificBillingPeriod = None,
+              endDateCondition = Some("Subscription_End"),
+              upToPeriodsType = None,
+              upToPeriods = None,
+              billingDay = Some("DefaultFromCustomer"),
+              triggerEvent = Some("CustomerAcceptance"),
+              triggerDate = None,
+              discountPercentage = None,
+              originalOrderDate = Some(LocalDate.of(2017, 8, 24)),
+              effectiveStartDate = Some(LocalDate.of(2017, 9, 4)),
+              effectiveEndDate = Some(LocalDate.of(2025, 9, 4))
+            )
+          ),
+          lastChangeType = Some("Add")
+        )
+      )
+    )
+  }
+
+  test("SI2025Extractions.getPercentageOrAdjustementDiscount") {
+    val subscription =
+      Fixtures.subscriptionFromJson("libs/SubscriptionIntrospection2025/subscription3-with-discount/subscription.json")
+
+    // The subscription has a "Percentage" discount, so that's what we expect
+
+    assertEquals(
+      SI2025Extractions.getPercentageOrAdjustementDiscount(subscription),
+      Some(
+        ZuoraRatePlan(
+          id = "8a129ce595aa3a180195c130cca57d19",
+          productName = "Discounts",
+          productRatePlanId = "2c92a0ff5345f9220153559d915d5c26",
+          ratePlanName = "Percentage",
+          ratePlanCharges = List(
+            ZuoraRatePlanCharge(
+              productRatePlanChargeId = "2c92a0fd5345efa10153559e97bb76c6",
+              name = "Percentage",
+              number = "C-01271544",
+              currency = "AUD",
+              price = None,
+              billingPeriod = Some("Annual"),
+              chargedThroughDate = Some(LocalDate.of(2026, 3, 23)),
+              processedThroughDate = Some(LocalDate.of(2025, 3, 23)),
+              specificBillingPeriod = None,
+              endDateCondition = Some("Subscription_End"),
+              upToPeriodsType = None,
+              upToPeriods = None,
+              billingDay = Some("DefaultFromCustomer"),
+              triggerEvent = Some("CustomerAcceptance"),
+              triggerDate = None,
+              discountPercentage = Some(10),
+              originalOrderDate = Some(LocalDate.of(2018, 3, 20)),
+              effectiveStartDate = Some(LocalDate.of(2018, 3, 23)),
+              effectiveEndDate = Some(LocalDate.of(2026, 3, 23))
+            )
+          ),
+          lastChangeType = Some("Add")
+        )
+      )
+    )
+  }
+
+  test("SI2025Extractions.getPercentageOrAdjustementDiscount") {
+    val subscription =
+      Fixtures.subscriptionFromJson(
+        "libs/SubscriptionIntrospection2025/subscription4-511760-Discount-Adjustment/subscription.json"
+      )
+
+    // The subscription has a "* Adjustment *" discount, so that's what we expect
+
+    assertEquals(
+      SI2025Extractions.getPercentageOrAdjustementDiscount(subscription),
       Some(
         ZuoraRatePlan(
           id = "8a128efc91a138d30191bb00a80c281f",

--- a/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
@@ -908,7 +908,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
     val subscription =
       Fixtures.subscriptionFromJson("Migrations/GuardianWeekly2025/6801-Discount/subscription.json")
     assertEquals(
-      SI2025Extractions.getDiscount(subscription, "Percentage"),
+      SI2025Extractions.getDiscountByRatePlanName(subscription, "Percentage"),
       Some(
         ZuoraRatePlan(
           id = "8a129ce595aa3a180195c130cca57d19",

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
@@ -90,4 +90,52 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
       Some(BigDecimal(15.99))
     )
   }
+
+  // Fixtures:
+
+  // 277291-everyday-annual
+  // val subscription = Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/subscription.json")
+  // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/account.json")
+  // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/invoice-preview.json")
+
+  // 277750-everyday-month
+  // val subscription = Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277750-everyday-month/subscription.json")
+  // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/277750-everyday-month/account.json")
+  // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/277750-everyday-month/invoice-preview.json")
+
+  // 412032-sixday-annual
+  // val subscription = Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/subscription.json")
+  // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/account.json")
+  // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/invoice-preview.json")
+
+  // A-S02075439-saturday-month
+  // val subscription = Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/subscription.json")
+  // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/account.json")
+  // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/invoice-preview.json")
+
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+    // 277291-everyday-annual
+    val subscription =
+      Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/subscription.json")
+    // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/account.json")
+    // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/invoice-preview.json")
+
+    assertEquals(
+      Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate(subscription),
+      Some(LocalDate.of(2024, 11, 27))
+    )
+  }
+
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+    // 412032-sixday-annual
+    val subscription =
+      Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/subscription.json")
+    // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/account.json")
+    // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/invoice-preview.json")
+
+    assertEquals(
+      Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate(subscription),
+      Some(LocalDate.of(2024, 8, 12))
+    )
+  }
 }

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
@@ -117,7 +117,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
   // --------------------------------------------------------------------
   // Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate
 
-  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate (277291-everyday-annual)") {
     // 277291-everyday-annual
     val subscription =
       Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/subscription.json")
@@ -130,7 +130,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
     )
   }
 
-  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate (412032-sixday-annual)") {
     // 412032-sixday-annual
     val subscription =
       Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/subscription.json")
@@ -146,7 +146,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
   // --------------------------------------------------------------------
   // Newspaper2025P3Migration.decideDeliveryPattern
 
-  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate (277291-everyday-annual)") {
     // 277291-everyday-annual
     val subscription =
       Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/subscription.json")
@@ -161,7 +161,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
     )
   }
 
-  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate (277750-everyday-month)") {
     // 277750-everyday-month
     val subscription =
       Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277750-everyday-month/subscription.json")
@@ -176,7 +176,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
     )
   }
 
-  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate (412032-sixday-annual)") {
     // 412032-sixday-annual
     val subscription =
       Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/subscription.json")
@@ -191,7 +191,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
     )
   }
 
-  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate (A-S02075439-saturday-month)") {
     // A-S02075439-saturday-month
     val subscription =
       Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/subscription.json")
@@ -206,4 +206,369 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
     )
   }
 
+  // --------------------------------------------------------------------
+  // Newspaper2025P3Migration.priceData
+
+  test("Newspaper2025P3Migration.priceData") {
+    // 277291-everyday-annual
+    val subscription =
+      Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/subscription.json")
+    val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/account.json")
+    val invoicePreview =
+      Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/invoice-preview.json")
+
+    // Here we are testing priceData, but to be confident that the price data
+    // is correct, we are going to test all the intermediary values of the
+    // for yield construct.
+
+    val ratePlan = SI2025RateplanFromSubAndInvoices.determineRatePlan(subscription, invoicePreview).get
+
+    assertEquals(
+      ratePlan,
+      ZuoraRatePlan(
+        id = "8a128da59348e4fd01936c6ed8466963",
+        productName = "Newspaper Voucher",
+        productRatePlanId = "2c92a0fd56fe270b0157040dd79b35da",
+        ratePlanName = "Everyday",
+        ratePlanCharges = List(
+          ZuoraRatePlanCharge(
+            productRatePlanChargeId = "2c92a0ff56fe33f5015709c39719783e",
+            name = "Sunday",
+            number = "C-06169227",
+            currency = "GBP",
+            price = Some(BigDecimal(137.4)),
+            billingPeriod = Some("Annual"),
+            chargedThroughDate = Some(LocalDate.of(2026, 1, 6)),
+            processedThroughDate = Some(LocalDate.of(2025, 1, 6)),
+            specificBillingPeriod = None,
+            endDateCondition = Some("Subscription_End"),
+            upToPeriodsType = None,
+            upToPeriods = None,
+            billingDay = Some("ChargeTriggerDay"),
+            triggerEvent = Some("CustomerAcceptance"),
+            triggerDate = None,
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2024, 11, 27)),
+            effectiveStartDate = Some(LocalDate.of(2025, 1, 6)),
+            effectiveEndDate = Some(LocalDate.of(2026, 1, 6))
+          ),
+          ZuoraRatePlanCharge(
+            productRatePlanChargeId = "2c92a0ff56fe33f3015709c110a71630",
+            name = "Wednesday",
+            number = "C-06169226",
+            currency = "GBP",
+            price = Some(BigDecimal(101.04)),
+            billingPeriod = Some("Annual"),
+            chargedThroughDate = Some(LocalDate.of(2026, 1, 6)),
+            processedThroughDate = Some(LocalDate.of(2025, 1, 6)),
+            specificBillingPeriod = None,
+            endDateCondition = Some("Subscription_End"),
+            upToPeriodsType = None,
+            upToPeriods = None,
+            billingDay = Some("ChargeTriggerDay"),
+            triggerEvent = Some("CustomerAcceptance"),
+            triggerDate = None,
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2024, 11, 27)),
+            effectiveStartDate = Some(LocalDate.of(2025, 1, 6)),
+            effectiveEndDate = Some(LocalDate.of(2026, 1, 6))
+          ),
+          ZuoraRatePlanCharge(
+            productRatePlanChargeId = "2c92a0ff56fe33f0015709c215527db4",
+            name = "Friday",
+            number = "C-06169225",
+            currency = "GBP",
+            price = Some(BigDecimal(101.04)),
+            billingPeriod = Some("Annual"),
+            chargedThroughDate = Some(LocalDate.of(2026, 1, 6)),
+            processedThroughDate = Some(LocalDate.of(2025, 1, 6)),
+            specificBillingPeriod = None,
+            endDateCondition = Some("Subscription_End"),
+            upToPeriodsType = None,
+            upToPeriods = None,
+            billingDay = Some("ChargeTriggerDay"),
+            triggerEvent = Some("CustomerAcceptance"),
+            triggerDate = None,
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2024, 11, 27)),
+            effectiveStartDate = Some(LocalDate.of(2025, 1, 6)),
+            effectiveEndDate = Some(LocalDate.of(2026, 1, 6))
+          ),
+          ZuoraRatePlanCharge(
+            productRatePlanChargeId = "2c92a0ff56fe33f0015709c182cb7c82",
+            name = "Thursday",
+            number = "C-06169224",
+            currency = "GBP",
+            price = Some(BigDecimal(101.04)),
+            billingPeriod = Some("Annual"),
+            chargedThroughDate = Some(LocalDate.of(2026, 1, 6)),
+            processedThroughDate = Some(LocalDate.of(2025, 1, 6)),
+            specificBillingPeriod = None,
+            endDateCondition = Some("Subscription_End"),
+            upToPeriodsType = None,
+            upToPeriods = None,
+            billingDay = Some("ChargeTriggerDay"),
+            triggerEvent = Some("CustomerAcceptance"),
+            triggerDate = None,
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2024, 11, 27)),
+            effectiveStartDate = Some(LocalDate.of(2025, 1, 6)),
+            effectiveEndDate = Some(LocalDate.of(2026, 1, 6))
+          ),
+          ZuoraRatePlanCharge(
+            productRatePlanChargeId = "2c92a0fd56fe270b015709c320ee0595",
+            name = "Saturday",
+            number = "C-06169223",
+            currency = "GBP",
+            price = Some(BigDecimal(137.28)),
+            billingPeriod = Some("Annual"),
+            chargedThroughDate = Some(LocalDate.of(2026, 1, 6)),
+            processedThroughDate = Some(LocalDate.of(2025, 1, 6)),
+            specificBillingPeriod = None,
+            endDateCondition = Some("Subscription_End"),
+            upToPeriodsType = None,
+            upToPeriods = None,
+            billingDay = Some("ChargeTriggerDay"),
+            triggerEvent = Some("CustomerAcceptance"),
+            triggerDate = None,
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2024, 11, 27)),
+            effectiveStartDate = Some(LocalDate.of(2025, 1, 6)),
+            effectiveEndDate = Some(LocalDate.of(2026, 1, 6))
+          ),
+          ZuoraRatePlanCharge(
+            productRatePlanChargeId = "2c92a0fd56fe26b6015709c0613b44a6",
+            name = "Tuesday",
+            number = "C-06169222",
+            currency = "GBP",
+            price = Some(BigDecimal(101.04)),
+            billingPeriod = Some("Annual"),
+            chargedThroughDate = Some(LocalDate.of(2026, 1, 6)),
+            processedThroughDate = Some(LocalDate.of(2025, 1, 6)),
+            specificBillingPeriod = None,
+            endDateCondition = Some("Subscription_End"),
+            upToPeriodsType = None,
+            upToPeriods = None,
+            billingDay = Some("ChargeTriggerDay"),
+            triggerEvent = Some("CustomerAcceptance"),
+            triggerDate = None,
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2024, 11, 27)),
+            effectiveStartDate = Some(LocalDate.of(2025, 1, 6)),
+            effectiveEndDate = Some(LocalDate.of(2026, 1, 6))
+          ),
+          ZuoraRatePlanCharge(
+            productRatePlanChargeId = "2c92a0fd56fe26b601570431a5bc5a34",
+            name = "Monday",
+            number = "C-06169221",
+            currency = "GBP",
+            price = Some(BigDecimal(101.04)),
+            billingPeriod = Some("Annual"),
+            chargedThroughDate = Some(LocalDate.of(2026, 1, 6)),
+            processedThroughDate = Some(LocalDate.of(2025, 1, 6)),
+            specificBillingPeriod = None,
+            endDateCondition = Some("Subscription_End"),
+            upToPeriodsType = None,
+            upToPeriods = None,
+            billingDay = Some("ChargeTriggerDay"),
+            triggerEvent = Some("CustomerAcceptance"),
+            triggerDate = None,
+            discountPercentage = None,
+            originalOrderDate = Some(LocalDate.of(2024, 11, 27)),
+            effectiveStartDate = Some(LocalDate.of(2025, 1, 6)),
+            effectiveEndDate = Some(LocalDate.of(2026, 1, 6))
+          )
+        ),
+        lastChangeType = Some("Add")
+      )
+    )
+
+    val deliveryPattern = Newspaper2025P3Migration.decideDeliveryPattern(ratePlan).get
+
+    assertEquals(
+      deliveryPattern,
+      Newspaper2025P3Everyday
+    )
+
+    val priceData = Newspaper2025P3Migration.priceData(
+      subscription,
+      invoicePreview,
+      account
+    )
+
+    assertEquals(
+      priceData,
+      Right(PriceData("GBP", BigDecimal(779.88), BigDecimal(839.88), "Annual"))
+    )
+  }
+
+  // --------------------------------------------------------------------
+  // Newspaper2025P3Migration.amendmentOrderPayload
+
+  test("Newspaper2025P3Migration.amendmentOrderPayload (276579)") {
+
+    // Newspaper2025P3Migration.amendmentOrderPayload without discount removal
+
+    // 277291-everyday-annual
+    val subscription =
+      Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/subscription.json")
+    val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/account.json")
+    val invoicePreview =
+      Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/invoice-preview.json")
+
+    val startDate = LocalDate.of(2025, 8, 23)
+    val oldPrice = BigDecimal(779.88) // using the same number from the Newspaper2025P3Migration.priceData check
+    val estimatedNewPrice = BigDecimal(839.88)
+
+    val cohortItem = CohortItem(
+      subscriptionName = subscription.subscriptionNumber,
+      processingStage = CohortTableFilter.NotificationSendDateWrittenToSalesforce,
+      startDate = Some(startDate),
+      currency = Some("GBP"),
+      oldPrice = Some(oldPrice),
+      estimatedNewPrice = Some(estimatedNewPrice),
+      billingPeriod = Some("Annual"),
+      migrationExtraAttributes = None
+    )
+
+    // We now collect the arguments of Newspaper2025P3Migration.amendmentOrderPayload
+
+    val orderDate = LocalDate.of(2025, 7, 20) // LocalDate.now()
+    val accountNumber = subscription.accountNumber
+    val subscriptionNumber = subscription.subscriptionNumber
+    val effectDate = startDate
+    val priceCap = 1.2
+
+    assertEquals(
+      Newspaper2025P3Migration.amendmentOrderPayload(
+        cohortItem,
+        orderDate,
+        accountNumber,
+        subscriptionNumber,
+        effectDate,
+        subscription,
+        oldPrice,
+        estimatedNewPrice,
+        priceCap,
+        invoicePreview
+      ),
+      Right(
+        ujson.read(
+          s"""{
+             |    "orderDate": "2025-07-20",
+             |    "existingAccountNumber": "SUBSCRIPTION-NUMBER",
+             |    "subscriptions": [
+             |        {
+             |            "subscriptionNumber": "SUBSCRIPTION-NUMBER",
+             |            "orderActions": [
+             |                {
+             |                    "type": "RemoveProduct",
+             |                    "triggerDates": [
+             |                        {
+             |                            "name": "ContractEffective",
+             |                            "triggerDate": "2025-08-23"
+             |                        },
+             |                        {
+             |                            "name": "ServiceActivation",
+             |                            "triggerDate": "2025-08-23"
+             |                        },
+             |                        {
+             |                            "name": "CustomerAcceptance",
+             |                            "triggerDate": "2025-08-23"
+             |                        }
+             |                    ],
+             |                    "removeProduct": {
+             |                        "ratePlanId": "8a128da59348e4fd01936c6ed8466963"
+             |                    }
+             |                },
+             |                {
+             |                    "type": "AddProduct",
+             |                    "triggerDates": [
+             |                        {
+             |                            "name": "ContractEffective",
+             |                            "triggerDate": "2025-08-23"
+             |                        },
+             |                        {
+             |                            "name": "ServiceActivation",
+             |                            "triggerDate": "2025-08-23"
+             |                        },
+             |                        {
+             |                            "name": "CustomerAcceptance",
+             |                            "triggerDate": "2025-08-23"
+             |                        }
+             |                    ],
+             |                    "addProduct": {
+             |                        "productRatePlanId": "2c92a0fd56fe270b0157040dd79b35da",
+             |                        "chargeOverrides": [
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0ff56fe33f5015709c39719783e",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 147.97
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0ff56fe33f3015709c110a71630",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 108.81
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0ff56fe33f0015709c215527db4",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 108.81
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0ff56fe33f0015709c182cb7c82",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 108.81
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0fd56fe270b015709c320ee0595",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 147.84
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0fd56fe26b6015709c0613b44a6",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 108.81
+             |                                    }
+             |                                }
+             |                            },
+             |                            {
+             |                                "productRatePlanChargeId": "2c92a0fd56fe26b601570431a5bc5a34",
+             |                                "pricing": {
+             |                                    "recurringFlatFee": {
+             |                                        "listPrice": 108.81
+             |                                    }
+             |                                }
+             |                            }
+             |                        ]
+             |                    }
+             |                }
+             |            ]
+             |        }
+             |    ],
+             |    "processingOptions": {
+             |        "runBilling": false,
+             |        "collectPayment": false
+             |    }
+             |}""".stripMargin
+        )
+      )
+    )
+  }
 }

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.migrations
 import pricemigrationengine.model.CohortTableFilter.ReadyForEstimation
 import pricemigrationengine.model._
 import pricemigrationengine.Fixtures
-import pricemigrationengine.libs.SI2025RateplanFromSubAndInvoices
+import pricemigrationengine.libs.{SI2025RateplanFromSub, SI2025RateplanFromSubAndInvoices}
 
 import java.time.LocalDate
 
@@ -91,6 +91,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
     )
   }
 
+  // --------------------------------------------------------------------
   // Fixtures:
 
   // 277291-everyday-annual
@@ -112,6 +113,9 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
   // val subscription = Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/subscription.json")
   // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/account.json")
   // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/invoice-preview.json")
+
+  // --------------------------------------------------------------------
+  // Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate
 
   test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
     // 277291-everyday-annual
@@ -138,4 +142,68 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
       Some(LocalDate.of(2024, 8, 12))
     )
   }
+
+  // --------------------------------------------------------------------
+  // Newspaper2025P3Migration.decideDeliveryPattern
+
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+    // 277291-everyday-annual
+    val subscription =
+      Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/subscription.json")
+    // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/account.json")
+    // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/277291-everyday-annual/invoice-preview.json")
+
+    val ratePlan = SI2025RateplanFromSub.determineRatePlan(subscription: ZuoraSubscription).get
+
+    assertEquals(
+      Newspaper2025P3Migration.decideDeliveryPattern(ratePlan),
+      Some(Newspaper2025P3Everyday)
+    )
+  }
+
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+    // 277750-everyday-month
+    val subscription =
+      Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/277750-everyday-month/subscription.json")
+    // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/277750-everyday-month/account.json")
+    // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/277750-everyday-month/invoice-preview.json")
+
+    val ratePlan = SI2025RateplanFromSub.determineRatePlan(subscription: ZuoraSubscription).get
+
+    assertEquals(
+      Newspaper2025P3Migration.decideDeliveryPattern(ratePlan),
+      Some(Newspaper2025P3Everyday)
+    )
+  }
+
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+    // 412032-sixday-annual
+    val subscription =
+      Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/subscription.json")
+    // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/account.json")
+    // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/412032-sixday-annual/invoice-preview.json")
+
+    val ratePlan = SI2025RateplanFromSub.determineRatePlan(subscription: ZuoraSubscription).get
+
+    assertEquals(
+      Newspaper2025P3Migration.decideDeliveryPattern(ratePlan),
+      Some(Newspaper2025P3Sixday)
+    )
+  }
+
+  test("Newspaper2025P3Migration.subscriptionToLastPriceMigrationDate") {
+    // A-S02075439-saturday-month
+    val subscription =
+      Fixtures.subscriptionFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/subscription.json")
+    // val account = Fixtures.accountFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/account.json")
+    // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/Newspaper2025P3/A-S02075439-saturday-month/invoice-preview.json")
+
+    val ratePlan = SI2025RateplanFromSub.determineRatePlan(subscription: ZuoraSubscription).get
+
+    assertEquals(
+      Newspaper2025P3Migration.decideDeliveryPattern(ratePlan),
+      Some(Newspaper2025P3Saturday)
+    )
+  }
+
 }

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
@@ -39,14 +39,14 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
     assertEquals(label, Some("Label 01"))
   }
 
-  test("decideShouldRemoveDiscount (2)") {
+  test("decideShouldRemoveDiscount (1)") {
     val cohortItem = CohortItem(
       subscriptionName = "A-000001",
       processingStage = ReadyForEstimation,
       migrationExtraAttributes = Some("""{ "brandTitle": "Label 01" }"""),
     )
-    val label = Newspaper2025P3Migration.decideShouldRemoveDiscount(cohortItem)
-    assertEquals(label, false)
+    val flag = Newspaper2025P3Migration.decideShouldRemoveDiscount(cohortItem)
+    assertEquals(flag, false)
   }
 
   test("decideShouldRemoveDiscount (2)") {
@@ -55,8 +55,8 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
       processingStage = ReadyForEstimation,
       migrationExtraAttributes = Some("""{ "brandTitle": "Label 01", "removeDiscount": true }"""),
     )
-    val label = Newspaper2025P3Migration.decideShouldRemoveDiscount(cohortItem)
-    assertEquals(label, true)
+    val flag = Newspaper2025P3Migration.decideShouldRemoveDiscount(cohortItem)
+    assertEquals(flag, true)
   }
 
   test("decideShouldRemoveDiscount (3)") {
@@ -65,8 +65,39 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
       processingStage = ReadyForEstimation,
       migrationExtraAttributes = Some("""{ "brandTitle": "Label 01", "removeDiscount": false }"""),
     )
-    val label = Newspaper2025P3Migration.decideShouldRemoveDiscount(cohortItem)
-    assertEquals(label, false)
+    val flag = Newspaper2025P3Migration.decideShouldRemoveDiscount(cohortItem)
+    assertEquals(flag, false)
+  }
+
+  test("getEarliestMigrationDateFromMigrationExtraAttributes (1)") {
+    val cohortItem = CohortItem(
+      subscriptionName = "A-000001",
+      processingStage = ReadyForEstimation,
+      migrationExtraAttributes = Some("""{ "brandTitle": "Label 01" }"""),
+    )
+    val date = Newspaper2025P3Migration.getEarliestMigrationDateFromMigrationExtraAttributes(cohortItem)
+    assertEquals(date, None)
+  }
+
+  test("getEarliestMigrationDateFromMigrationExtraAttributes (2)") {
+    val cohortItem = CohortItem(
+      subscriptionName = "A-000001",
+      processingStage = ReadyForEstimation,
+      migrationExtraAttributes = Some("""{ "brandTitle": "Label 01", "earliestMigrationDate": "2025-10-06" }"""),
+    )
+    val date = Newspaper2025P3Migration.getEarliestMigrationDateFromMigrationExtraAttributes(cohortItem)
+    assertEquals(date, Some(LocalDate.of(2025, 10, 6)))
+  }
+
+  test("getEarliestMigrationDateFromMigrationExtraAttributes (3)") {
+    val cohortItem = CohortItem(
+      subscriptionName = "A-000001",
+      processingStage = ReadyForEstimation,
+      migrationExtraAttributes =
+        Some("""{ "brandTitle": "Label 01", "removeDiscount": false, "earliestMigrationDate": "2025-10-06" }"""),
+    )
+    val date = Newspaper2025P3Migration.getEarliestMigrationDateFromMigrationExtraAttributes(cohortItem)
+    assertEquals(date, Some(LocalDate.of(2025, 10, 6)))
   }
 
   test("priceLookUp") {


### PR DESCRIPTION
This implements the Newspaper2025P3, aka Card and Voucher, price migration.


Historical note: Newspaper2025P3 is the first price migration to use all 3 novels extra attributes.

```
case class Newspaper2025P3ExtraAttributes(
    brandTitle: String,
    removeDiscount: Option[Boolean] = None,
    earliestMigrationDate: Option[LocalDate] = None
)
```