### PR TITLE
better post amendment price check

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentHelper.scala
@@ -12,4 +12,21 @@ object AmendmentHelper {
       billingPeriodAfterUpdate <- SI2025Extractions.determineBillingPeriod(ratePlan)
     } yield billingPeriodReference == BillingPeriod.toString(billingPeriodAfterUpdate)
   }
+
+  def priceEquality(float1: BigDecimal, float2: BigDecimal): Boolean = {
+    (float1 - float2).abs < 0.001
+  }
+
+  def newPriceHasBeenCappedAt20Percent(oldPrice: BigDecimal, newPrice: BigDecimal): Boolean = {
+    // This function takes a oldPrice (assumed from the cohort item) and a new price (assumed
+    // from Zuora post amendment) and return true if the newPrice appears to have been capped at +20%
+
+    // Note: This is Phase 1 of a solution to prevent unnecessarily alarming when a subscription has been
+    // capped and the cohort item estimated newPrice (which didn't carry the capping) is not equal to
+    // post amendment price. In Phase 2 we are going to expand the standard cohort item to add the
+    // capped price (the price that as put into the comms). Phase 2 will come shortly.
+
+    priceEquality(oldPrice * 1.2, newPrice)
+  }
+
 }


### PR DESCRIPTION
Previously, in [post amendment price check]: https://github.com/guardian/price-migration-engine/pull/1237

In this episode:

I have noticed three subscriptions which are failing the post amendment price check because of a form of discount that the current check is not considering: the price cap (at 20%). Here we update the check. 

Note: This is Phase 1 of a solution to prevent unnecessarily alarming when a subscription has been capped and the cohort item `estimatedNewPrice` (which doesn't carry the capping) is not equal to post amendment `newPrice`. In Phase 2 we are going to expand the standard cohort item to add the capped price (the price that as put into the comms). Phase 2 will come shortly.