### PR TITLE
[android-price-rise] decommission node-fetch which is not being used

### DIFF
--- a/android-price-rise/package.json
+++ b/android-price-rise/package.json
@@ -32,7 +32,6 @@
     "@types/node": "^22.12.0",
     "aws-sdk": "^2.1692.0",
     "jsonwebtoken": "^9.0.2",
-    "node-fetch": "2.6.7",
     "source-map-support": "^0.5.21",
     "typed-rest-client": "^2.1.0",
     "zod": "^3.24.1"

--- a/android-price-rise/yarn.lock
+++ b/android-price-rise/yarn.lock
@@ -1711,7 +1711,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^2.3.1, braces@^3.0.3:
+braces@3.0.3, braces@^2.3.1, braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -4573,13 +4573,6 @@ njwt@^2.0.1:
     "@types/node" "^15.0.1"
     ecdsa-sig-formatter "^1.0.5"
     uuid "^8.3.2"
-
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
 
 node-fetch@^2.6.9:
   version "2.7.0"


### PR DESCRIPTION
Address security warning: https://github.com/guardian/price-migration-engine/security/dependabot/12

By removing node-fetch which is actually not being used. 

 