### PR TITLE
correct Newspaper2025P3Migration.getNotificationData

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -135,7 +135,7 @@ object Newspaper2025P3Migration {
       item: CohortItem
   ): ZIO[Zuora, Failure, Newspaper2025P3NotificationData] = {
     MigrationType(cohortSpec) match {
-      case Newspaper2025P1 => {
+      case Newspaper2025P3 => {
         (for {
           brandTitle <- getLabelFromMigrationExtraAttributes(item)
         } yield Newspaper2025P3NotificationData(


### PR DESCRIPTION
Correct a bug in `Newspaper2025P3Migration.getNotificationData`, which was listening to the wrong cohort item. We also log the email message, this will help reviewing what is actually sent to Braze. 