### PR TITLE
ProductMigration2025N4 (Notifications)

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -372,7 +372,6 @@ object AmendmentHandler extends CohortHandler {
           priceCap,
           invoiceList
         )
-
       case ProductMigration2025N4 =>
         ProductMigration2025N4Migration.amendmentOrderPayload(
           cohortItem,
@@ -457,7 +456,6 @@ object AmendmentHandler extends CohortHandler {
             s"[2eecdf44] subscription: ${subscriptionBeforeUpdate.subscriptionNumber}, reason: ${e.reason}"
           )
         )
-
       _ <- Logging.info(
         s"[6e6da544] Amending subscription ${subscriptionBeforeUpdate.subscriptionNumber} with order ${order}"
       )

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -588,8 +588,13 @@ object NotificationHandler extends CohortHandler {
           bn <- ZIO.fromEither(SupporterPlus2024Migration.brazeName(subscription))
         } yield bn
       }
-      case ProductMigration2025N4 => ZIO.succeed(ProductMigration2025N4Migration.brazeName(item))
-      case _                      => ZIO.succeed(cohortSpec.brazeName)
+      case ProductMigration2025N4 =>
+        ZIO
+          .fromOption(ProductMigration2025N4Migration.brazeName(item))
+          .orElseFail(
+            DataExtractionFailure(s"[] could not determine brazeName for ProductMigration2025N4, item: ${item}")
+          )
+      case _ => ZIO.succeed(cohortSpec.brazeName)
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -36,7 +36,9 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
         ZIO
           .fromOption(item.salesforcePriceRiseId)
           .orElseFail(SalesforcePriceRiseWriteFailure("salesforcePriceRiseId is required to update Salesforce"))
-      // temporary, only to observe the values coming back from Salesforce
+      // [September 2025]
+      // Temporary, only to observe the values coming back from Salesforce
+      // as part of preparing for ProductMigration2025N4
       _ <- SalesforceClient.getPriceRise(salesforcePriceRiseId)
       _ <- SalesforceClient.updatePriceRise(salesforcePriceRiseId, priceRise)
       now <- Clock.instant

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandler.scala
@@ -4,7 +4,8 @@ import pricemigrationengine.migrations.{
   GuardianWeekly2025Migration,
   HomeDelivery2025Migration,
   Newspaper2025P1Migration,
-  Newspaper2025P3Migration
+  Newspaper2025P3Migration,
+  ProductMigration2025N4Migration
 }
 import pricemigrationengine.model.CohortTableFilter.{EstimationComplete, SalesforcePriceRiseCreationComplete}
 import pricemigrationengine.model._

