### PR TITLE
CohortSpec upgrade

### DIFF
--- a/docs/migration-implementation-manual.md
+++ b/docs/migration-implementation-manual.md
@@ -34,9 +34,11 @@ As part of setting up a migration you will want to run some of the lambdas on de
 
 The difference between the two is that the former is used to run specific lambdas and the latter used to run the state machine itself. They both carry the same information.
 
-* **cohortName**: A unique name to identify the cohort. Must consist of alphanumeric, whitespace, '-' and '_' characters.
+* **cohortName**: A unique name to identify the cohort. Must consist of alphanumeric, '-' and '_' characters (without space(s)). [1]
 * **brazeName**: The name that membership-workflow uses to refer to the Braze campaign or canvas for notifying subscribers. Must consist of alphanumeric, whitespace, '-' and '_' characters. This name is given to us by Marketing after they have set up the campaign or canvas in Braze.
 * **earliestPriceMigrationStartDate**: Earliest date on which a subscription can have its price increased. Increases will always begin on the first day of a billing period on or after this date. Format is `yyyy-mm-dd`.
+
+[1] Pascal always sticks to alphanumerical names, for instance "HomeDelivery2025" (where the year the migration has started appears in the name)
 
 ## Subscription numbers upload to the DynamoDB tables
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -19,9 +19,18 @@ object AmendmentHandler extends CohortHandler {
   private def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora, Failure, HandlerOutput] = {
     for {
       catalogue <- Zuora.fetchProductCatalogue
-      count <- CohortTable
-        .fetch(NotificationSendDateWrittenToSalesforce, None)
-        .take(batchSize)
+      count <- (
+        cohortSpec.subscriptionNumber match {
+          case None =>
+            CohortTable
+              .fetch(NotificationSendDateWrittenToSalesforce, None)
+              .take(batchSize)
+          case Some(subscriptionNumber) =>
+            CohortTable
+              .fetch(NotificationSendDateWrittenToSalesforce, None)
+              .filter(item => item.subscriptionName == subscriptionNumber)
+        }
+      )
         .mapZIO(item => amend(cohortSpec, catalogue, item).tapBoth(Logging.logFailure(item), Logging.logSuccess(item)))
         .runCount
     } yield HandlerOutput(isComplete = count < batchSize)

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandler.scala
@@ -18,7 +18,7 @@ object SubscriptionIdUploadHandler extends CohortHandler {
     ZIO.service[StageConfig] map { stageConfig =>
       S3Location(
         s"price-migration-engine-${stageConfig.stage.toLowerCase}",
-        s"${cohortSpec.normalisedCohortName}"
+        s"${cohortSpec.cohortName}"
       )
     }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -10,7 +10,7 @@ import java.util
 /** Specification of a cohort.
   *
   * @param cohortName
-  *   Name that uniquely identifies a cohort, eg. "Vouchers 2020"
+  *   Name that uniquely identifies a cohort, eg. "Vouchers2020"
   * @param brazeName
   *   Name of the Braze campaign, or Braze canvas for this cohort.
   *   Mapping to environment-specific Braze campaign ID is provided by membership-workflow:

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -18,11 +18,21 @@ import java.util
   * @param earliestPriceMigrationStartDate
   *   Earliest date on which any sub in the cohort can have price migrated. The actual date for any sub will depend on
   *   its billing dates.
+  * @param subscriptionNumber
+  *   subscriptionNumber is an optional attribute, which, when present, and in the correct context (eg:
+  *   estimation handler, notification handler and amendment handler) is going to cause the handler to run
+  *   on this one specified subscription, rather than a subset of the cohort table. Note that for security,
+  *   the handler must still verify that the item, if found, has the right processing stage for this particular
+  *   handler.
+  *
+  *   This attribute was added to CohortSpec in August 2025, to help with rescuing some print migration
+  *   cohort items causing timeouts in Zuora. This attribute is not intended to be used by the state machine.
   */
 case class CohortSpec(
     cohortName: String,
     brazeName: String,
     earliestPriceMigrationStartDate: LocalDate,
+    subscriptionNumber: Option[String] = None,
 ) {
   def tableName(stage: String): String = s"PriceMigration-${stage}-${cohortName}"
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -24,8 +24,7 @@ case class CohortSpec(
     brazeName: String,
     earliestPriceMigrationStartDate: LocalDate,
 ) {
-  val normalisedCohortName: String = cohortName.replaceAll(" ", "")
-  def tableName(stage: String): String = s"PriceMigration-$stage-$normalisedCohortName"
+  def tableName(stage: String): String = s"PriceMigration-${stage}-${cohortName}"
 }
 
 object CohortSpec {

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortStateMachineLive.scala
@@ -33,7 +33,7 @@ object CohortStateMachineLive {
                 stateMachine.startExecution(
                   StartExecutionRequest.builder
                     .stateMachineArn(config.stateMachineArn)
-                    .name(s"${spec.normalisedCohortName}-$timeStr")
+                    .name(s"${spec.cohortName}-$timeStr")
                     .input(write(StateMachineInput(spec)))
                     .build()
                 )

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -17,13 +17,6 @@ class CohortSpecTest extends munit.FunSuite {
   private def assertTrue(obtained: Boolean): Unit = assertEquals(obtained, true)
   private def assertFalse(obtained: Boolean): Unit = assertEquals(obtained, false)
 
-  test("tableName: should be transformed cohort name") {
-    assertEquals(
-      cohortSpec.tableName(stage = "PROD"),
-      "PriceMigration-PROD-HomeDelivery2018"
-    )
-  }
-
   test("fromDynamoDbItem: should include all fields") {
     val item = Map(
       "cohortName" -> AttributeValue.builder.s("Home Delivery 2018").build(),


### PR DESCRIPTION
Here we upgrade `CohortSpec` with a new optional attribute called `subscriptionNumber` which, when present, and in the correct context (eg: estimation handler, notification handler and amendment handler) is going to cause the handler to run on this one specified subscription, rather than a subset of the cohort table. Note that for security, the handler must still verify that the item, if found, has the right processing stage for this particular handler.
  
This attribute was added to CohortSpec in August 2025, to help with rescuing some print migration cohort items causing timeouts in Zuora. This attribute is not intended to be used by the state machine (it would not really make sense to do so).