### PR TITLE
rename: earliestPriceMigrationStartDate -> earliestAmendmentEffectiveDate

### DIFF
--- a/docs/lambdas-code-structure.md
+++ b/docs/lambdas-code-structure.md
@@ -54,7 +54,7 @@ Individual lambdas like the `EstimationLambda` and the `AmendmentLambda` can be 
 {
   "cohortName": "EchoLegacyTesting",
   "brazeName": "cmp123",
-  "earliestAmendmentEffectDate": "2022-08-02"
+  "earliestAmendmentEffectiveDate": "2022-08-02"
 }
 ```
 

--- a/docs/migration-implementation-manual.md
+++ b/docs/migration-implementation-manual.md
@@ -20,14 +20,14 @@ As part of setting up a migration you will want to run some of the lambdas on de
 {
     "cohortName":"GW2024",
     "brazeName":"SV_GW_PriceRise2024Email",
-    "earliestAmendmentEffectDate":"2024-05-20"
+    "earliestAmendmentEffectiveDate":"2024-05-20"
 }
 
 {
     "cohortSpec": {
         "cohortName":"GW2024",
         "brazeName":"SV_GW_PriceRise2024Email",
-        "earliestAmendmentEffectDate":"2024-05-20"
+        "earliestAmendmentEffectiveDate":"2024-05-20"
     }
 }
 ```
@@ -36,7 +36,7 @@ The difference between the two is that the former is used to run specific lambda
 
 * **cohortName**: A unique name to identify the cohort. Must consist of alphanumeric, '-' and '_' characters (without space(s)). [1]
 * **brazeName**: The name that membership-workflow uses to refer to the Braze campaign or canvas for notifying subscribers. Must consist of alphanumeric, whitespace, '-' and '_' characters. This name is given to us by Marketing after they have set up the campaign or canvas in Braze.
-* **earliestAmendmentEffectDate**: Earliest date on which a subscription can have its price increased, or will move to another rate plan (with or without price increase). Increases will always begin on the first day of a billing period on or after this date. Format is `yyyy-mm-dd`.
+* **earliestAmendmentEffectiveDate**: Earliest date on which a subscription can have its price increased, or will move to another rate plan (with or without price increase). Increases will always begin on the first day of a billing period on or after this date. Format is `yyyy-mm-dd`.
 
 [1] Pascal always sticks to alphanumerical names, for instance "HomeDelivery2025" (where the year the migration has started appears in the name)
 

--- a/docs/start-date-computation.md
+++ b/docs/start-date-computation.md
@@ -16,11 +16,11 @@ First we need a cohort spec. Let's assume that the cohort spec is
 {
     "cohortName":"GW2024",
     "brazeName":"SV_GW_PriceRise2024",
-    "earliestAmendmentEffectDate":"2024-05-20" 
+    "earliestAmendmentEffectiveDate":"2024-05-20" 
 }
 ```
 
-The only relevant bit of cohort spec we need for the computation of a subscription's start date is the `earliestAmendmentEffectDate`. 
+The only relevant bit of cohort spec we need for the computation of a subscription's start date is the `earliestAmendmentEffectiveDate`. 
 
 Let us assume thay the notification period for this migration is `[-49, -36]`. This is Pascal's notation for the fact that we start notifying at -49 days and alarm at -36.
 
@@ -52,7 +52,7 @@ If we have a lot of monthlies to migrate, that's a lot of user notifications per
 
 With the above context and the explanation about spread periods, let's compute the start date of our subscription.
 
-Step 1: We know that the chosen date needs to be after the cohort spec's `earliestAmendmentEffectDate`, meaning after `2024-05-20`. The date `2024-05-20` is our first lowerbound.
+Step 1: We know that the chosen date needs to be after the cohort spec's `earliestAmendmentEffectiveDate`, meaning after `2024-05-20`. The date `2024-05-20` is our first lowerbound.
 
 Step 2: We know that the date needs to be after today plus the end of a notification period (otherwise the engine will alarm immediately). Remember we are using `2024-03-07` as "today". The notification period is `[-49, -36]`, so there should be at least 37 days between today and the chosen date. This means thay we have a lowerbound at `today + 37 days`, meaning `2024-03-07 + 37 days`, meaning `2024-04-13` (13th of April).
 

--- a/docs/subscription-numbers-upload.md
+++ b/docs/subscription-numbers-upload.md
@@ -38,7 +38,7 @@ Do not forget to set the correct cohort specifications (see example below, but u
 {
     "cohortName":"migration-name",
     "brazeName":"any-name",
-    "earliestAmendmentEffectDate":"2024-05-20" 
+    "earliestAmendmentEffectiveDate":"2024-05-20" 
 }
 ```
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
@@ -62,7 +62,7 @@ trait CohortHandler extends ZIOAppDefault with RequestStreamHandler {
     *     "cohortSpec":{
     *         "cohortName":"M2023",
     *         "brazeName":"SV_MB_M2023",
-    *         "earliestAmendmentEffectDate":"2023-01-02"
+    *         "earliestAmendmentEffectiveDate":"2023-01-02"
     *     }
     * }
     */

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -136,7 +136,7 @@ object EstimationHandler extends CohortHandler {
             SubscriptionCancelledInZuoraFailure(s"subscription ${item.subscriptionName} has been cancelled in Zuora")
           )
       account <- Zuora.fetchAccount(subscription.accountNumber, subscription.subscriptionNumber)
