### PR TITLE
Decommission migrationCompleteDate

### DIFF
--- a/docs/migration-implementation-manual.md
+++ b/docs/migration-implementation-manual.md
@@ -81,3 +81,14 @@ aws dynamodb scan --region eu-west-1 --table-name PriceMigration-PROD-GW2024 --s
 """
 
 If the table that you are downloading has more than 50,000 items, and you want all of them, just update that number.
+
+## When is a migration completed ?
+
+A migration is completed when every item of the cohort table is in either of the following processing stages:
+
+- `AmendmentWrittenToSalesforce`
+- `ZuoraCancellation`
+- `EstimationFailed`
+- `NotificationSendFailed`
+- `AmendmentFailed`
+- `Cancelled`

--- a/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
@@ -12,11 +12,10 @@ object MigrationHandler extends ZIOAppDefault with RequestHandler[Unit, Unit] {
 
   private val migrateActiveCohorts =
     (for {
-      today <- Clock.currentDateTime.map(_.toLocalDate)
       cohortSpecs <- CohortSpecTable.fetchAll
       activeSpecs <-
         ZIO
-          .filter(cohortSpecs)(cohort => ZIO.succeed(CohortSpec.isActive(cohort)(today)))
+          .filter(cohortSpecs)(cohort => ZIO.succeed(true)) // TODO: simplify this
           .tap(specs => Logging.info(s"Currently ${specs.size} active cohorts"))
       _ <- ZIO.foreachDiscard(activeSpecs)(CohortStateMachine.startExecution)
     } yield ()).tapError(e => Logging.error(s"Migration run failed: $e"))

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -18,14 +18,11 @@ import java.util
   * @param earliestPriceMigrationStartDate
   *   Earliest date on which any sub in the cohort can have price migrated. The actual date for any sub will depend on
   *   its billing dates.
-  * @param migrationCompleteDate
-  *   Date on which the final step in the price migration was complete for every sub in the cohort.
   */
 case class CohortSpec(
     cohortName: String,
     brazeName: String,
     earliestPriceMigrationStartDate: LocalDate,
-    migrationCompleteDate: Option[LocalDate] = None
 ) {
   val normalisedCohortName: String = cohortName.replaceAll(" ", "")
   def tableName(stage: String): String = s"PriceMigration-$stage-$normalisedCohortName"
@@ -34,9 +31,6 @@ case class CohortSpec(
 object CohortSpec {
 
   implicit val rw: ReadWriter[CohortSpec] = macroRW
-
-  def isActive(spec: CohortSpec)(date: LocalDate): Boolean =
-    spec.migrationCompleteDate.forall(_.isAfter(date))
 
   def isValid(spec: CohortSpec): Boolean = {
     def isValidStringValue(s: String) = s.trim == s && s.nonEmpty && s.matches("[A-Za-z0-9-_ ]+")
@@ -49,11 +43,9 @@ object CohortSpec {
       cohortName <- getStringFromResults(values, "cohortName")
       brazeName <- getStringFromResults(values, "brazeName")
       earliestPriceMigrationStartDate <- getDateFromResults(values, "earliestPriceMigrationStartDate")
-      migrationCompleteDate <- getOptionalDateFromResults(values, "migrationCompleteDate")
     } yield CohortSpec(
       cohortName,
       brazeName,
-      earliestPriceMigrationStartDate,
-      migrationCompleteDate
+      earliestPriceMigrationStartDate
     )).left.map(e => CohortSpecFetchFailure(e))
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -82,7 +82,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
     val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
 
     val cohortSpec: CohortSpec =
-      CohortSpec("cohortName", "brazeName", LocalDate.of(2022, 1, 1), None)
+      CohortSpec("cohortName", "brazeName", LocalDate.of(2022, 1, 1))
 
     val cohortItem = CohortItem(
       subscriptionName = subscriptionName,

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -8,35 +8,14 @@ import scala.jdk.CollectionConverters._
 
 class CohortSpecTest extends munit.FunSuite {
 
-  private val migrationCompleteDate = LocalDate.of(2020, 6, 18)
-
   private val cohortSpec = CohortSpec(
     cohortName = "Home Delivery 2018",
     brazeName = "cmp123",
-    earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 2),
-    migrationCompleteDate = None
+    earliestPriceMigrationStartDate = LocalDate.of(2020, 1, 2)
   )
 
   private def assertTrue(obtained: Boolean): Unit = assertEquals(obtained, true)
   private def assertFalse(obtained: Boolean): Unit = assertEquals(obtained, false)
-
-  private def isActive(onDay: LocalDate, migrationComplete: Option[LocalDate] = Some(migrationCompleteDate)) =
-    CohortSpec.isActive(
-      CohortSpec(
-        cohortName = "name",
-        brazeName = "cmp123",
-        earliestPriceMigrationStartDate = LocalDate.of(2021, 1, 1),
-        migrationComplete
-      )
-    )(onDay)
-
-  test("isActive: should be false when given date is on migration complete date") {
-    assertFalse(isActive(migrationCompleteDate))
-  }
-
-  test("isActive: should be false when given date is after migration complete date") {
-    assertFalse(isActive(migrationCompleteDate.plusDays(3)))
-  }
 
   test("tableName: should be transformed cohort name") {
     assertEquals(


### PR DESCRIPTION
The `CohortSpec` attribute `migrationCompleteDate` is not being used. 

Instead we read the cohort table to know the last migrationDate and check the distinct processing stages of the short table.