### PR TITLE
Correct priceCap lookup ups

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -296,7 +296,7 @@ object AmendmentHandler extends CohortHandler {
               zuora_subscription = subscriptionBeforeUpdate,
               oldPrice = oldPrice,
               estimatedNewPrice = estimatedNewPrice,
-              priceCap = Newspaper2025P1Migration.priceCap,
+              priceCap = HomeDelivery2025Migration.priceCap,
               invoiceList = invoicePreviewBeforeUpdate
             )
           )
@@ -311,7 +311,7 @@ object AmendmentHandler extends CohortHandler {
               zuora_subscription = subscriptionBeforeUpdate,
               oldPrice = oldPrice,
               estimatedNewPrice = estimatedNewPrice,
-              priceCap = Newspaper2025P1Migration.priceCap,
+              priceCap = Newspaper2025P3Migration.priceCap,
               invoiceList = invoicePreviewBeforeUpdate
             )
           )


### PR DESCRIPTION
Correct price cap look ups for HomeDelivery2025 and Newspaper2025P3.

(They are all equal to 1.20 so this wasn't technically a bug, but still good to correct.)