### PR TITLE
Ph 20250922 1759 salesforce opt out

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -36,6 +36,7 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
         ZIO
           .fromOption(item.salesforcePriceRiseId)
           .orElseFail(SalesforcePriceRiseWriteFailure("salesforcePriceRiseId is required to update Salesforce"))
+      _ <- SalesforceClient.getPriceRise(salesforcePriceRiseId)
       _ <- SalesforceClient.updatePriceRise(salesforcePriceRiseId, priceRise)
       now <- Clock.instant
       _ <-

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -36,6 +36,7 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
         ZIO
           .fromOption(item.salesforcePriceRiseId)
           .orElseFail(SalesforcePriceRiseWriteFailure("salesforcePriceRiseId is required to update Salesforce"))
+      // temporary, only to observe the values coming back from Salesforce
       _ <- SalesforceClient.getPriceRise(salesforcePriceRiseId)
       _ <- SalesforceClient.updatePriceRise(salesforcePriceRiseId, priceRise)
       now <- Clock.instant

--- a/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SalesforcePriceRise.scala
@@ -2,6 +2,42 @@ package pricemigrationengine.model
 
 import java.time.LocalDate
 
+/*
+  Example of a SalesforcePriceRise [22nd Sept 2025] (sanitized)
+
+  {
+    "attributes": {
+        "type": "Price_Rise__c",
+        "url": "/services/data/v64.0/sobjects/Price_Rise__c/260c802f9bdf"
+    },
+    "Id": "260c802f9bdf",
+    "OwnerId": "6c88ca6ae12d",
+    "IsDeleted": false,
+    "Name": "00784b8c",
+    "CreatedDate": "2019-02-27T14:51:50.000+0000",
+    "CreatedById": "6c88ca6ae12d",
+    "LastModifiedDate": "2025-08-04T11:09:17.000+0000",
+    "LastModifiedById": "03d339ceb533",
+    "SystemModstamp": "2025-08-04T11:09:17.000+0000",
+    "LastViewedDate": null,
+    "LastReferencedDate": null,
+    "Buyer__c": "c13e8789316b",
+    "Current_Price_Today__c": 30,
+    "Date_Letter_Sent__c": "2019-02-04",
+    "File_Name__c": "ad76eb4ea4a3",
+    "Guardian_Weekly_New_Price__c": 37.5,
+    "Price_Rise_Date__c": "2019-04-07",
+    "SF_Subscription__c": "715e519d26a4",
+    "Increase__c": 25,
+    "Amended_Zuora_Subscription_Id__c": null,
+    "Cancellation_Reason__c": null,
+    "Migration_Name__c": null,
+    "Migration_Status__c": null,
+    "Status__c": null,
+    "Customer_Opt_Out__c": true
+}
+ */
+
 case class SalesforcePriceRise(
     Name: Option[String] = None,
     Buyer__c: Option[String] = None,
@@ -13,7 +49,8 @@ case class SalesforcePriceRise(
     Amended_Zuora_Subscription_Id__c: Option[ZuoraSubscriptionId] = None,
     Migration_Name__c: Option[String],
     Migration_Status__c: Option[String], // [1]
-    Cancellation_Reason__c: Option[String]
+    Cancellation_Reason__c: Option[String],
+    Customer_Opt_Out__c: Option[Boolean] = None // [2]
 )
 
 // [1] The processing state of the cohort item at time of salesforce notification
@@ -22,3 +59,8 @@ case class SalesforcePriceRise(
 // Note that Cancellation_Reason__c should remain withing 255 chars. This is a limitation
 // imposed by Salesforce which came during the initial
 // integration: https://github.com/guardian/salesforce/pull/976
+
+// [2] The Customer_Opt_Out__c attribute was added in September 2025 as part of the
+// product migration: ProductMigration2025N4. Users who have read the communication
+// and want to opt out will interact with a formstack page and trigger Salesforce
+// to set that attribute to `true`.

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClient.scala
@@ -17,6 +17,7 @@ trait SalesforceClient {
       priceRise: SalesforcePriceRise
   ): IO[SalesforceClientFailure, SalesforcePriceRiseCreationResponse]
   def updatePriceRise(priceRiseId: String, priceRise: SalesforcePriceRise): IO[SalesforceClientFailure, Unit]
+  def getPriceRise(priceRiseId: String): IO[SalesforceClientFailure, SalesforcePriceRise]
 }
 
 object SalesforceClient {
@@ -41,4 +42,9 @@ object SalesforceClient {
       priceRise: SalesforcePriceRise
   ): ZIO[SalesforceClient, SalesforceClientFailure, Unit] =
     ZIO.environmentWithZIO(_.get.updatePriceRise(priceRiseId, priceRise))
+
+  def getPriceRise(
+      priceRiseId: String
+  ): ZIO[SalesforceClient, SalesforceClientFailure, SalesforcePriceRise] =
+    ZIO.environmentWithZIO(_.get.getPriceRise(priceRiseId))
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/SalesforceClientLive.scala
@@ -124,7 +124,19 @@ object SalesforceClientLive {
               .header("Authorization", s"Bearer ${auth.access_token}")
               .header("Content-Type", "application/json")
           ).unit
-        } <* logging.info(s"Successfully updated Price_Rise__c object: $priceRiseId")
+        } <* logging.info(s"Successfully updated Price_Rise__c object, priceRiseId: ${priceRiseId}")
+
+        override def getPriceRise(priceRiseId: String): IO[SalesforceClientFailure, SalesforcePriceRise] =
+          sendRequestAndParseResponse[SalesforcePriceRise](
+            Http(s"${auth.instance_url}/${salesforceApiPathPrefixToVersion}/sobjects/Price_Rise__c/${priceRiseId}")
+              .header("Authorization", s"Bearer ${auth.access_token}")
+              .method("GET")
+          ).tap(priceRise =>
+            logging.info(
+              s"Successfully retrieved Salesforce price rise object, priceRiseId: ${priceRiseId}, priceRise: ${priceRise}"
+            )
+          )
+
       }
     }
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -71,6 +71,10 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
         override def getContact(
             contactId: String
         ): IO[SalesforceClientFailure, SalesforceContact] = ???
+
+        override def getPriceRise(
+            priceRiseId: String
+        ): IO[SalesforceClientFailure, SalesforcePriceRise] = ???
       }
     )
   }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforcePriceRiseCreationHandlerTest.scala
@@ -95,6 +95,10 @@ class SalesforcePriceRiseCreationHandlerTest extends munit.FunSuite {
         override def getContact(
             contactId: String
         ): IO[SalesforceClientFailure, SalesforceContact] = ???
+
+        override def getPriceRise(
+            priceRiseId: String
+        ): IO[SalesforceClientFailure, SalesforcePriceRise] = ???
       }
     )
   }


### PR DESCRIPTION
Migration ProductMigration2025N4 is going to use a new attribute of `SalesforcePriceRise`, which itself needs to be retrieved from Salesforce. @graham228221 did the work of upgrading Salesforce, and here we

1.  Upgrade `SalesforcePriceRise` with `Customer_Opt_Out__c`

2. Update `SalesforceClient` with `getPriceRise(priceRiseId: String): IO[SalesforceClientFailure, SalesforcePriceRise]`

3. Temporarily update SalesforceAmendmentUpdateHandler.scala, to call this new end point.