### PR TITLE
Upgrade signature of ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
@@ -236,6 +236,7 @@ object HomeDelivery2025Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
+            estimatedNewPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
@@ -261,6 +262,7 @@ object HomeDelivery2025Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
+            estimatedNewPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
@@ -278,6 +278,7 @@ object Newspaper2025P1Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
+            estimatedNewPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
@@ -303,6 +304,7 @@ object Newspaper2025P1Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
+            estimatedNewPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -249,6 +249,7 @@ object Newspaper2025P3Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
+            estimatedNewPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
@@ -274,6 +275,7 @@ object Newspaper2025P3Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
+            estimatedNewPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
@@ -666,7 +666,7 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                "productRatePlanChargeId": "2c92a0ff56fe33f5015709cdedbd246b",
              |                                "pricing": {
              |                                    "recurringFlatFee": {
-             |                                        "listPrice": 11.54
+             |                                        "listPrice": 22.56
              |                                    }
              |                                },
              |                                "billing": {
@@ -876,7 +876,7 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
              |                                "productRatePlanChargeId": "2c92a0ff56fe33f5015709cce7ad1aea",
              |                                "pricing": {
              |                                    "recurringFlatFee": {
-             |                                        "listPrice": 10.85
+             |                                        "listPrice": 11.54
              |                                    }
              |                                },
              |                                "billing": {

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
@@ -534,7 +534,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
              |                                "productRatePlanChargeId": "2c92a0ff56fe33f5015709c39719783e",
              |                                "pricing": {
              |                                    "recurringFlatFee": {
-             |                                        "listPrice": 147.97
+             |                                        "listPrice": 147.99
              |                                    }
              |                                },
              |                                "billing": {

--- a/lambda/src/test/scala/pricemigrationengine/model/ZuoraOrdersApiPrimitivesTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/ZuoraOrdersApiPrimitivesTest.scala
@@ -501,7 +501,8 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
 
     val json = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
       ratePlan.ratePlanCharges,
-      BigDecimal(1.5),
+      BigDecimal(1.5), // price increase ratio
+      BigDecimal(88.47), // target price (aka: estimated new price)
       "Month"
     )
 
@@ -514,7 +515,7 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |        "productRatePlanChargeId": "2c92a0ff56fe33f5015709cdedbd246b",
         |        "pricing": {
         |            "recurringFlatFee": {
-        |                "listPrice": 13.44
+        |                "listPrice": 13.43
         |            }
         |        },
         |        "billing": {
@@ -589,6 +590,10 @@ class ZuoraOrdersAPIPrimitivesTest extends munit.FunSuite {
         |    }
         |]""".stripMargin
     )
+
+    // We can then perform a manual check that the sum of prices is indeed equal
+    // to the estimated new prices:
+    // 88.47 = 13.43 + 3 + 13.44 + 18.28 + 13.44 + 13.44 + 13.44
   }
 
   test("ZuoraOrdersApiPrimitives.subscriptionRenewalPayload") {


### PR DESCRIPTION
Context: Newspaper2025P1, HomeDelivery2025 and Newspaper2025P3

As part of the operations of the Amendment handler, the function `ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides` generates charge overrides that correspond to the total estimated new price. 

Each individual price charge is a multiplicative increase of the old price that is then rounded to precision 0.01. Sadly this means that floating point errors can then accumulate to the total price of the amended subscription, which then can be a few pennies less than the originally estimated price rise. This was not detected by the post amendment price check which only checks that the new price is not higher than the estimated new price. [1]

Here we update `ratePlanChargesToChargeOverrides` as follow:
- The target price, the estimated new price is passed to the function
- We ensure (possibly performing price adjustment) that the total prices of the charge overrides is exactly the value that was passed. When an adjustment is needed it is carried by the first leg, that was an arbitrary choice. 

[1] A reenforced price check was released as a companion PR here: https://github.com/guardian/price-migration-engine/pull/1234 