### PR TITLE
ZuoraCancellation

### DIFF
--- a/docs/the-journey-of-a-cohort-item.md
+++ b/docs/the-journey-of-a-cohort-item.md
@@ -182,6 +182,19 @@ CohortItem(
 
 Once the cohort item is in `Cancelled` state the engine will no longer touch it. Alike `AmendmentWrittenToSalesforce`, `Cancelled` is a final state for a cohort item.
 
+### ZuoraCancellation
+
+The processing stage `ZuoraCancellation` is used when the subscription has been cancelled in Zuora. Before August 2025, we used the `Cancelled` processing state with a `cancellationReason`.
+
+### Non standard processing stages
+
+The `Cancelled` processing stage in not the only processing stage a subscription can be put in when something goes wrong and the migration cannot pursue on it. Three other processing stages can be found in Dynamo table when Pascal investigates a failure from an handler. In such cases the item can be put manually in 
+- `EstimationFailed` (failure mode for `EstimationComplete`)
+- `NotificationSendFailed` (failure mode for `NotificationSendComplete`)
+- `AmendmentFailed` (failure mode for `AmendmentComplete`)
+
+The advantage of specifing the stage that was current when the failure happened helps recovering from the failure (when an attemps to do so is performed)
+
 ### Processing Lambdas
 
 The price migration engine define a state machine which is linear. The lambdas fire in a given linear order (ocassionaly the same lambda fires more than once) For reference here is the other in which the lambda fire 

--- a/docs/the-journey-of-a-cohort-item.md
+++ b/docs/the-journey-of-a-cohort-item.md
@@ -137,14 +137,6 @@ CohortItem(
 
 Then, the cohort item is going to.... sleep. It's going to sleep as long as it take for it to be at the start date minus about 40 days. This might take a few days or up to a year.
 
-### The Estimation Stage (part 3)
-
-I discovered during Newspaper2025P1 a curious behavior of some subscriptions. When one runs the Estimation step, they move from `ReadyForEstimation` to `EstimationFailed` (which doesn't cause an error in the engine -- maybe it should), but without any apparent reason. I initially thought there was an irregularity with the subs and that it would appear in tests by downloading the fixtures, but nothing came up. Turns out that moving the item back to `ReadyForEstimation` and running the Estimation handler again did work. This signals that there is transcient problem in Zuora which doesn't cause an error in the engine 🤔
-
-I managed to rescue a dozen subscriptions which had been incorrectly put in `EstimationFailed` except one: 344070.
-
-The same day, looking at HomeDelivery2025, I discovered that some items had ended up in EstimationFailed due to dirty data in Zuora, which this PR corrected: [https://github.com/guardian/price-migration-engine/pull/1180](https://github.com/guardian/price-migration-engine/pull/1180)
-
 ### Notification (part 1)
 
 In the case of migration SupporterPlus2024, the first operation is to check whether the item is under an active cancellation save. By definition, an "active" cancellation save is a cancellation save that was issued less than 6 months ago. If the item is found in that state, its processing stage become `DoNotProcessUntil` and the value of `doNotProcessUntil` is updated to become the effective date of the cancelation save plus 6 months.

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -1,7 +1,11 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.libs.AmendmentHelper
-import pricemigrationengine.model.CohortTableFilter.{Cancelled, NotificationSendDateWrittenToSalesforce}
+import pricemigrationengine.model.CohortTableFilter.{
+  Cancelled,
+  NotificationSendDateWrittenToSalesforce,
+  ZuoraCancellation
+}
 import pricemigrationengine.model._
 import pricemigrationengine.migrations._
 import pricemigrationengine.services._
@@ -34,21 +38,19 @@ object AmendmentHandler extends CohortHandler {
   ): ZIO[CohortTable with Zuora with Logging, Failure, AmendmentResult] =
     doAmendment(cohortSpec, catalogue, item).foldZIO(
       failure = {
-        case _: CancelledSubscriptionFailure => {
-          // `CancelledSubscriptionFailure` happens when the subscription was cancelled in Zuora
+        case _: SubscriptionCancelledInZuoraFailure => {
+          // This happens when the subscription was cancelled in Zuora
           // in which case we simply update the processing state for this item in the database
           // Although it was given to us as a failure of `doAmendment`, the only effect of the database update, if it
           // is not recorded as a failure of `amend`, is to allow the processing to continue.
-          val result = CancelledAmendmentResult(item.subscriptionName)
           CohortTable
             .update(
               CohortItem(
-                result.subscriptionNumber,
-                processingStage = Cancelled,
-                cancellationReason = Some("(cause: 99727bf9) subscription was cancelled in Zuora")
+                item.subscriptionName,
+                processingStage = ZuoraCancellation
               )
             )
-            .as(result)
+            .as(SubscriptionCancelledInZuoraAmendmentResult(item.subscriptionName))
         }
         case e: ZuoraUpdateFailure => {
           // We are only interested in the ZuoraUpdateFailures corresponding to message
@@ -70,7 +72,9 @@ object AmendmentHandler extends CohortHandler {
   private def fetchSubscription(item: CohortItem): ZIO[Zuora, Failure, ZuoraSubscription] =
     Zuora
       .fetchSubscription(item.subscriptionName)
-      .filterOrFail(_.status != "Cancelled")(CancelledSubscriptionFailure(item.subscriptionName))
+      .filterOrFail(_.status != "Cancelled")(
+        SubscriptionCancelledInZuoraFailure(s"subscription ${item.subscriptionName} has been cancelled in Zuora")
+      )
 
   private def renewSubscription(
       subscription: ZuoraSubscription,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -330,7 +330,7 @@ object AmendmentHandler extends CohortHandler {
       _ <-
         if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec) && (newPrice > estimatedNewPrice)) {
           ZIO.fail(
-            DataExtractionFailure(
+            AmendmentFailure(
               s"[e9054daa] Item ${item} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice}"
             )
           )

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -1,7 +1,7 @@
 package pricemigrationengine.handlers
 
 import pricemigrationengine.libs.AmendmentHelper
-import pricemigrationengine.model.CohortTableFilter.NotificationSendDateWrittenToSalesforce
+import pricemigrationengine.model.CohortTableFilter.{Cancelled, NotificationSendDateWrittenToSalesforce}
 import pricemigrationengine.model._
 import pricemigrationengine.migrations._
 import pricemigrationengine.services._
@@ -42,7 +42,11 @@ object AmendmentHandler extends CohortHandler {
           val result = CancelledAmendmentResult(item.subscriptionName)
           CohortTable
             .update(
-              CohortItem.fromCancelledAmendmentResult(result, "(cause: 99727bf9) subscription was cancelled in Zuora")
+              CohortItem(
+                result.subscriptionNumber,
+                processingStage = Cancelled,
+                cancellationReason = Some("(cause: 99727bf9) subscription was cancelled in Zuora")
+              )
             )
             .as(result)
         }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -46,13 +46,6 @@ object AmendmentHandler extends CohortHandler {
             )
             .as(result)
         }
-        case _: ExpiringSubscriptionFailure => {
-          // `ExpiringSubscriptionFailure` happens when the subscription's end of effective period is before the
-          // intended startDate (the price increase date). Alike `CancelledSubscriptionFailure` we cancel the amendment
-          // and the only effect is an updated cohort item in the database
-          val result = ExpiringSubscriptionResult(item.subscriptionName)
-          CohortTable.update(CohortItem.fromExpiringSubscriptionResult(result)).as(result)
-        }
         case e: ZuoraUpdateFailure => {
           // We are only interested in the ZuoraUpdateFailures corresponding to message
           // "Operation failed due to a lock competition"

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -75,9 +75,11 @@ object EstimationHandler extends CohortHandler {
           val result = CancelledEstimationResult(item.subscriptionName)
           CohortTable
             .update(
-              CohortItem.fromCancelledEstimationResult(
-                result,
-                s"(reason: b6829dd30) subscription ${item.subscriptionName} has been cancelled in Zuora"
+              CohortItem(
+                item.subscriptionName,
+                processingStage = Cancelled,
+                cancellationReason =
+                  Some(s"(reason: b6829dd30) subscription ${item.subscriptionName} has been cancelled in Zuora")
               )
             )
             .as(result)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -72,7 +72,7 @@ object EstimationHandler extends CohortHandler {
     doEstimation(catalogue, item, cohortSpec, today).foldZIO(
       failure = {
         case _: SubscriptionCancelledInZuoraFailure =>
-          val result = CancelledEstimationResult(item.subscriptionName)
+          val result = SubscriptionCancelledInZuoraEstimationResult(item.subscriptionName)
           CohortTable
             .update(
               CohortItem(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -118,7 +118,7 @@ object NotificationHandler extends CohortHandler {
         if (sfSubscription.Status__c != Cancelled_Status) {
           sendNotification(cohortSpec, cohortItem, sfSubscription)
         } else {
-          putSubIntoCancelledStatus(cohortSpec, cohortItem, Some("Item has been cancelled in Zuora"))
+          putSubIntoZuoraCancellationStatus(cohortSpec, cohortItem)
         }
     } yield ()
   }
@@ -526,10 +526,9 @@ object NotificationHandler extends CohortHandler {
     } yield ()
   }
 
-  def putSubIntoCancelledStatus(
+  def putSubIntoZuoraCancellationStatus(
       cohortSpec: CohortSpec,
-      cohortItem: CohortItem,
-      reason: Option[String]
+      cohortItem: CohortItem
   ): ZIO[Logging with SalesforceClient with CohortTable, Failure, Unit] = {
     for {
       _ <-
@@ -537,10 +536,14 @@ object NotificationHandler extends CohortHandler {
           .update(
             CohortItem(
               subscriptionName = cohortItem.subscriptionName,
-              processingStage = Cancelled
+              processingStage = ZuoraCancellation
             )
           )
-      _ <- notifySalesforceOfCancelledStatus(cohortSpec, cohortItem, reason)
+      _ <- notifySalesforceOfCancelledStatus(
+        cohortSpec,
+        cohortItem,
+        Some("Item has been cancelled in Zuora")
+      )
       _ <- Logging.error(
         s"Subscription ${cohortItem.subscriptionName} has been cancelled, price rise notification not sent"
       )

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
@@ -18,7 +18,7 @@ case class CancelledAmendmentResult(
     subscriptionNumber: String
 ) extends AmendmentResult
 
-case class ExpiringSubscriptionResult(
+case class SubscriptionCancelledInZuoraAmendmentResult(
     subscriptionNumber: String
 ) extends AmendmentResult
 

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
@@ -14,10 +14,6 @@ case class SuccessfulAmendmentResult(
     whenDone: Instant
 ) extends AmendmentResult
 
-case class CancelledAmendmentResult(
-    subscriptionNumber: String
-) extends AmendmentResult
-
 case class SubscriptionCancelledInZuoraAmendmentResult(
     subscriptionNumber: String
 ) extends AmendmentResult

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -68,9 +68,6 @@ object CohortItem {
   def fromNoPriceIncreaseEstimationResult(result: EstimationData): UIO[CohortItem] =
     fromSuccessfulEstimationResult(result).map(_.copy(processingStage = NoPriceIncrease))
 
-  def fromFailedEstimationResult(result: FailedEstimationResult): CohortItem =
-    CohortItem(result.subscriptionNumber, EstimationFailed)
-
   def fromCancelledEstimationResult(result: CancelledEstimationResult, reason: String): CohortItem =
     CohortItem(result.subscriptionNumber, processingStage = Cancelled, cancellationReason = Some(reason))
 

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -68,9 +68,6 @@ object CohortItem {
   def fromNoPriceIncreaseEstimationResult(result: EstimationData): UIO[CohortItem] =
     fromSuccessfulEstimationResult(result).map(_.copy(processingStage = NoPriceIncrease))
 
-  def fromCancelledEstimationResult(result: CancelledEstimationResult, reason: String): CohortItem =
-    CohortItem(result.subscriptionNumber, processingStage = Cancelled, cancellationReason = Some(reason))
-
   def fromSuccessfulAmendmentResult(result: SuccessfulAmendmentResult): CohortItem =
     CohortItem(
       result.subscriptionNumber,
@@ -79,13 +76,6 @@ object CohortItem {
       newPrice = Some(result.newPrice),
       newSubscriptionId = Some(result.newSubscriptionId),
       whenAmendmentDone = Some(result.whenDone)
-    )
-
-  def fromCancelledAmendmentResult(result: CancelledAmendmentResult, reason: String): CohortItem =
-    CohortItem(
-      result.subscriptionNumber,
-      processingStage = Cancelled,
-      cancellationReason = Some(reason)
     )
 
   def fromExpiringSubscriptionResult(result: ExpiringSubscriptionResult): CohortItem =

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -78,9 +78,6 @@ object CohortItem {
       whenAmendmentDone = Some(result.whenDone)
     )
 
-  def fromExpiringSubscriptionResult(result: ExpiringSubscriptionResult): CohortItem =
-    CohortItem(result.subscriptionNumber, Cancelled)
-
   def isProcessable(item: CohortItem, today: LocalDate): Boolean = {
     // This function return a boolean indicating whether the item is processable
     // defined as either doNotProcessUntil is None or is a date equal to today or in the past.

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -29,11 +29,11 @@ object CohortTableFilter {
     override val value: String = "AmendmentWrittenToSalesforce"
   }
 
-  /*
-   * Status of a sub that has been cancelled since the price migration process began, or has
-   * undergone some amendments in Zuora that are incompatible with the price rise.
-   * We mark it as ineligible for further processing.
-   */
+  case object ZuoraCancellation extends CohortTableFilter { override val value: String = "ZuoraCancellation" }
+
+  // General termination processing state. This is a terminal state for a cohort item
+  // It is used when the processing of a cohort items cannot pursue (for another reason than)
+  // the subscription having been cancelled in Zuora
   case object Cancelled extends CohortTableFilter { override val value: String = "Cancelled" }
 
   /*

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -44,14 +44,11 @@ object CohortTableFilter {
 
   // ++++++++++ Exceptional states ++++++++++
 
-  case object AmendmentFailed extends CohortTableFilter { override val value: String = "AmendmentFailed" }
-
   case object DoNotProcessUntil extends CohortTableFilter { override val value: String = "DoNotProcessUntil" }
 
   // Set of all states.  Remember to update when adding a state.
   val all: Set[CohortTableFilter] = Set(
     AmendmentComplete,
-    AmendmentFailed,
     AmendmentWrittenToSalesforce,
     Cancelled,
     EstimationComplete,

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -44,8 +44,6 @@ object CohortTableFilter {
 
   // ++++++++++ Exceptional states ++++++++++
 
-  case object EstimationFailed extends CohortTableFilter { override val value: String = "EstimationFailed" }
-
   case object AmendmentFailed extends CohortTableFilter { override val value: String = "AmendmentFailed" }
 
   case object DoNotProcessUntil extends CohortTableFilter { override val value: String = "DoNotProcessUntil" }
@@ -57,7 +55,6 @@ object CohortTableFilter {
     AmendmentWrittenToSalesforce,
     Cancelled,
     EstimationComplete,
-    EstimationFailed,
     NoPriceIncrease,
     NotificationSendComplete,
     NotificationSendDateWrittenToSalesforce,

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -42,14 +42,6 @@ object CohortTableFilter {
    */
   case object NoPriceIncrease extends CohortTableFilter { override val value: String = "NoPriceIncrease" }
 
-  /*
-   * Status of a sub where the estimation indicates a price rise of 20% or more,
-   * It was introduced during the Guardian Weekly price-rise that we would cap price-rises at 20%.
-   * We need to do more dev work to add ChargeOverrides to cap the price when adding the rate plan to Zuora,
-   * but we need to start the Cohort now, so are using this field temporarily to stop those subscriptions from being further processed.
-   */
-  case object CappedPriceIncrease extends CohortTableFilter { override val value: String = "CappedPriceIncrease" }
-
   // ++++++++++ Exceptional states ++++++++++
 
   case object EstimationFailed extends CohortTableFilter { override val value: String = "EstimationFailed" }
@@ -65,7 +57,6 @@ object CohortTableFilter {
     AmendmentWrittenToSalesforce,
     Cancelled,
     EstimationComplete,
-    CappedPriceIncrease,
     EstimationFailed,
     NoPriceIncrease,
     NotificationSendComplete,

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -17,10 +17,6 @@ case class EstimationData(
     billingPeriod: String
 ) extends EstimationResult
 
-case class FailedEstimationResult(subscriptionNumber: String, reason: String) extends EstimationResult
-
-case class CancelledEstimationResult(subscriptionNumber: String) extends EstimationResult
-
 object EstimationResult {
   def apply(
       account: ZuoraAccount,
@@ -43,3 +39,5 @@ object EstimationResult {
     )
   }
 }
+
+case class SubscriptionCancelledInZuoraEstimationResult(subscriptionNumber: String) extends EstimationResult

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -29,7 +29,8 @@ case class ZuoraUpdateFailure(reason: String) extends Failure
 case class ZuoraRenewalFailure(reason: String) extends Failure
 case class ZuoraOrderFailure(reason: String) extends Failure
 
-case class CancelledSubscriptionFailure(reason: String) extends Failure
+case class SubscriptionCancelledInZuoraFailure(reason: String) extends Failure
+
 case class RatePlansProbeFailure(reason: String) extends Failure
 
 case class SalesforcePriceRiseWriteFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -30,7 +30,6 @@ case class ZuoraRenewalFailure(reason: String) extends Failure
 case class ZuoraOrderFailure(reason: String) extends Failure
 
 case class CancelledSubscriptionFailure(reason: String) extends Failure
-case class ExpiringSubscriptionFailure(reason: String) extends Failure
 case class RatePlansProbeFailure(reason: String) extends Failure
 
 case class SalesforcePriceRiseWriteFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/model/NotificationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/NotificationResult.scala
@@ -1,0 +1,9 @@
+package pricemigrationengine.model
+
+import java.time.{Instant, LocalDate}
+
+trait NotificationResult
+
+case class CancelledNotificationResult(
+    subscriptionNumber: String
+) extends NotificationResult

--- a/lambda/src/main/scala/pricemigrationengine/model/NotificationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/NotificationResult.scala
@@ -1,9 +1,0 @@
-package pricemigrationengine.model
-
-import java.time.{Instant, LocalDate}
-
-trait NotificationResult
-
-case class CancelledNotificationResult(
-    subscriptionNumber: String
-) extends NotificationResult

--- a/lambda/src/test/scala/pricemigrationengine/migrations/HomeDelivery2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/HomeDelivery2025MigrationTest.scala
@@ -513,6 +513,8 @@ class HomeDelivery2025MigrationTest extends munit.FunSuite {
     // there was a problem with HomeDelivery2025Migration.decideDeliveryPattern due to a space in the subscription's
     // rate plan's ratePlanName. Which lead to https://github.com/guardian/price-migration-engine/pull/1180
 
+    // The `EstimationFailed` processing stage has been decommissioned
+
     val subscription =
       Fixtures.subscriptionFromJson("Migrations/HomeDelivery2025/A-S01588918-EstimationFailed/subscription.json")
     val account = Fixtures.accountFromJson("Migrations/HomeDelivery2025/A-S01588918-EstimationFailed/account.json")

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
@@ -523,7 +523,7 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
   }
 
   // The following subscription is interesting.
-  // I moves from ReadyForEstimation to EstimationFailed in AWS, and only AWS,
+  // It moves from ReadyForEstimation to EstimationFailed in AWS, and only AWS,
   // without any indication of what the cause might be.
   // It's the only subscription of Newspaper2025P1 with that behavior 🤔
 
@@ -534,6 +534,8 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
 
   test("priceData (344070-EstimationFailed)") {
     // Subscription fixture: 344070-EstimationFailed
+
+    // The `EstimationFailed` processing stage has been decommissioned
 
     val subscription =
       Fixtures.subscriptionFromJson("Migrations/Newspaper2025P1/344070-EstimationFailed/subscription.json")


### PR DESCRIPTION
In this change we introduce a new processing stage `ZuoraCancellation`, a more specific version of `Cancelled` and perform for light refactoring work about naming and documentation. 

The aim is to make it easier to mark cohort items in case of investigations and help with Zuora timeouts.

