### PR TITLE
strengthen the post amendment price check

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -417,7 +417,7 @@ object AmendmentHandler extends CohortHandler {
         )
 
       _ <-
-        if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec) && (newPrice != estimatedNewPrice)) {
+        if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec) && (estimatedNewPrice - newPrice).abs > 0.001) {
           ZIO.fail(
             AmendmentFailure(
               s"[e9054daa] Item ${item} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice}"


### PR DESCRIPTION
Traditionally the engine has been tolerating of final prices that are a penny (or cent) lower than the estimated new price. Here we make that check stronger and require equality. This might cause the engine to fail in situation Zuora would perform float operations different of that of the engine, but we will investigate every such case and update the migration code accordingly. 

Note that this is a companion PR of: https://github.com/guardian/price-migration-engine/pull/1233

Update:

Discounts on a subscription do not play well with the price post amendment, and the equality check will fail when that happens. The next time it happens I will check the sub for active discounts and will then update the code to behave as follows:
- If the post amendment sub doesn't have discounts, then perform the price equality test.
- If the post amendment sub has discounts then perform the inequality test.