### PR TITLE
Update CohortTableDdlLive with updated indices

### DIFF
--- a/dynamoDb/README.md
+++ b/dynamoDb/README.md
@@ -11,9 +11,9 @@ aws dynamodb create-table \
     --region eu-west-1 \
     --endpoint-url http://localhost:8000 \
     --table-name PriceMigrationEngineDEV \
-    --attribute-definitions AttributeName=subscriptionNumber,AttributeType=S AttributeName=processingStage,AttributeType=S AttributeName=startDate,AttributeType=S \
+    --attribute-definitions AttributeName=subscriptionNumber,AttributeType=S AttributeName=processingStage,AttributeType=S AttributeName=amendmentEffectiveDate,AttributeType=S \
     --key-schema AttributeName=subscriptionNumber,KeyType=HASH \
-    --global-secondary-indexes IndexName=ProcessingStageIndexV2,KeySchema=["{AttributeName=processingStage,KeyType=HASH}","{AttributeName=startDate,KeyType=RANGE}"],Projection="{ProjectionType=KEYS_ONLY}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}" \
+    --global-secondary-indexes IndexName=ProcessingStageIndexV2,KeySchema=["{AttributeName=processingStage,KeyType=HASH}","{AttributeName=amendmentEffectiveDate,KeyType=RANGE}"],Projection="{ProjectionType=KEYS_ONLY}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}" \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 
 ```
 
@@ -58,7 +58,7 @@ aws dynamodb query \
     --region eu-west-1 \
     --table-name PriceMigrationEngineDEV \
     --index-name ProcessingStageStartDateIndexV1 \
-    --key-condition-expression "processingStage = :stage AND startDate BETWEEN :earliestDate AND :latestDate" \
+    --key-condition-expression "processingStage = :stage AND amendmentEffectiveDate BETWEEN :earliestDate AND :latestDate" \
     --expression-attribute-values '{":stage":{"S":"SalesforcePriceRiseCreationComplete"},":earliestDate":{"S":"2020-06-26"},":latestDate":{"S":"2020-06-28"}}'
 ```
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -158,7 +158,9 @@ object EstimationHandler extends CohortHandler {
           today
         )
       )
-      _ <- Logging.info(s"item: ${item.toString}, startDateLowerBound: ${amendmentEffectiveDateLowerBound}")
+      _ <- Logging.info(
+        s"item: ${item.toString}, amendmentEffectiveDateLowerBound: ${amendmentEffectiveDateLowerBound}"
+      )
       result <- ZIO.fromEither(
         EstimationResult(account, catalogue, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec)
       )

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -147,8 +147,8 @@ object NotificationHandler extends CohortHandler {
       country <- ZIO.fromEither(country(cohortSpec, address))
       oldPrice <- ZIO.fromEither(requiredField(cohortItem.oldPrice, "CohortItem.oldPrice"))
       estimatedNewPrice <- ZIO.fromEither(requiredField(cohortItem.estimatedNewPrice, "CohortItem.estimatedNewPrice"))
-      startDate <- ZIO.fromEither(
-        requiredField(cohortItem.amendmentEffectiveDate.map(_.toString()), "CohortItem.startDate")
+      amendmentEffectiveDate <- ZIO.fromEither(
+        requiredField(cohortItem.amendmentEffectiveDate.map(_.toString()), "CohortItem.amendmentEffectiveDate")
       )
       billingPeriod <- ZIO.fromEither(requiredField(cohortItem.billingPeriod, "CohortItem.billingPeriod"))
       paymentFrequency <- paymentFrequency(billingPeriod)
@@ -240,7 +240,7 @@ object NotificationHandler extends CohortHandler {
               billing_state = address.state,
               billing_country = country,
               payment_amount = priceWithOptionalCappingWithCurrencySymbol, // [1]
-              next_payment_date = startDateConversion(startDate),
+              next_payment_date = startDateConversion(amendmentEffectiveDate),
               payment_frequency = paymentFrequency,
               subscription_id = cohortItem.subscriptionName,
               product_type = sfSubscription.Product_Type__c.getOrElse(""),

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdlLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableDdlLive.scala
@@ -13,10 +13,10 @@ object CohortTableDdlLive {
   private val partitionKey = "subscriptionNumber"
 
   private val stageIndex = "ProcessingStageIndexV2"
-  private val stageAndStartDateIndex = "ProcessingStageStartDateIndexV1"
+  private val stageAndDateIndex = "ProcessingStageAndDateIndexV1"
 
   private val stageAttribute = "processingStage"
-  private val startDateAttribute = "startDate"
+  private val amendmentEffectiveDateAttribute = "amendmentEffectiveDate"
 
   val impl: ZLayer[DynamoDBClient with StageConfig with Logging, ConfigFailure, CohortTableDdl] =
     ZLayer.fromZIO(
@@ -34,7 +34,7 @@ object CohortTableDdlLive {
               AttributeDefinition.builder.attributeName(partitionKey).attributeType(S).build(),
               AttributeDefinition.builder.attributeName(stageAttribute).attributeType(S).build(),
               AttributeDefinition.builder
-                .attributeName(startDateAttribute)
+                .attributeName(amendmentEffectiveDateAttribute)
                 .attributeType(S)
                 .build()
             )
@@ -45,10 +45,10 @@ object CohortTableDdlLive {
                 .projection(Projection.builder.projectionType(ProjectionType.ALL).build())
                 .build(),
               GlobalSecondaryIndex.builder
-                .indexName(stageAndStartDateIndex)
+                .indexName(stageAndDateIndex)
                 .keySchema(
                   KeySchemaElement.builder.attributeName(stageAttribute).keyType(HASH).build(),
-                  KeySchemaElement.builder.attributeName(startDateAttribute).keyType(RANGE).build()
+                  KeySchemaElement.builder.attributeName(amendmentEffectiveDateAttribute).keyType(RANGE).build()
                 )
                 .projection(Projection.builder.projectionType(ProjectionType.ALL).build())
                 .build()


### PR DESCRIPTION
This is a follow up of [rename cohort item startDate to amendmentEffectiveDate](https://github.com/guardian/price-migration-engine/pull/1251), where we update some old documentation and the CohortTableDdlLive for the next migration.