### PR TITLE
Extend CohortItems - Part 1: new attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It currently consists in
     - [Downloading fixtures](docs/downloading-fixtures.md)
     - [Notes on the Zuora Order API](docs/zuora-order-api.md)
     - [Communication with braze](docs/communication-with-braze.md)
-    - [Extending cohort items](docs/extending-CohortItem.md)
+    - [Cohort Items](docs/cohort-item.md)
     - [Troubleshooting document](docs/troubleshooting.md)
 
 - Android Price Rises

--- a/docs/cohort-item.md
+++ b/docs/cohort-item.md
@@ -1,0 +1,5 @@
+
+## Extending CohortItem
+
+When you extend CohortItem, do not forget to [map the dynamo record to the Scala type](https://github.com/guardian/price-migration-engine/pull/1158). It's not done automatically.
+

--- a/docs/extending-CohortItem.md
+++ b/docs/extending-CohortItem.md
@@ -1,5 +1,0 @@
-
-## Extending CohortItem
-
-With the [introduction of migrationExtraAttributes](https://github.com/guardian/price-migration-engine/pull/1139), I do not expect `CohortItem`s to be extended any time soon, but if you do, do not forget to [map the dynamo record to the Scala type](https://github.com/guardian/price-migration-engine/pull/1158). It's not done automatically.
-

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -25,6 +25,12 @@ case class CohortItem(
     cancellationReason: Option[String] = None,
     doNotProcessUntil: Option[LocalDate] = None, // [18]
     migrationExtraAttributes: Option[String] = None, // [19]
+    extendedAttribute1: Option[String] = None, // [20]
+    extendedAttribute2: Option[String] = None,
+    extendedAttribute3: Option[String] = None,
+    extendedAttribute4: Option[String] = None,
+    extendedAttribute5: Option[String] = None,
+    extendedAttribute6: Option[String] = None,
 )
 
 // [18]
@@ -48,6 +54,14 @@ case class CohortItem(
 // Guardian Weekly 2025 migration), for if and when we need to perform
 // operations using parameters that are not hold into the Zuora subscription.
 // For more details about when and how to use that attribute, see the documentation.
+
+// [20]
+//
+// Date: August 2025
+// Author: Pascal
+// Comment: extendedAttributes 1 to 6 were introduced to support migration
+// specific functionalities as a replacement of migrationExtraAttributes.
+// See docs/cohort-item.md for details.
 
 object CohortItem {
 

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -40,6 +40,12 @@ object CohortTableLive {
             getOptionalStringFromResults(cohortItem, "cancellationReason")
           doNotProcessUntil <- getOptionalDateFromResults(cohortItem, "doNotProcessUntil")
           migrationExtraAttributes <- getOptionalStringFromResults(cohortItem, "migrationExtraAttributes")
+          extendedAttribute1 <- getOptionalStringFromResults(cohortItem, "extendedAttribute1")
+          extendedAttribute2 <- getOptionalStringFromResults(cohortItem, "extendedAttribute2")
+          extendedAttribute3 <- getOptionalStringFromResults(cohortItem, "extendedAttribute3")
+          extendedAttribute4 <- getOptionalStringFromResults(cohortItem, "extendedAttribute4")
+          extendedAttribute5 <- getOptionalStringFromResults(cohortItem, "extendedAttribute5")
+          extendedAttribute6 <- getOptionalStringFromResults(cohortItem, "extendedAttribute6")
         } yield CohortItem(
           subscriptionName = subscriptionNumber,
           processingStage = processingStage,
@@ -58,7 +64,13 @@ object CohortTableLive {
           whenNotificationSentWrittenToSalesforce = whenNotificationSentWrittenToSalesforce,
           cancellationReason = cancellationReason,
           doNotProcessUntil = doNotProcessUntil,
-          migrationExtraAttributes = migrationExtraAttributes
+          migrationExtraAttributes = migrationExtraAttributes,
+          extendedAttribute1 = extendedAttribute1,
+          extendedAttribute2 = extendedAttribute2,
+          extendedAttribute3 = extendedAttribute3,
+          extendedAttribute4 = extendedAttribute4,
+          extendedAttribute5 = extendedAttribute5,
+          extendedAttribute6 = extendedAttribute6,
         )
       )
       .mapError(e => DynamoDBZIOError(e))
@@ -101,6 +113,12 @@ object CohortTableLive {
         cohortItem.cancellationReason.map(reason => stringFieldUpdate("cancellationReason", reason)),
         cohortItem.doNotProcessUntil.map(date => dateFieldUpdate("doNotProcessUntil", date)),
         cohortItem.migrationExtraAttributes.map(extra => stringFieldUpdate("migrationExtraAttributes", extra)),
+        cohortItem.extendedAttribute1.map(extra => stringFieldUpdate("extendedAttribute1", extra)),
+        cohortItem.extendedAttribute2.map(extra => stringFieldUpdate("extendedAttribute2", extra)),
+        cohortItem.extendedAttribute3.map(extra => stringFieldUpdate("extendedAttribute3", extra)),
+        cohortItem.extendedAttribute4.map(extra => stringFieldUpdate("extendedAttribute4", extra)),
+        cohortItem.extendedAttribute5.map(extra => stringFieldUpdate("extendedAttribute5", extra)),
+        cohortItem.extendedAttribute6.map(extra => stringFieldUpdate("extendedAttribute6", extra)),
       ).flatten.toMap.asJava
 
   private implicit val cohortTableKeySerialiser: DynamoDBSerialiser[CohortTableKey] =


### PR DESCRIPTION
Earlier this year, we introduced to encode migration specific attributes, to support migration specific features, as a serialized json object stored in the field of a Dynamo table. This has worked very well, and as a prelude to ProductMigration2025N4, we refactor that scheme by introducing new attributes that we are going to use to unfold the json objects. This will make cohort items much easier to use as we extend their capabilities.

This is the first of three changes. In change 2 we are going to refactor (unfold) the current print migrations `migrationExtraAttributes` into the new flat attributes. In change 3 we are going to decommission `migrationExtraAttributes`.