### PR TITLE
strengthen the post amendment price check (part 2)

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlan.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraRatePlan.scala
@@ -26,12 +26,11 @@ object ZuoraRatePlan {
     } yield BillingPeriod.fromString(billingPeriod)
   }
 
-  // Sadly `lastChangeType` is not always defined on all rate plans. The situation is:
-  //     - Not defined                    -> Active rate plan
-  //     - Defined and value is "Add"     -> Active rate plan
-  //     - Defined and value is "Remove"  -> Non active rate plan
-
   def ratePlanIsActive(ratePlan: ZuoraRatePlan): Boolean = {
+    // `lastChangeType` is not always defined on all rate plans. The situation is:
+    //     - Not defined                    -> Active rate plan
+    //     - Defined and value is "Add"     -> Active rate plan
+    //     - Defined and value is "Remove"  -> Non active rate plan
     !ratePlan.lastChangeType.contains("Remove")
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/model/SubscriptionIntrospection2025Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/SubscriptionIntrospection2025Test.scala
@@ -549,6 +549,24 @@ class SI2025ExtractionsTest extends munit.FunSuite {
     )
   }
 
+  test("SI2025Extractions.subscriptionHasActiveDiscounts (no discounts)") {
+    val subscription =
+      Fixtures.subscriptionFromJson("model/SubscriptionIntrospection2025/subscription1/subscription.json")
+    assertEquals(
+      SI2025Extractions.subscriptionHasActiveDiscounts(subscription),
+      false
+    )
+  }
+
+  test("SI2025Extractions.subscriptionHasActiveDiscounts (discounts)") {
+    val subscription =
+      Fixtures.subscriptionFromJson("model/SubscriptionIntrospection2025/subscription3-with-discount/subscription.json")
+    assertEquals(
+      SI2025Extractions.subscriptionHasActiveDiscounts(subscription),
+      true
+    )
+  }
+
   // ----------------------------------------------------
   // SI2025Templates
   // ----------------------------------------------------


### PR DESCRIPTION
When we did Part 1 of this upgrade of the post amendment price check, we said that there would be a follow up the first time the check fails not because of incorrect pricing but because of the presence of discounts on the subscription. It has happened this morning.

Here we perform the upgrade 