### PR TITLE
Set default country for newspaper phase3

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -451,6 +451,7 @@ object NotificationHandler extends CohortHandler {
       case SupporterPlus2024 => Right(address.country.getOrElse(""))
       case Newspaper2025P1   => Right(address.country.getOrElse("United Kingdom"))
       case HomeDelivery2025  => Right(address.country.getOrElse("United Kingdom"))
+      case Newspaper2025P3   => Right(address.country.getOrElse("United Kingdom"))
       case _                 => requiredField(address.country, "Contact.OtherAddress.country")
     }
   }


### PR DESCRIPTION
Set default mailing country to "United Kingdom" for Phase3 (same operation we did for Phase2 last week: https://github.com/guardian/price-migration-engine/pull/1187/files)