-      invoicePreviewTargetDate = cohortSpec.earliestAmendmentEffectDate.plusMonths(16)
+      invoicePreviewTargetDate = cohortSpec.earliestAmendmentEffectiveDate.plusMonths(16)
       invoicePreview <- Zuora
         .fetchInvoicePreview(subscription.accountId, invoicePreviewTargetDate)
       _ <-

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -17,7 +17,7 @@ import java.util
   *   Mapping to environment-specific Braze campaign ID is provided by membership-workflow:
   *   See https://github.com/guardian/membership-workflow/blob/master/conf/PROD.public.conf#L39
   *
-  * @param earliestAmendmentEffectDate
+  * @param earliestAmendmentEffectiveDate
   *   Earliest date on which any sub in the cohort can have price migrated. The actual date for any sub will depend on
   *   its billing dates.
   *
@@ -37,7 +37,7 @@ import java.util
 case class CohortSpec(
     cohortName: String,
     brazeName: String,
-    earliestAmendmentEffectDate: LocalDate,
+    earliestAmendmentEffectiveDate: LocalDate,
     subscriptionNumber: Option[String] = None,
     forceNotifications: Option[Boolean] = None,
 ) {
@@ -58,10 +58,10 @@ object CohortSpec {
     (for {
       cohortName <- getStringFromResults(values, "cohortName")
       brazeName <- getStringFromResults(values, "brazeName")
-      earliestAmendmentEffectDate <- getDateFromResults(values, "earliestAmendmentEffectDate")
+      earliestAmendmentEffectiveDate <- getDateFromResults(values, "earliestAmendmentEffectiveDate")
     } yield CohortSpec(
       cohortName,
       brazeName,
-      earliestAmendmentEffectDate
+      earliestAmendmentEffectiveDate
     )).left.map(e => CohortSpecFetchFailure(e))
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/StartDates.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/StartDates.scala
@@ -54,7 +54,7 @@ object StartDates {
     //   during a single month.
 
     Date.datesMax(
-      cohortSpec.earliestAmendmentEffectDate,
+      cohortSpec.earliestAmendmentEffectiveDate,
       today.plusDays(
         NotificationHandler.minLeadTime(cohortSpec: CohortSpec) + 1
       ) // +1 because we need to be strictly over minLeadTime days away. Exactly minLeadTime is not enough.

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -69,7 +69,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
             CohortSpec(
               cohortName = "cohortName",
               brazeName = "cmp123",
-              earliestAmendmentEffectDate = LocalDate.of(2020, 1, 1)
+              earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 1)
             )
           )
           .provideLayer(

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -188,7 +188,7 @@ class AmendmentDataTest extends munit.FunSuite {
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
       brazeName = "BrazeName",
-      earliestAmendmentEffectDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
+      earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 
     assertEquals(

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -11,7 +11,7 @@ class CohortSpecTest extends munit.FunSuite {
   private val cohortSpec = CohortSpec(
     cohortName = "Home Delivery 2018",
     brazeName = "cmp123",
-    earliestAmendmentEffectDate = LocalDate.of(2020, 1, 2)
+    earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 2)
   )
 
   private def assertTrue(obtained: Boolean): Unit = assertEquals(obtained, true)
@@ -21,7 +21,7 @@ class CohortSpecTest extends munit.FunSuite {
     val item = Map(
       "cohortName" -> AttributeValue.builder.s("Home Delivery 2018").build(),
       "brazeName" -> AttributeValue.builder.s("cmp123").build(),
-      "earliestAmendmentEffectDate" -> AttributeValue.builder.s("2020-01-02").build()
+      "earliestAmendmentEffectiveDate" -> AttributeValue.builder.s("2020-01-02").build()
     ).asJava
     assertEquals(
       CohortSpec.fromDynamoDbItem(item),

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -19,7 +19,7 @@ class CohortTableLiveTest extends munit.FunSuite {
   private val cohortSpec = CohortSpec(
     cohortName = "name",
     brazeName = "cmp123",
-    earliestAmendmentEffectDate = LocalDate.of(2020, 1, 1)
+    earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 1)
   )
 
   val stubCohortTableConfiguration = ZLayer.succeed(CohortTableConfig(10))

--- a/lambda/src/test/scala/pricemigrationengine/model/StartDatesTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/StartDatesTest.scala
@@ -18,7 +18,7 @@ class StartDatesTest extends munit.FunSuite {
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
       brazeName = "BrazeName",
-      earliestAmendmentEffectDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
+      earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 
     // --------------------------------------------------
@@ -112,7 +112,7 @@ class StartDatesTest extends munit.FunSuite {
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
       brazeName = "BrazeName",
-      earliestAmendmentEffectDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
+      earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 
     // --------------------------------------------------


### PR DESCRIPTION
To accommodate the fact that not all migrations are price migrations we rename the `CohortSpec` attribute `earliestPriceMigrationStartDate` to `earliestAmendmentEffectDate`