--- a/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
@@ -18,11 +18,83 @@ object ProductMigration2025N4Migration {
   val maxLeadTime = 35
   val minLeadTime = 33
 
+  def decideFormstackUrl(salesforcePriceRiseId: String): String = {
+    s"https://guardiannewsandmedia.formstack.com/forms/print_migration_25?subscription_reference=${salesforcePriceRiseId}"
+  }
+
+  def getNotificationData(
+      cohortSpec: CohortSpec,
+      item: CohortItem
+  ): Option[ProductMigration2025N4NotificationData] = {
+    MigrationType(cohortSpec) match {
+      case ProductMigration2025N4 => {
+        for {
+          brandTitle <- item.ex_2025N4_label
+          salesforcePriceRiseId <- item.salesforcePriceRiseId
+          formstackUrl = decideFormstackUrl(salesforcePriceRiseId)
+        } yield ProductMigration2025N4NotificationData(
+          brandTitle,
+          formstackUrl
+        )
+      }
+      case _ =>
+        Some(
+          // For Tom reading this... Same as usual, I can't return a None
+          // and the case class cannot have its fields defined as Options :)
+          // #EmptyString ☺️
+          ProductMigration2025N4NotificationData(
+            "",
+            ""
+          )
+        )
+    }
+  }
+
+  def brazeName(cohortItem: CohortItem): String = {
+    /*
+      Canvas1: Newspaper+
+      Canvas ID: af95cae0-0d3a-46c4-90da-193764ecc87d
+      Canvas name:  SV_NP_DigitalMigrationNewspaperPlus_2025
+
+      Canvas2: Newspaper only
+      Canvas ID: dac04631-af52-46a3-94e1-082c2b38908d
+      Canvas name: SV_NP_DigitalMigrationNewspaperOnly_2025
+
+      Canvas3: Digi Subs
+      Canvas ID: 7c8445fe-e36a-4e50-b3d4-5090b1c3e314
+      Canvas name: SV_NP_DigitalMigrationDigitalSubs_2025
+     */
+    cohortItem.ex_2025N4_canvas.get match {
+      case "canvas1" => "SV_NP_DigitalMigrationNewspaperPlus_2025"
+      case "canvas2" => "SV_NP_DigitalMigrationNewspaperOnly_2025"
+      case "canvas3" => "SV_NP_DigitalMigrationDigitalSubs_2025"
+      case _         => throw new Exception("unexpected ProductMigration2025N4 cohort item canvas name")
+    }
+  }
+
+  // -----------------------------------------------------
+
   def priceData(
       subscription: ZuoraSubscription,
       invoiceList: ZuoraInvoiceList,
-      account: ZuoraAccount
-  ): Either[DataExtractionFailure, PriceData] = ???
+  ): Either[DataExtractionFailure, PriceData] = {
+    val priceDataOpt: Option[PriceData] = for {
+      ratePlan <- SI2025RateplanFromSubAndInvoices.determineRatePlan(subscription, invoiceList)
+      currency <- SI2025Extractions.determineCurrency(ratePlan)
+      oldPrice = SI2025Extractions.determineOldPrice(ratePlan)
+      billingPeriod <- SI2025Extractions.determineBillingPeriod(ratePlan)
+      newPrice = oldPrice
+    } yield PriceData(currency, oldPrice, newPrice, BillingPeriod.toString(billingPeriod))
+    priceDataOpt match {
+      case Some(pricedata) => Right(pricedata)
+      case None =>
+        Left(
+          DataExtractionFailure(
+            s"[9ac10338] Could not determine PriceData for subscription ${subscription.subscriptionNumber}"
+          )
+        )
+    }
+  }
 
   def amendmentOrderPayload(
       cohortItem: CohortItem,

--- a/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
@@ -62,7 +62,9 @@ object ProductMigration2025N4Migration {
 
       Canvas3: Digi Subs
       Canvas ID: 7c8445fe-e36a-4e50-b3d4-5090b1c3e314
-      Canvas name: SV_NP_DigitalMigrationDigitalSubs_2025
+      Canvas name:
+          (old) SV_NP_DigitalMigrationDigitalSubs_2025
+          (new) SV_NP_DigitalMigrationNewspaperOnlyNoOptOut_2025
      */
     for {
       canvas <- cohortItem.ex_2025N4_canvas
@@ -70,7 +72,7 @@ object ProductMigration2025N4Migration {
       canvas match {
         case "canvas1" => "SV_NP_DigitalMigrationNewspaperPlus_2025"
         case "canvas2" => "SV_NP_DigitalMigrationNewspaperOnly_2025"
-        case "canvas3" => "SV_NP_DigitalMigrationDigitalSubs_2025"
+        case "canvas3" => "SV_NP_DigitalMigrationNewspaperOnlyNoOptOut_2025"
         case _         => throw new Exception("unexpected ProductMigration2025N4 cohort item canvas name")
       }
     }

--- a/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
@@ -50,7 +50,7 @@ object ProductMigration2025N4Migration {
     }
   }
 
-  def brazeName(cohortItem: CohortItem): String = {
+  def brazeName(cohortItem: CohortItem): Option[String] = {
     /*
       Canvas1: Newspaper+
       Canvas ID: af95cae0-0d3a-46c4-90da-193764ecc87d
@@ -64,11 +64,15 @@ object ProductMigration2025N4Migration {
       Canvas ID: 7c8445fe-e36a-4e50-b3d4-5090b1c3e314
       Canvas name: SV_NP_DigitalMigrationDigitalSubs_2025
      */
-    cohortItem.ex_2025N4_canvas.get match {
-      case "canvas1" => "SV_NP_DigitalMigrationNewspaperPlus_2025"
-      case "canvas2" => "SV_NP_DigitalMigrationNewspaperOnly_2025"
-      case "canvas3" => "SV_NP_DigitalMigrationDigitalSubs_2025"
-      case _         => throw new Exception("unexpected ProductMigration2025N4 cohort item canvas name")
+    for {
+      canvas <- cohortItem.ex_2025N4_canvas
+    } yield {
+      canvas match {
+        case "canvas1" => "SV_NP_DigitalMigrationNewspaperPlus_2025"
+        case "canvas2" => "SV_NP_DigitalMigrationNewspaperOnly_2025"
+        case "canvas3" => "SV_NP_DigitalMigrationDigitalSubs_2025"
+        case _         => throw new Exception("unexpected ProductMigration2025N4 cohort item canvas name")
+      }
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -138,7 +138,7 @@ object AmendmentData {
       case Newspaper2025P1        => Newspaper2025P1Migration.priceData(subscription, invoiceList, account)
       case HomeDelivery2025       => HomeDelivery2025Migration.priceData(subscription, invoiceList, account)
       case Newspaper2025P3        => Newspaper2025P3Migration.priceData(subscription, invoiceList, account)
-      case ProductMigration2025N4 => ProductMigration2025N4Migration.priceData(subscription, invoiceList, account)
+      case ProductMigration2025N4 => ProductMigration2025N4Migration.priceData(subscription, invoiceList)
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/StartDates.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/StartDates.scala
@@ -122,17 +122,32 @@ object StartDates {
     }
 
     // We now respect the policy of not increasing members during their first year
-    val startDateLowerBound2 = noPriceRiseDuringSubscriptionFirstYearPolicyUpdate(startDateLowerBound1, subscription)
+    // This doesn't apply to ProductMigration2025N4 which is not a price rise
+    val startDateLowerBound2 = MigrationType(cohortSpec) match {
+      case ProductMigration2025N4 => startDateLowerBound1
+      case _ => noPriceRiseDuringSubscriptionFirstYearPolicyUpdate(startDateLowerBound1, subscription)
+    }
 
     // And the policy not to price rise a sub twice within 12 months of any possible price rise
-    val startDateLowerBound3 =
-      noPriceRiseWithinAYearOfLastPriceRisePolicyUpdate(cohortSpec, subscription, startDateLowerBound2)
+    // This doesn't apply to ProductMigration2025N4 which is not a price rise
+    val startDateLowerBound3 = MigrationType(cohortSpec) match {
+      case ProductMigration2025N4 => startDateLowerBound2
+      case _ => noPriceRiseWithinAYearOfLastPriceRisePolicyUpdate(cohortSpec, subscription, startDateLowerBound2)
+    }
 
     // With GuardianWeekly2025, we were given lower bounds in the Marketing spreadsheet
     // that was the first use of the new cohortItem's migrationExtraAttributes. If we expect a
     // migration to provide it own lowerbound computation, we do it here, otherwise we identity
     // on startDateLowerBound3
     val startDateLowerBound4 = MigrationType(cohortSpec) match {
+      // [1]
+      // Date: June 2025
+      // Author: Pascal
+      // (Comment group: ef77de28)
+      // Here I am re-using GuardianWeekly2025Migration.computeStartDateLowerBound4, for testing.
+      // Technically this test will break when GuardianWeekly2025 is decommissioned in October 2026,
+      // but at that point if we really want to carry on testing the migration extended attributes as
+      // part of start date computations we can move the code to Test1's own migration module
       case Test1 => GuardianWeekly2025Migration.computeStartDateLowerBound4(startDateLowerBound3, item) // [1]
       case SupporterPlus2024      => startDateLowerBound3
       case GuardianWeekly2025     => GuardianWeekly2025Migration.computeStartDateLowerBound4(startDateLowerBound3, item)
@@ -141,16 +156,6 @@ object StartDates {
       case Newspaper2025P3        => Newspaper2025P3Migration.computeStartDateLowerBound4(startDateLowerBound3, item)
       case ProductMigration2025N4 => startDateLowerBound3
     }
-
-    // [1]
-    // Date: June 2025
-    // Author: Pascal
-    // (Comment group: ef77de28)
-
-    // Here I am re-using GuardianWeekly2025Migration.computeStartDateLowerBound4, for testing it.
-    // Technically this test will break when GuardianWeekly2025 is decommissioned in October 2026,
-    // but at that point if we really want to carry on testing the migration extended attributes as
-    // part of start date computations we can move the code to Test1's own migration module
 
     // Decide the spread period for this migration
     val spreadPeriod = decideSpreadPeriod(subscription, invoicePreview, cohortSpec)

--- a/lambda/src/main/scala/pricemigrationengine/model/membershipworkflow/EmailMessage.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/membershipworkflow/EmailMessage.scala
@@ -26,19 +26,29 @@ case class EmailPayloadSubscriberAttributes(
     sp2024_contribution_amount: Option[String] = None,
     sp2024_previous_combined_amount: Option[String] = None,
     sp2024_new_combined_amount: Option[String] = None,
+    // -----------------------------------------------
 
     // -----------------------------------------------
     // Newspaper2025P1 (extension)
     // (Comment Group: 571dac68)
     newspaper2025_brand_title: Option[String] = None,
+    // -----------------------------------------------
 
     // -----------------------------------------------
     // HomeDelivery2025 (extension)
     homedelivery2025_brand_title: Option[String] = None,
+    // -----------------------------------------------
 
     // -----------------------------------------------
     // Newspaper2025P3 (extension)
     newspaper2025_phase3_brand_title: Option[String] = None,
+    // -----------------------------------------------
+
+    // -----------------------------------------------
+    // ProductMigration2025N4 (extension)
+    newspaper2025_phase4_brand_title: Option[String] = None,
+    newspaper2025_phase4_formstack_url: Option[String] = None,
+    // -----------------------------------------------
 )
 
 /*

--- a/lambda/src/test/scala/pricemigrationengine/migrations/ProductMigration2025N4MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/ProductMigration2025N4MigrationTest.scala
@@ -1,0 +1,13 @@
+package pricemigrationengine.migrations
+
+import pricemigrationengine.model.CohortTableFilter.ReadyForEstimation
+import pricemigrationengine.model._
+import pricemigrationengine.Fixtures
+
+import java.time.LocalDate
+
+class ProductMigration2025N4MigrationTest extends munit.FunSuite {
+  test("true") {
+    assertEquals(true, true)
+  }
+}


### PR DESCRIPTION
`ProductMigration2025N4` (Part 1).

This migration is novel because it will
1. Not be a price rise
2. Not perform the amendment step immediately after the notification, but only after a period of 30+ days
3. In the meantime the user can perform an action that is going to determine whether the amendment is going to happen or not. That action will update Salesforce and this explains our recent expansion of the Salesforce client (https://github.com/guardian/price-migration-engine/pull/1238 and https://github.com/guardian/price-migration-engine/pull/1241)
4. Uses 3 canvases, thereby breaking the record set by Supporter Plus last year.

This is only Part 1, because we are only encoding the notifications. The conditional amendments will come in Part 2.

