### PR TITLE
Suspend amendment for print migrations

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -400,14 +400,26 @@ object AmendmentHandler extends CohortHandler {
   }
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
-    main(input).provideSome[Logging](
-      EnvConfig.cohortTable.layer,
-      EnvConfig.zuora.layer,
-      EnvConfig.stage.layer,
-      DynamoDBZIOLive.impl,
-      DynamoDBClientLive.impl,
-      CohortTableLive.impl(input),
-      ZuoraLive.impl
-    )
+    // Date: 14th August 2025
+    // Author: Pascal
+    // I am suspending the amendment handler for the print migrations.
+    // Instead, the process will be running using an asynchronous solution that
+    // we will be porting back to this codebase in the near future.
+    MigrationType(input) match {
+      case GuardianWeekly2025 => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025P1    => ZIO.succeed(HandlerOutput(isComplete = true))
+      case HomeDelivery2025   => ZIO.succeed(HandlerOutput(isComplete = true))
+      case Newspaper2025P3    => ZIO.succeed(HandlerOutput(isComplete = true))
+      case _ =>
+        main(input).provideSome[Logging](
+          EnvConfig.cohortTable.layer,
+          EnvConfig.zuora.layer,
+          EnvConfig.stage.layer,
+          DynamoDBZIOLive.impl,
+          DynamoDBClientLive.impl,
+          CohortTableLive.impl(input),
+          ZuoraLive.impl
+        )
+    }
   }
 }


### PR DESCRIPTION
I am suspending the amendment lambda for the print migration as it doesn't work well with some subscriptions which cause repeated errors (and alarms). 

Another process will be performing that function while we refactor the handler. 