### PR TITLE
Specify billing period in amendment payload

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitives.scala
+++ b/lambda/src/main/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitives.scala
@@ -5,6 +5,7 @@ import pricemigrationengine.model.ZuoraRatePlanCharge
 import java.time.LocalDate
 import upickle.default._
 import ujson._
+
 import scala.math.BigDecimal.RoundingMode
 
 // This file contains the primitives to be able to construct the Orders API Payload
@@ -98,7 +99,7 @@ object ZuoraOrdersApiPrimitives {
     )
   }
 
-  def chargeOverride(productRatePlanChargeId: String, listPrice: BigDecimal): Value = {
+  def chargeOverride(productRatePlanChargeId: String, listPrice: BigDecimal, billingPeriod: String): Value = {
     /*
         {
             "productRatePlanChargeId": "8a128ed885fc6ded018602296af13eba",
@@ -115,13 +116,17 @@ object ZuoraOrdersApiPrimitives {
         "recurringFlatFee" -> Obj(
           "listPrice" -> Num(listPrice.doubleValue)
         )
+      ),
+      "billing" -> Obj(
+        "billingPeriod" -> Str(billingPeriod)
       )
     )
   }
 
   def ratePlanChargesToChargeOverrides(
       ratePlanCharges: List[ZuoraRatePlanCharge],
-      priceRatio: BigDecimal
+      priceRatio: BigDecimal,
+      billingPeriod: String
   ): List[Value] = {
     // This functions is a more general case of the previous function (`chargeOverride`)
     // We originally introduced `chargeOverride` for price increases that have a single charge
@@ -153,6 +158,9 @@ object ZuoraOrdersApiPrimitives {
           "recurringFlatFee" -> Obj(
             "listPrice" -> Num((rpc.price.get * priceRatio).setScale(2, RoundingMode.DOWN).doubleValue) // [1]
           )
+        ),
+        "billing" -> Obj(
+          "billingPeriod" -> Str(billingPeriod)
         )
       )
     }

--- a/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
@@ -228,6 +228,7 @@ object HomeDelivery2025Migration {
       if (!decideShouldRemoveDiscount(cohortItem)) {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
+          billingPeriod <- ZuoraRatePlan.ratePlanToBillingPeriod(ratePlan)
         } yield {
           val subscriptionRatePlanId = ratePlan.id
           val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)
@@ -235,7 +236,8 @@ object HomeDelivery2025Migration {
           val productRatePlanId = ratePlan.productRatePlanId // We are upgrading on the same rate plan.
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
-            priceRatio
+            priceRatio,
+            BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
           val order_subscription =
@@ -249,6 +251,7 @@ object HomeDelivery2025Migration {
       } else {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
+          billingPeriod <- ZuoraRatePlan.ratePlanToBillingPeriod(ratePlan)
           discount <- SI2025Extractions.getDiscountByRatePlanName(zuora_subscription, "Percentage")
         } yield {
           val subscriptionRatePlanId = ratePlan.id
@@ -258,7 +261,8 @@ object HomeDelivery2025Migration {
           val productRatePlanId = ratePlan.productRatePlanId // We are upgrading on the same rate plan.
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
-            priceRatio
+            priceRatio,
+            BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
           val order_subscription =

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
@@ -270,6 +270,7 @@ object Newspaper2025P1Migration {
       if (!decideShouldRemoveDiscount(cohortItem)) {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
+          billingPeriod <- ZuoraRatePlan.ratePlanToBillingPeriod(ratePlan)
         } yield {
           val subscriptionRatePlanId = ratePlan.id
           val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)
@@ -277,7 +278,8 @@ object Newspaper2025P1Migration {
           val productRatePlanId = ratePlan.productRatePlanId // We are upgrading on the same rate plan.
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
-            priceRatio
+            priceRatio,
+            BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
           val order_subscription =
@@ -291,6 +293,7 @@ object Newspaper2025P1Migration {
       } else {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
+          billingPeriod <- ZuoraRatePlan.ratePlanToBillingPeriod(ratePlan)
           discount <- SI2025Extractions.getDiscountByRatePlanName(zuora_subscription, "Adjustment")
         } yield {
           val subscriptionRatePlanId = ratePlan.id
@@ -300,7 +303,8 @@ object Newspaper2025P1Migration {
           val productRatePlanId = ratePlan.productRatePlanId // We are upgrading on the same rate plan.
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
-            priceRatio
+            priceRatio,
+            BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
           val order_subscription =

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -241,6 +241,7 @@ object Newspaper2025P3Migration {
       if (!decideShouldRemoveDiscount(cohortItem)) {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
+          billingPeriod <- ZuoraRatePlan.ratePlanToBillingPeriod(ratePlan)
         } yield {
           val subscriptionRatePlanId = ratePlan.id
           val removeProduct = ZuoraOrdersApiPrimitives.removeProduct(effectDate.toString, subscriptionRatePlanId)
@@ -248,7 +249,8 @@ object Newspaper2025P3Migration {
           val productRatePlanId = ratePlan.productRatePlanId // We are upgrading on the same rate plan.
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
-            priceRatio
+            priceRatio,
+            BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
           val order_subscription =
@@ -262,6 +264,7 @@ object Newspaper2025P3Migration {
       } else {
         for {
           ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(zuora_subscription, invoiceList)
+          billingPeriod <- ZuoraRatePlan.ratePlanToBillingPeriod(ratePlan)
           discount <- SI2025Extractions.getPercentageOrAdjustementDiscount(zuora_subscription)
         } yield {
           val subscriptionRatePlanId = ratePlan.id
@@ -271,7 +274,8 @@ object Newspaper2025P3Migration {
           val productRatePlanId = ratePlan.productRatePlanId // We are upgrading on the same rate plan.
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
-            priceRatio
+            priceRatio,
+            BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
           val order_subscription =

--- a/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/libs/ZuoraOrdersApiPrimitivesTest.scala
@@ -74,7 +74,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
   }
 
   test("ZuoraOrdersApiPrimitives.chargeOverride") {
-    val chargeOverride = ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12)
+    val chargeOverride = ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12, "Quarter")
     val jsonstrpp = ujson.write(chargeOverride, indent = 4)
     assertEquals(
       jsonstrpp,
@@ -84,6 +84,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |        "recurringFlatFee": {
         |            "listPrice": 12
         |        }
+        |    },
+        |    "billing": {
+        |        "billingPeriod": "Quarter"
         |    }
         |}""".stripMargin
     )
@@ -91,8 +94,8 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
 
   test("ZuoraOrdersApiPrimitives.addProduct") {
     val chargeOverrides = List(
-      ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12),
-      ZuoraOrdersApiPrimitives.chargeOverride("8a128d7085fc6dec01860234cd075270", 0)
+      ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12, "Month"),
+      ZuoraOrdersApiPrimitives.chargeOverride("8a128d7085fc6dec01860234cd075270", 0, "Month")
     )
     val addProduct = ZuoraOrdersApiPrimitives.addProduct(
       "2024-11-28",
@@ -127,6 +130,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |                    "recurringFlatFee": {
         |                        "listPrice": 12
         |                    }
+        |                },
+        |                "billing": {
+        |                    "billingPeriod": "Month"
         |                }
         |            },
         |            {
@@ -135,6 +141,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |                    "recurringFlatFee": {
         |                        "listPrice": 0
         |                    }
+        |                },
+        |                "billing": {
+        |                    "billingPeriod": "Month"
         |                }
         |            }
         |        ]
@@ -149,8 +158,8 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
       "2025-05-20",
       "8a128ed885fc6ded018602296ace3eb8",
       List(
-        ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12),
-        ZuoraOrdersApiPrimitives.chargeOverride("8a128d7085fc6dec01860234cd075270", 0)
+        ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12, "Annual"),
+        ZuoraOrdersApiPrimitives.chargeOverride("8a128d7085fc6dec01860234cd075270", 0, "Annual")
       )
     )
     val json = ZuoraOrdersApiPrimitives.subscription("a1809f5e84dd", List(removeProduct), List(addProduct))
@@ -205,6 +214,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |                            "recurringFlatFee": {
         |                                "listPrice": 12
         |                            }
+        |                        },
+        |                        "billing": {
+        |                            "billingPeriod": "Annual"
         |                        }
         |                    },
         |                    {
@@ -213,6 +225,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |                            "recurringFlatFee": {
         |                                "listPrice": 0
         |                            }
+        |                        },
+        |                        "billing": {
+        |                            "billingPeriod": "Annual"
         |                        }
         |                    }
         |                ]
@@ -229,8 +244,8 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
       "2025-05-20",
       "8a128ed885fc6ded018602296ace3eb8",
       List(
-        ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12),
-        ZuoraOrdersApiPrimitives.chargeOverride("8a128d7085fc6dec01860234cd075270", 0)
+        ZuoraOrdersApiPrimitives.chargeOverride("8a128ed885fc6ded018602296af13eba", 12, "Month"),
+        ZuoraOrdersApiPrimitives.chargeOverride("8a128d7085fc6dec01860234cd075270", 0, "Month")
       )
     )
     val subscription = ZuoraOrdersApiPrimitives.subscription("a1809f5e84dd", List(removeProduct), List(addProduct))
@@ -296,6 +311,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |                                    "recurringFlatFee": {
         |                                        "listPrice": 12
         |                                    }
+        |                                },
+        |                                "billing": {
+        |                                    "billingPeriod": "Month"
         |                                }
         |                            },
         |                            {
@@ -304,6 +322,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |                                    "recurringFlatFee": {
         |                                        "listPrice": 0
         |                                    }
+        |                                },
+        |                                "billing": {
+        |                                    "billingPeriod": "Month"
         |                                }
         |                            }
         |                        ]
@@ -483,7 +504,8 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
 
     val json = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
       ratePlan.ratePlanCharges,
-      BigDecimal(1.5)
+      BigDecimal(1.5),
+      "Month"
     )
 
     val jsonstrpp = ujson.write(json, indent = 4)
@@ -497,6 +519,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |            "recurringFlatFee": {
         |                "listPrice": 13.44
         |            }
+        |        },
+        |        "billing": {
+        |            "billingPeriod": "Month"
         |        }
         |    },
         |    {
@@ -505,6 +530,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |            "recurringFlatFee": {
         |                "listPrice": 3
         |            }
+        |        },
+        |        "billing": {
+        |            "billingPeriod": "Month"
         |        }
         |    },
         |    {
@@ -513,6 +541,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |            "recurringFlatFee": {
         |                "listPrice": 13.44
         |            }
+        |        },
+        |        "billing": {
+        |            "billingPeriod": "Month"
         |        }
         |    },
         |    {
@@ -521,6 +552,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |            "recurringFlatFee": {
         |                "listPrice": 18.28
         |            }
+        |        },
+        |        "billing": {
+        |            "billingPeriod": "Month"
         |        }
         |    },
         |    {
@@ -529,6 +563,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |            "recurringFlatFee": {
         |                "listPrice": 13.44
         |            }
+        |        },
+        |        "billing": {
+        |            "billingPeriod": "Month"
         |        }
         |    },
         |    {
@@ -537,6 +574,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |            "recurringFlatFee": {
         |                "listPrice": 13.44
         |            }
+        |        },
+        |        "billing": {
+        |            "billingPeriod": "Month"
         |        }
         |    },
         |    {
@@ -545,6 +585,9 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |            "recurringFlatFee": {
         |                "listPrice": 13.44
         |            }
+        |        },
+        |        "billing": {
+        |            "billingPeriod": "Month"
         |        }
         |    }
         |]""".stripMargin

--- a/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
@@ -262,6 +262,9 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 16.5
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            }
              |                        ]
@@ -380,6 +383,9 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
             |                                    "recurringFlatFee": {
             |                                        "listPrice": 240
             |                                    }
+            |                                },
+            |                                "billing": {
+            |                                    "billingPeriod": "Month"
             |                                }
             |                            }
             |                        ]
@@ -494,6 +500,9 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 348.0
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Annual"
              |                                }
              |                            }
              |                        ]
@@ -646,7 +655,8 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
     val chargeOverrides = List(
       ZuoraOrdersApiPrimitives.chargeOverride(
         ratePlan.ratePlanCharges.headOption.get.productRatePlanChargeId,
-        PriceCap.cappedPrice(oldPrice, estimatedNewPrice, priceCap)
+        PriceCap.cappedPrice(oldPrice, estimatedNewPrice, priceCap),
+        "Quarter"
       )
     )
 
@@ -680,6 +690,9 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
            |                    "recurringFlatFee": {
            |                        "listPrice": 49.5
            |                    }
+           |                },
+           |                "billing": {
+           |                    "billingPeriod": "Quarter"
            |                }
            |            }
            |        ]
@@ -744,6 +757,9 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
            |                            "recurringFlatFee": {
            |                                "listPrice": 49.5
            |                            }
+           |                        },
+           |                        "billing": {
+           |                            "billingPeriod": "Quarter"
            |                        }
            |                    }
            |                ]
@@ -886,6 +902,9 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 49.5
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Quarter"
              |                                }
              |                            }
              |                        ]
@@ -1066,6 +1085,9 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 49.5
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Annual"
              |                                }
              |                            }
              |                        ]
@@ -1186,6 +1208,9 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 81
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Quarter"
              |                                }
              |                            }
              |                        ]

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
@@ -667,6 +667,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 11.54
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -675,6 +678,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 2.57
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -683,6 +689,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 11.54
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -691,6 +700,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 15.71
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -699,6 +711,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 11.54
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -707,6 +722,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 11.54
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -715,6 +733,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 11.54
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            }
              |                        ]
@@ -856,6 +877,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 10.85
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -864,6 +888,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 14.75
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -872,6 +899,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 10.85
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -880,6 +910,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 10.85
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -888,6 +921,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 10.85
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -896,6 +932,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 10.85
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -904,6 +943,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 14.74
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            },
              |                            {
@@ -912,6 +954,9 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 2.57
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Month"
              |                                }
              |                            }
              |                        ]

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
@@ -537,6 +537,9 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 147.97
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Annual"
              |                                }
              |                            },
              |                            {
@@ -545,6 +548,9 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 108.81
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Annual"
              |                                }
              |                            },
              |                            {
@@ -553,6 +559,9 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 108.81
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Annual"
              |                                }
              |                            },
              |                            {
@@ -561,6 +570,9 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 108.81
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Annual"
              |                                }
              |                            },
              |                            {
@@ -569,6 +581,9 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 147.84
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Annual"
              |                                }
              |                            },
              |                            {
@@ -577,6 +592,9 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 108.81
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Annual"
              |                                }
              |                            },
              |                            {
@@ -585,6 +603,9 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
              |                                    "recurringFlatFee": {
              |                                        "listPrice": 108.81
              |                                    }
+             |                                },
+             |                                "billing": {
+             |                                    "billingPeriod": "Annual"
              |                                }
              |                            }
              |                        ]


### PR DESCRIPTION
Here we start specifying the billing period as additional attribute of the charge override. This will prevent a problem (production issue) we encountered with subscription whose billing period doesn't correspond to the equivalent product in the product catalogue (which was a problem because of the particular way we perform price rise amendments)

Super thanks to @graham228221 @rupertbates and @tomrf1 🙏