### PR TITLE
Introducing commsPrice

### DIFF
--- a/docs/cohort-items.md
+++ b/docs/cohort-items.md
@@ -3,7 +3,7 @@
 
 case class `CohortItem` carries the migration state as well as metadata for a subscription.
 
-When expanding the `CohortItem` case class, do not forget to [map the dynamo record to the Scala type](https://github.com/guardian/price-migration-engine/pull/1158). It's not done automatically.
+When expanding the `CohortItem` case class, do not forget to [map the dynamo record to the Scala type](https://github.com/guardian/price-migration-engine/pull/1158) in CohortTableLive. It's not done automatically.
 
 ## Extending CohortItem (Part 1)
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -160,7 +160,7 @@ object AmendmentHandler extends CohortHandler {
   ): Either[String, Unit] = {
     if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec)) {
       if (SI2025Extractions.subscriptionHasActiveDiscounts(subscriptionAfterUpdate, today)) {
-        if (newPrice < commsPrice) {
+        if (newPrice <= commsPrice) {
           // should perform final check
           // has active discount, therefore only performing the inequality check
           // has passed the check

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -326,7 +326,6 @@ object AmendmentHandler extends CohortHandler {
           subscriptionNumber,
           effectDate,
           zuora_subscription,
-          oldPrice,
           commsPrice,
           invoiceList
         )

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -154,32 +154,27 @@ object AmendmentHandler extends CohortHandler {
       cohortSpec: CohortSpec,
       cohortItem: CohortItem,
       subscriptionAfterUpdate: ZuoraSubscription,
-      estimatedNewPrice: BigDecimal,
+      commsPrice: BigDecimal,
       newPrice: BigDecimal,
       today: LocalDate
   ): Either[String, Unit] = {
     if (shouldPerformFinalPriceCheck(cohortSpec: CohortSpec)) {
-      if (
-        SI2025Extractions.subscriptionHasActiveDiscounts(subscriptionAfterUpdate, today)
-        || AmendmentHandlerHelper.newPriceHasBeenCappedAt20Percent(cohortItem.oldPrice.get, newPrice)
-        // Purposeful use of `.get` in the above as a cohortItem in Amendment step without
-        // an `oldPrice` would be extremely pathological
-      ) {
-        if (newPrice > estimatedNewPrice) {
-          // should perform final check
-          // has active discount, therefore only performing the inequality check
-          // has failed the check
-          Left(
-            s"[6831cff2] Item ${cohortItem} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice} (nb: has discounts)"
-          )
-        } else {
+      if (SI2025Extractions.subscriptionHasActiveDiscounts(subscriptionAfterUpdate, today)) {
+        if (newPrice < commsPrice) {
           // should perform final check
           // has active discount, therefore only performing the inequality check
           // has passed the check
           Right(())
+        } else {
+          // should perform final check
+          // has active discount, therefore only performing the inequality check
+          // has failed the check
+          Left(
+            s"[6831cff2] Item ${cohortItem} has gone through the amendment step but has failed the final price check. commsPrice was ${commsPrice}, but the final price was ${newPrice} (nb: has discounts)"
+          )
         }
       } else {
-        if (AmendmentHandlerHelper.priceEquality(estimatedNewPrice, newPrice)) {
+        if (AmendmentHandlerHelper.priceEquality(commsPrice, newPrice)) {
           // should perform final check
           // has no active discount, therefore performing the "equality" check
           // has passed the check
@@ -189,7 +184,7 @@ object AmendmentHandler extends CohortHandler {
           // has no active discount, therefore performing the "equality" check
           // has failed the check
           Left(
-            s"[e9054daa] Item ${cohortItem} has gone through the amendment step but has failed the final price check. Estimated price was ${estimatedNewPrice}, but the final price was ${newPrice} (nb: no discounts)"
+            s"[e9054daa] Item ${cohortItem} has gone through the amendment step but has failed the final price check. commsPrice was ${commsPrice}, but the final price was ${newPrice} (nb: no discounts)"
           )
         }
       }
@@ -301,9 +296,7 @@ object AmendmentHandler extends CohortHandler {
     } yield SuccessfulAmendmentResult(
       item.subscriptionName,
       amendmentEffectiveDate,
-      oldPrice,
       newPrice,
-      estimatedNewPrice,
       subscriptionAfterUpdate.id,
       whenDone
     )
@@ -318,8 +311,7 @@ object AmendmentHandler extends CohortHandler {
       effectDate: LocalDate,
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal,
-      priceCap: Option[BigDecimal],
+      commsPrice: BigDecimal,
       invoiceList: ZuoraInvoiceList
   ): Either[Failure, Value] = {
     MigrationType(cohortSpec) match {
@@ -335,8 +327,7 @@ object AmendmentHandler extends CohortHandler {
           effectDate,
           zuora_subscription,
           oldPrice,
-          estimatedNewPrice,
-          priceCap,
+          commsPrice,
           invoiceList
         )
       case Newspaper2025P1 =>
@@ -348,8 +339,7 @@ object AmendmentHandler extends CohortHandler {
           effectDate,
           zuora_subscription,
           oldPrice,
-          estimatedNewPrice,
-          priceCap,
+          commsPrice,
           invoiceList
         )
       case HomeDelivery2025 =>
@@ -361,8 +351,7 @@ object AmendmentHandler extends CohortHandler {
           effectDate,
           zuora_subscription,
           oldPrice,
-          estimatedNewPrice,
-          priceCap,
+          commsPrice,
           invoiceList
         )
       case Newspaper2025P3 =>
@@ -374,8 +363,7 @@ object AmendmentHandler extends CohortHandler {
           effectDate,
           zuora_subscription,
           oldPrice,
-          estimatedNewPrice,
-          priceCap,
+          commsPrice,
           invoiceList
         )
       case ProductMigration2025N4 =>
@@ -387,8 +375,7 @@ object AmendmentHandler extends CohortHandler {
           effectDate,
           zuora_subscription,
           oldPrice,
-          estimatedNewPrice,
-          priceCap,
+          commsPrice,
           invoiceList
         )
     }
@@ -408,10 +395,10 @@ object AmendmentHandler extends CohortHandler {
 
       oldPrice <- ZIO.fromOption(item.oldPrice).orElseFail(DataExtractionFailure(s"No old price in $item"))
 
-      estimatedNewPrice <-
+      commsPrice <-
         ZIO
-          .fromOption(item.estimatedNewPrice)
-          .orElseFail(DataExtractionFailure(s"No estimated new price in $item"))
+          .fromOption(item.commsPrice)
+          .orElseFail(DataExtractionFailure(s"No commsPrice in $item"))
 
       invoicePreviewTargetDate = amendmentEffectiveDate.plusMonths(13)
 
@@ -444,8 +431,7 @@ object AmendmentHandler extends CohortHandler {
             effectDate = amendmentEffectiveDate,
             zuora_subscription = subscriptionBeforeUpdate,
             oldPrice = oldPrice,
-            estimatedNewPrice = estimatedNewPrice,
-            priceCap = EstimationHandlerHelper.capRatio(cohortSpec).map(ratio => BigDecimal(ratio)),
+            commsPrice = commsPrice,
             invoiceList = invoicePreviewBeforeUpdate
           )
         )
@@ -488,7 +474,7 @@ object AmendmentHandler extends CohortHandler {
 
       _ <- ZIO
         .fromEither(
-          postAmendmentPriceCheck(cohortSpec, item, subscriptionAfterUpdate, estimatedNewPrice, newPrice, today)
+          postAmendmentPriceCheck(cohortSpec, item, subscriptionAfterUpdate, commsPrice, newPrice, today)
         )
         .mapError(message => AmendmentFailure(message))
 
@@ -496,9 +482,7 @@ object AmendmentHandler extends CohortHandler {
     } yield SuccessfulAmendmentResult(
       item.subscriptionName,
       amendmentEffectiveDate,
-      oldPrice,
       newPrice,
-      estimatedNewPrice,
       subscriptionAfterUpdate.id,
       whenDone
     )

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -238,8 +238,7 @@ object AmendmentHandler extends CohortHandler {
               mainChargeEffectDate = amendmentEffectiveDate,
               subscription = subscriptionBeforeUpdate,
               oldPrice = oldPrice,
-              estimatedNewPrice = estimatedNewPrice,
-              priceCap = SupporterPlus2024Migration.priceCap
+              estimatedNewPrice = estimatedNewPrice
             )
           )
         case GuardianWeekly2025 =>
@@ -320,7 +319,7 @@ object AmendmentHandler extends CohortHandler {
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
       estimatedNewPrice: BigDecimal,
-      priceCap: BigDecimal,
+      priceCap: Option[BigDecimal],
       invoiceList: ZuoraInvoiceList
   ): Either[Failure, Value] = {
     MigrationType(cohortSpec) match {
@@ -446,7 +445,7 @@ object AmendmentHandler extends CohortHandler {
             zuora_subscription = subscriptionBeforeUpdate,
             oldPrice = oldPrice,
             estimatedNewPrice = estimatedNewPrice,
-            priceCap = GuardianWeekly2025Migration.priceCap,
+            priceCap = EstimationHandlerHelper.capRatio(cohortSpec).map(ratio => BigDecimal(ratio)),
             invoiceList = invoicePreviewBeforeUpdate
           )
         )

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -208,9 +208,9 @@ object AmendmentHandler extends CohortHandler {
 
       oldPrice <- ZIO.fromOption(item.oldPrice).orElseFail(DataExtractionFailure(s"No old price in $item"))
 
-      estimatedNewPrice <-
+      commsPrice <-
         ZIO
-          .fromOption(item.estimatedNewPrice)
+          .fromOption(item.commsPrice)
           .orElseFail(DataExtractionFailure(s"No estimated new price in $item"))
 
       invoicePreviewTargetDate = amendmentEffectiveDate.plusMonths(13)
@@ -232,8 +232,7 @@ object AmendmentHandler extends CohortHandler {
               subscriptionNumber = subscriptionBeforeUpdate.subscriptionNumber,
               mainChargeEffectDate = amendmentEffectiveDate,
               subscription = subscriptionBeforeUpdate,
-              oldPrice = oldPrice,
-              estimatedNewPrice = estimatedNewPrice
+              commsPrice = commsPrice
             )
           )
         case GuardianWeekly2025 =>

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
@@ -243,7 +243,6 @@ object GuardianWeekly2025Migration {
       subscriptionNumber: String,
       effectDate: LocalDate,
       zuora_subscription: ZuoraSubscription,
-      oldPrice: BigDecimal,
       commsPrice: BigDecimal,
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
@@ -31,12 +31,6 @@ object GuardianWeekly2025ExtraAttributes {
 object GuardianWeekly2025Migration {
 
   // ------------------------------------------------
-  // Price capping
-  // ------------------------------------------------
-
-  val priceCap = 1.20 // 20%
-
-  // ------------------------------------------------
   // Notification Timings
   // ------------------------------------------------
 
@@ -251,7 +245,7 @@ object GuardianWeekly2025Migration {
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
       estimatedNewPrice: BigDecimal,
-      priceCap: BigDecimal,
+      priceCap: Option[BigDecimal],
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {
 

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
@@ -244,8 +244,7 @@ object GuardianWeekly2025Migration {
       effectDate: LocalDate,
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal,
-      priceCap: Option[BigDecimal],
+      commsPrice: BigDecimal,
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {
 
@@ -267,7 +266,7 @@ object GuardianWeekly2025Migration {
           val chargeOverrides = List(
             ZuoraOrdersApiPrimitives.chargeOverride(
               determineTargetRatePlanChargeId(ratePlan),
-              PriceCap.cappedPrice(oldPrice, estimatedNewPrice, priceCap),
+              commsPrice,
               BillingPeriod.toString(billingPeriod)
             )
           )
@@ -294,7 +293,7 @@ object GuardianWeekly2025Migration {
           val chargeOverrides = List(
             ZuoraOrdersApiPrimitives.chargeOverride(
               determineTargetRatePlanChargeId(ratePlan),
-              PriceCap.cappedPrice(oldPrice, estimatedNewPrice, priceCap),
+              commsPrice,
               BillingPeriod.toString(billingPeriod)
             )
           )

--- a/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
@@ -39,12 +39,6 @@ case class HomeDelivery2025NotificationData(
 object HomeDelivery2025Migration {
 
   // ------------------------------------------------
-  // Price capping
-  // ------------------------------------------------
-
-  val priceCap = 1.20
-
-  // ------------------------------------------------
   // Notification Timings
   // ------------------------------------------------
 
@@ -208,7 +202,7 @@ object HomeDelivery2025Migration {
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
       estimatedNewPrice: BigDecimal,
-      priceCap: BigDecimal,
+      priceCap: Option[BigDecimal],
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {
     // This version of `amendmentOrderPayload`, applied to subscriptions with the active rate plan having

--- a/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
@@ -212,8 +212,6 @@ object HomeDelivery2025Migration {
     // in the case of GuardianWeekly2025, for instance, is the price ratio from the old price to the new price
     // (both carried by the cohort item).
 
-    // Note that we do use `get` here. The cohort items always get them from the estimation step, but in the
-    // abnormal case it would not, we want the process to error and alarm.
     val priceRatio = commsPrice / oldPrice
 
     val order_opt = {

--- a/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/HomeDelivery2025Migration.scala
@@ -201,8 +201,7 @@ object HomeDelivery2025Migration {
       effectDate: LocalDate,
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal,
-      priceCap: Option[BigDecimal],
+      commsPrice: BigDecimal,
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {
     // This version of `amendmentOrderPayload`, applied to subscriptions with the active rate plan having
@@ -215,7 +214,7 @@ object HomeDelivery2025Migration {
 
     // Note that we do use `get` here. The cohort items always get them from the estimation step, but in the
     // abnormal case it would not, we want the process to error and alarm.
-    val priceRatio = estimatedNewPrice / oldPrice
+    val priceRatio = commsPrice / oldPrice
 
     val order_opt = {
       if (!decideShouldRemoveDiscount(cohortItem)) {
@@ -230,7 +229,7 @@ object HomeDelivery2025Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
-            estimatedNewPrice,
+            commsPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
@@ -256,7 +255,7 @@ object HomeDelivery2025Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
-            estimatedNewPrice,
+            commsPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
@@ -44,12 +44,6 @@ case class Newspaper2025P1NotificationData(
 object Newspaper2025P1Migration {
 
   // ------------------------------------------------
-  // Price capping
-  // ------------------------------------------------
-
-  val priceCap = 1.20
-
-  // ------------------------------------------------
   // Notification Timings
   // ------------------------------------------------
 
@@ -249,7 +243,7 @@ object Newspaper2025P1Migration {
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
       estimatedNewPrice: BigDecimal,
-      priceCap: BigDecimal,
+      priceCap: Option[BigDecimal],
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {
 

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
@@ -254,8 +254,6 @@ object Newspaper2025P1Migration {
     // in the case of GuardianWeekly2025, for instance, is the price ratio from the old price to the new price
     // (both carried by the cohort item).
 
-    // Note that we do use `get` here. The cohort items always get them from the estimation step, but in the
-    // abnormal case it would not, we want the process to error and alarm.
     val priceRatio = commsPrice / oldPrice
 
     val order_opt = {

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
@@ -242,8 +242,7 @@ object Newspaper2025P1Migration {
       effectDate: LocalDate,
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal,
-      priceCap: Option[BigDecimal],
+      commsPrice: BigDecimal,
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {
 
@@ -257,7 +256,7 @@ object Newspaper2025P1Migration {
 
     // Note that we do use `get` here. The cohort items always get them from the estimation step, but in the
     // abnormal case it would not, we want the process to error and alarm.
-    val priceRatio = estimatedNewPrice / oldPrice
+    val priceRatio = commsPrice / oldPrice
 
     val order_opt = {
       if (!decideShouldRemoveDiscount(cohortItem)) {
@@ -272,7 +271,7 @@ object Newspaper2025P1Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
-            estimatedNewPrice,
+            commsPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
@@ -298,7 +297,7 @@ object Newspaper2025P1Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
-            estimatedNewPrice,
+            commsPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -213,8 +213,7 @@ object Newspaper2025P3Migration {
       effectDate: LocalDate,
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal,
-      priceCap: Option[BigDecimal],
+      commsPrice: BigDecimal,
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {
 
@@ -228,7 +227,7 @@ object Newspaper2025P3Migration {
 
     // Note that we do use `get` here. The cohort items always get them from the estimation step, but in the
     // abnormal case it would not, we want the process to error and alarm.
-    val priceRatio = estimatedNewPrice / oldPrice
+    val priceRatio = commsPrice / oldPrice
 
     val order_opt = {
       if (!decideShouldRemoveDiscount(cohortItem)) {
@@ -243,7 +242,7 @@ object Newspaper2025P3Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
-            estimatedNewPrice,
+            commsPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)
@@ -269,7 +268,7 @@ object Newspaper2025P3Migration {
           val chargeOverrides: List[Value] = ZuoraOrdersApiPrimitives.ratePlanChargesToChargeOverrides(
             ratePlan.ratePlanCharges,
             priceRatio,
-            estimatedNewPrice,
+            commsPrice,
             BillingPeriod.toString(billingPeriod)
           )
           val addProduct = ZuoraOrdersApiPrimitives.addProduct(triggerDateString, productRatePlanId, chargeOverrides)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -44,12 +44,6 @@ case class Newspaper2025P3NotificationData(
 object Newspaper2025P3Migration {
 
   // ------------------------------------------------
-  // Price capping
-  // ------------------------------------------------
-
-  val priceCap = 1.20
-
-  // ------------------------------------------------
   // Notification Timings
   // ------------------------------------------------
 
@@ -220,7 +214,7 @@ object Newspaper2025P3Migration {
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
       estimatedNewPrice: BigDecimal,
-      priceCap: BigDecimal,
+      priceCap: Option[BigDecimal],
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = {
 

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -225,8 +225,6 @@ object Newspaper2025P3Migration {
     // in the case of GuardianWeekly2025, for instance, is the price ratio from the old price to the new price
     // (both carried by the cohort item).
 
-    // Note that we do use `get` here. The cohort items always get them from the estimation step, but in the
-    // abnormal case it would not, we want the process to error and alarm.
     val priceRatio = commsPrice / oldPrice
 
     val order_opt = {

--- a/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
@@ -110,8 +110,7 @@ object ProductMigration2025N4Migration {
       effectDate: LocalDate,
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal,
-      priceCap: Option[BigDecimal],
+      commsPrice: BigDecimal,
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = ???
 }

--- a/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
@@ -111,7 +111,7 @@ object ProductMigration2025N4Migration {
       zuora_subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
       estimatedNewPrice: BigDecimal,
-      priceCap: BigDecimal,
+      priceCap: Option[BigDecimal],
       invoiceList: ZuoraInvoiceList,
   ): Either[Failure, Value] = ???
 }

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
@@ -15,12 +15,6 @@ case class SupporterPlus2024NotificationData(
 
 object SupporterPlus2024Migration {
 
-  // ------------------------------------------------
-  // Static Data
-  // ------------------------------------------------
-
-  val priceCap = 1.27
-
   val maxLeadTime = 33
   val minLeadTime = 31
 
@@ -362,8 +356,7 @@ object SupporterPlus2024Migration {
       mainChargeEffectDate: LocalDate,
       subscription: ZuoraSubscription,
       oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal,
-      priceCap: BigDecimal
+      estimatedNewPrice: BigDecimal
   ): Either[Failure, ZuoraAmendmentOrderPayload] = {
     for {
       existingRatePlan <- getSupporterPlusV2RatePlan(subscription)
@@ -395,7 +388,7 @@ object SupporterPlus2024Migration {
       productRatePlanId = existingRatePlan.productRatePlanId,
       existingBaseProductRatePlanChargeId = existingBaseRatePlanCharge.productRatePlanChargeId,
       existingContributionRatePlanChargeId = existingContributionRatePlanCharge.productRatePlanChargeId,
-      newBaseAmount = PriceCap.cappedPrice(oldPrice, estimatedNewPrice, priceCap),
+      newBaseAmount = PriceCap.cappedPrice(oldPrice, estimatedNewPrice, Some(1.27)),
       newContributionAmount = existingContributionPrice
     )
   }

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2024Migration.scala
@@ -355,8 +355,7 @@ object SupporterPlus2024Migration {
       subscriptionNumber: String,
       mainChargeEffectDate: LocalDate,
       subscription: ZuoraSubscription,
-      oldPrice: BigDecimal,
-      estimatedNewPrice: BigDecimal
+      commsPrice: BigDecimal
   ): Either[Failure, ZuoraAmendmentOrderPayload] = {
     for {
       existingRatePlan <- getSupporterPlusV2RatePlan(subscription)
@@ -388,7 +387,7 @@ object SupporterPlus2024Migration {
       productRatePlanId = existingRatePlan.productRatePlanId,
       existingBaseProductRatePlanChargeId = existingBaseRatePlanCharge.productRatePlanChargeId,
       existingContributionRatePlanChargeId = existingContributionRatePlanCharge.productRatePlanChargeId,
-      newBaseAmount = PriceCap.cappedPrice(oldPrice, estimatedNewPrice, Some(1.27)),
+      newBaseAmount = commsPrice,
       newContributionAmount = existingContributionPrice
     )
   }

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentHandlerHelper.scala
@@ -16,17 +16,4 @@ object AmendmentHandlerHelper {
   def priceEquality(float1: BigDecimal, float2: BigDecimal): Boolean = {
     (float1 - float2).abs < 0.001
   }
-
-  def newPriceHasBeenCappedAt20Percent(oldPrice: BigDecimal, newPrice: BigDecimal): Boolean = {
-    // This function takes a oldPrice (assumed from the cohort item) and a new price (assumed
-    // from Zuora post amendment) and return true if the newPrice appears to have been capped at +20%
-
-    // Note: This is Phase 1 of a solution to prevent unnecessarily alarming when a subscription has been
-    // capped and the cohort item estimated newPrice (which didn't carry the capping) is not equal to
-    // post amendment price. In Phase 2 we are going to expand the standard cohort item to add the
-    // capped price (the price that as put into the comms). Phase 2 will come shortly.
-
-    priceEquality(oldPrice * 1.2, newPrice)
-  }
-
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentResult.scala
@@ -7,9 +7,7 @@ trait AmendmentResult
 case class SuccessfulAmendmentResult(
     subscriptionNumber: String,
     amendmentEffectiveDate: LocalDate,
-    oldPrice: BigDecimal,
     newPrice: BigDecimal,
-    estimatedNewPrice: BigDecimal,
     newSubscriptionId: ZuoraSubscriptionId,
     whenDone: Instant
 ) extends AmendmentResult

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -34,14 +34,14 @@ case class CohortItem(
     // cancellation journey of Supporter Plus subscriptions.
     // The default value is `None`, and if a none trivial value is present it represents
     // the date until when the item should be left alone and not being processed.
-    doNotProcessUntil: Option[LocalDate] = None, // [18]
+    doNotProcessUntil: Option[LocalDate] = None,
 
     // migrationExtraAttributes was introduced to allow a cohort item to hold
     // extra attributes that are migration dependent (specifically for the
     // Guardian Weekly 2025 migration), for if and when we need to perform
     // operations using parameters that are not hold into the Zuora subscription.
     // For more details about when and how to use that attribute, see the documentation.
-    migrationExtraAttributes: Option[String] = None, // [19]
+    migrationExtraAttributes: Option[String] = None,
 
     //
     cancellationReason: Option[String] = None,

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortItem.scala
@@ -75,6 +75,7 @@ object CohortItem {
       processingStage = EstimationComplete,
       oldPrice = Some(result.oldPrice),
       estimatedNewPrice = Some(result.estimatedNewPrice),
+      commsPrice = Some(result.commsPrice),
       currency = Some(result.currency),
       amendmentEffectiveDate = Some(result.amendmentEffectiveDate),
       billingPeriod = Some(result.billingPeriod),

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
@@ -15,7 +15,7 @@ object EstimationHandlerHelper {
     }
   }
 
-  def computeCommsPrice(cohortSpec: CohortSpec, oldPrice: BigDecimal, estimatedNewPriceUncapped: BigDecimal) = {
+  def commsPrice(cohortSpec: CohortSpec, oldPrice: BigDecimal, estimatedNewPriceUncapped: BigDecimal) = {
     PriceCap.cappedPrice(
       oldPrice,
       estimatedNewPriceUncapped,

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
@@ -3,7 +3,7 @@ package pricemigrationengine.model
 object EstimationHandlerHelper {
 
   def migrationCapRatio(cohortSpec: CohortSpec): Option[Double] = {
-    // This is where we declare the optional capping of each subscription
+    // This is where we declare the optional capping of each migration
     MigrationType(cohortSpec) match {
       case Test1                  => None
       case SupporterPlus2024      => None

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
@@ -2,8 +2,8 @@ package pricemigrationengine.model
 
 object EstimationHandlerHelper {
 
-  def capRatio(cohortSpec: CohortSpec): Option[Double] = {
-    // This is where we declare the optional capping of each subscriptions
+  def migrationCapRatio(cohortSpec: CohortSpec): Option[Double] = {
+    // This is where we declare the optional capping of each subscription
     MigrationType(cohortSpec) match {
       case Test1                  => None
       case SupporterPlus2024      => None
@@ -19,7 +19,7 @@ object EstimationHandlerHelper {
     PriceCap.cappedPrice(
       oldPrice,
       estimatedNewPriceUncapped,
-      capRatio(cohortSpec: CohortSpec).map(ratio => BigDecimal(ratio))
+      migrationCapRatio(cohortSpec: CohortSpec).map(ratio => BigDecimal(ratio))
     )
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
@@ -6,7 +6,7 @@ object EstimationHandlerHelper {
     // This is where we declare the optional capping of each migration
     MigrationType(cohortSpec) match {
       case Test1                  => None
-      case SupporterPlus2024      => None
+      case SupporterPlus2024      => Some(1.27)
       case GuardianWeekly2025     => Some(1.2)
       case Newspaper2025P1        => Some(1.2)
       case HomeDelivery2025       => Some(1.2)

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
@@ -15,7 +15,7 @@ object EstimationHandlerHelper {
     }
   }
 
-  def commsPrice(cohortSpec: CohortSpec, oldPrice: BigDecimal, estimatedNewPriceUncapped: BigDecimal) = {
+  def commsPrice(cohortSpec: CohortSpec, oldPrice: BigDecimal, estimatedNewPriceUncapped: BigDecimal): BigDecimal = {
     PriceCap.cappedPrice(
       oldPrice,
       estimatedNewPriceUncapped,

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
@@ -1,0 +1,25 @@
+package pricemigrationengine.model
+
+object EstimationHandlerHelper {
+
+  def capRatio(cohortSpec: CohortSpec): Option[Double] = {
+    // This is where we declare the optional capping of each subscriptions
+    MigrationType(cohortSpec) match {
+      case Test1                  => None
+      case SupporterPlus2024      => None
+      case GuardianWeekly2025     => Some(1.2)
+      case Newspaper2025P1        => Some(1.2)
+      case HomeDelivery2025       => Some(1.2)
+      case Newspaper2025P3        => Some(1.2)
+      case ProductMigration2025N4 => None
+    }
+  }
+
+  def computeCommsPrice(cohortSpec: CohortSpec, oldPrice: BigDecimal, estimatedNewPriceUncapped: BigDecimal) = {
+    PriceCap.cappedPrice(
+      oldPrice,
+      estimatedNewPriceUncapped,
+      capRatio(cohortSpec: CohortSpec).map(ratio => BigDecimal(ratio))
+    )
+  }
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -14,6 +14,7 @@ case class EstimationData(
     currency: Currency,
     oldPrice: BigDecimal,
     estimatedNewPrice: BigDecimal,
+    commsPrice: BigDecimal,
     billingPeriod: String
 ) extends EstimationResult
 
@@ -38,7 +39,8 @@ object EstimationResult {
       amendmentEffectiveDate,
       priceData.currency,
       priceData.oldPrice,
-      priceData.newPrice,
+      priceData.newPrice, // aka: estimatedNewPrice
+      EstimationHandlerHelper.computeCommsPrice(cohortSpec, priceData.oldPrice, priceData.newPrice),
       priceData.billingPeriod
     )
   }

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationResult.scala
@@ -40,7 +40,7 @@ object EstimationResult {
       priceData.currency,
       priceData.oldPrice,
       priceData.newPrice, // aka: estimatedNewPrice
-      EstimationHandlerHelper.computeCommsPrice(cohortSpec, priceData.oldPrice, priceData.newPrice),
+      EstimationHandlerHelper.commsPrice(cohortSpec, priceData.oldPrice, priceData.newPrice),
       priceData.billingPeriod
     )
   }

--- a/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/PriceCap.scala
@@ -8,9 +8,14 @@ object PriceCap {
   def cappedPrice(
       oldPrice: BigDecimal,
       uncappedNewPrice: BigDecimal,
-      priceCappingMultiplier: BigDecimal
+      priceCappingMultiplierOpt: Option[BigDecimal]
   ): BigDecimal = {
-    // For a price cap of 20%, the priceCappingMultiplier is set to 1.2
-    List(uncappedNewPrice, oldPrice * priceCappingMultiplier).min
+    priceCappingMultiplierOpt match {
+      case None => uncappedNewPrice
+      case Some(priceCappingMultiplier) => {
+        // For a price cap of 20%, the priceCappingMultiplier is set to 1.2
+        List(uncappedNewPrice, oldPrice * priceCappingMultiplier).min
+      }
+    }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
+++ b/lambda/src/main/scala/pricemigrationengine/services/CohortTableLive.scala
@@ -30,6 +30,7 @@ object CohortTableLive {
           whenEstimationDone <- getOptionalInstantFromResults(cohortItem, "whenEstimationDone")
           salesforcePriceRiseId <- getOptionalStringFromResults(cohortItem, "salesforcePriceRiseId")
           whenSfShowEstimate <- getOptionalInstantFromResults(cohortItem, "whenSfShowEstimate")
+          commsPrice <- getOptionalBigDecimalFromResults(cohortItem, "commsPrice")
           newPrice <- getOptionalBigDecimalFromResults(cohortItem, "newPrice")
           newSubscriptionId <- getOptionalStringFromResults(cohortItem, "newSubscriptionId")
           whenAmendmentDone <- getOptionalInstantFromResults(cohortItem, "whenAmendmentDone")
@@ -51,6 +52,7 @@ object CohortTableLive {
           amendmentEffectiveDate = amendmentEffectiveDate,
           currency = currency,
           oldPrice = oldPrice,
+          commsPrice = commsPrice,
           estimatedNewPrice = estimatedNewPrice,
           billingPeriod = billingPeriod,
           whenEstimationDone = whenEstimationDone,
@@ -93,6 +95,7 @@ object CohortTableLive {
         cohortItem.whenSfShowEstimate
           .map(whenSfShowEstimate => instantFieldUpdate("whenSfShowEstimate", whenSfShowEstimate)),
         cohortItem.newPrice.map(newPrice => bigDecimalFieldUpdate("newPrice", newPrice)),
+        cohortItem.commsPrice.map(commsPrice => bigDecimalFieldUpdate("commsPrice", commsPrice)),
         cohortItem.newSubscriptionId
           .map(newSubscriptionId => stringFieldUpdate("newSubscriptionId", newSubscriptionId)),
         cohortItem.whenAmendmentDone

--- a/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
@@ -206,7 +206,6 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         subscriptionNumber,
         effectDate,
         subscription,
-        oldPrice,
         commsPrice,
         invoicePreview
       ),
@@ -327,7 +326,6 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         subscriptionNumber,
         effectDate,
         subscription,
-        oldPrice,
         commsPrice,
         invoicePreview
       ),
@@ -444,7 +442,6 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         subscriptionNumber,
         effectDate,
         subscription,
-        oldPrice,
         commsPrice,
         invoicePreview
       ),
@@ -846,7 +843,6 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         subscriptionNumber,
         effectDate,
         subscription,
-        oldPrice,
         commsPrice,
         invoicePreview
       ),
@@ -1009,7 +1005,6 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         subscriptionNumber,
         effectDate,
         subscription,
-        oldPrice,
         commsPrice,
         invoicePreview
       ),
@@ -1152,7 +1147,6 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         subscriptionNumber,
         effectDate,
         subscription,
-        oldPrice,
         commsPrice,
         invoicePreview
       ),

--- a/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
@@ -190,6 +190,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
     val effectDate = LocalDate.of(2025, 11, 8) // "2025-11-08": Will be used in tiggerDates
     val oldPrice = BigDecimal(15.0)
     val estimatedNewPrice = BigDecimal(16.5)
+    val commsPrice = BigDecimal(16.5)
     val priceCap = BigDecimal(1.2)
 
     // So here, I think that the natural way to test is to compare Values.
@@ -206,8 +207,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         effectDate,
         subscription,
         oldPrice,
-        estimatedNewPrice,
-        priceCap,
+        commsPrice,
         invoicePreview
       ),
       Right(
@@ -311,6 +311,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
     val effectDate = LocalDate.of(2025, 11, 8) // "2025-11-08": Will be used in tiggerDates
     val oldPrice = BigDecimal(200.0)
     val estimatedNewPrice = BigDecimal(300.0)
+    val commsPrice = BigDecimal(240.0)
     val priceCap = BigDecimal(1.2)
 
     // So here, I think that the natural way to test is to compare Values.
@@ -327,8 +328,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         effectDate,
         subscription,
         oldPrice,
-        estimatedNewPrice,
-        priceCap,
+        commsPrice,
         invoicePreview
       ),
       Right(
@@ -428,6 +428,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
     val effectDate = LocalDate.of(2025, 11, 5) // "2025-11-08": Will be used in tiggerDates
     val oldPrice = BigDecimal(318.0)
     val estimatedNewPrice = BigDecimal(348.0)
+    val commsPrice = BigDecimal(348.0)
     val priceCap = BigDecimal(1.2)
 
     // So here, I think that the natural way to test is to compare Values.
@@ -444,8 +445,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         effectDate,
         subscription,
         oldPrice,
-        estimatedNewPrice,
-        priceCap,
+        commsPrice,
         invoicePreview
       ),
       Right(
@@ -652,12 +652,12 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
 
     val oldPrice = BigDecimal(45)
     val estimatedNewPrice = BigDecimal(49.5)
-    val priceCap = 1.2
+    val priceCap = BigDecimal(1.2)
 
     val chargeOverrides = List(
       ZuoraOrdersApiPrimitives.chargeOverride(
         ratePlan.ratePlanCharges.headOption.get.productRatePlanChargeId,
-        PriceCap.cappedPrice(oldPrice, estimatedNewPrice, priceCap),
+        PriceCap.cappedPrice(oldPrice, estimatedNewPrice, Some(priceCap)),
         "Quarter"
       )
     )
@@ -818,6 +818,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
     val startDate = LocalDate.of(2025, 8, 11)
     val oldPrice = BigDecimal(45)
     val estimatedNewPrice = BigDecimal(49.5)
+    val commsPrice = BigDecimal(49.5)
 
     val cohortItem = CohortItem(
       subscriptionName = subscription.subscriptionNumber,
@@ -846,8 +847,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         effectDate,
         subscription,
         oldPrice,
-        estimatedNewPrice,
-        priceCap,
+        commsPrice,
         invoicePreview
       ),
       Right(
@@ -975,6 +975,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
     val startDate = LocalDate.of(2025, 8, 11)
     val oldPrice = BigDecimal(45)
     val estimatedNewPrice = BigDecimal(49.5)
+    val commsPrice = BigDecimal(49.5)
 
     val cohortItem = CohortItem(
       subscriptionName = subscription.subscriptionNumber,
@@ -1009,8 +1010,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         effectDate,
         subscription,
         oldPrice,
-        estimatedNewPrice,
-        priceCap,
+        commsPrice,
         invoicePreview
       ),
       Right(
@@ -1118,6 +1118,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
     val startDate = LocalDate.of(2025, 8, 5)
     val oldPrice = BigDecimal(67.5)
     val estimatedNewPrice = BigDecimal(87.0)
+    val commsPrice = BigDecimal(81.0)
 
     val cohortItem = CohortItem(
       subscriptionName = subscription.subscriptionNumber,
@@ -1152,8 +1153,7 @@ class GuardianWeekly2025MigrationTest extends munit.FunSuite {
         effectDate,
         subscription,
         oldPrice,
-        estimatedNewPrice,
-        priceCap,
+        commsPrice,
         invoicePreview
       ),
       Right(

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P1MigrationTest.scala
@@ -581,6 +581,7 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
     val startDate = LocalDate.of(2025, 8, 5)
     val oldPrice = BigDecimal(67.5)
     val estimatedNewPrice = BigDecimal(87.0)
+    val commsPrice = estimatedNewPrice
 
     val cohortItem = CohortItem(
       subscriptionName = subscription.subscriptionNumber,
@@ -588,6 +589,7 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
       amendmentEffectiveDate = Some(startDate),
       currency = Some("EUR"),
       oldPrice = Some(oldPrice),
+      commsPrice = Some(commsPrice),
       estimatedNewPrice = Some(estimatedNewPrice),
       billingPeriod = Some("Quarter"),
       migrationExtraAttributes = None
@@ -610,8 +612,7 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
         effectDate,
         subscription,
         oldPrice,
-        estimatedNewPrice,
-        priceCap,
+        commsPrice,
         invoicePreview
       ),
       Right(
@@ -771,6 +772,7 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
     val startDate = LocalDate.of(2025, 8, 5)
     val oldPrice = BigDecimal(67.5)
     val estimatedNewPrice = BigDecimal(87.0)
+    val commsPrice = estimatedNewPrice
 
     val cohortItem = CohortItem(
       subscriptionName = subscription.subscriptionNumber,
@@ -778,6 +780,7 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
       amendmentEffectiveDate = Some(startDate),
       currency = Some("EUR"),
       oldPrice = Some(oldPrice),
+      commsPrice = Some(commsPrice),
       estimatedNewPrice = Some(estimatedNewPrice),
       billingPeriod = Some("Quarter"),
       migrationExtraAttributes = Some("""{ "brandTitle": "Label 01", "removeDiscount": true }""")
@@ -800,8 +803,7 @@ class Newspaper2025P1MigrationTest extends munit.FunSuite {
         effectDate,
         subscription,
         oldPrice,
-        estimatedNewPrice,
-        priceCap,
+        commsPrice,
         invoicePreview
       ),
       Right(

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
@@ -449,6 +449,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
     val startDate = LocalDate.of(2025, 8, 23)
     val oldPrice = BigDecimal(779.88) // using the same number from the Newspaper2025P3Migration.priceData check
     val estimatedNewPrice = BigDecimal(839.88)
+    val commsPrice = BigDecimal(839.88)
 
     val cohortItem = CohortItem(
       subscriptionName = subscription.subscriptionNumber,
@@ -457,6 +458,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
       currency = Some("GBP"),
       oldPrice = Some(oldPrice),
       estimatedNewPrice = Some(estimatedNewPrice),
+      commsPrice = Some(commsPrice),
       billingPeriod = Some("Annual"),
       migrationExtraAttributes = None
     )
@@ -478,7 +480,7 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
         effectDate,
         subscription,
         oldPrice,
-        estimatedNewPrice,
+        commsPrice,
         invoicePreview
       ),
       Right(

--- a/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/Newspaper2025P3MigrationTest.scala
@@ -479,7 +479,6 @@ class Newspaper2025P3MigrationTest extends munit.FunSuite {
         subscription,
         oldPrice,
         estimatedNewPrice,
-        priceCap,
         invoicePreview
       ),
       Right(

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
@@ -698,6 +698,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
           currency = "GBP",
           oldPrice = BigDecimal(10.0),
           estimatedNewPrice = BigDecimal(12.0),
+          commsPrice = BigDecimal(12.0),
           billingPeriod = "Month"
         )
       )
@@ -724,6 +725,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
           currency = "AUD",
           oldPrice = BigDecimal(150.0),
           estimatedNewPrice = BigDecimal(200.0),
+          commsPrice = BigDecimal(200.0),
           billingPeriod = "Annual"
         )
       )

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
@@ -762,8 +762,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
         subscriptionNumber = subscription.subscriptionNumber,
         mainChargeEffectDate = LocalDate.of(2024, 11, 27),
         subscription = subscription,
-        oldPrice = 10,
-        estimatedNewPrice = 12
+        commsPrice = 12
       ),
       Right(
         ZuoraAmendmentOrderPayload(
@@ -856,8 +855,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
         subscriptionNumber = subscription.subscriptionNumber,
         mainChargeEffectDate = LocalDate.of(2024, 11, 27),
         subscription = subscription,
-        oldPrice = 10,
-        estimatedNewPrice = 11
+        commsPrice = 11
       ),
       Right(
         ZuoraAmendmentOrderPayload(
@@ -950,8 +948,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
         subscriptionNumber = subscription.subscriptionNumber,
         mainChargeEffectDate = LocalDate.of(2023, 11, 11),
         subscription = subscription,
-        oldPrice = 150,
-        estimatedNewPrice = 200
+        commsPrice = 190.5
       ),
       Right(
         ZuoraAmendmentOrderPayload(
@@ -1342,8 +1339,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
         subscriptionNumber = subscription.subscriptionNumber,
         mainChargeEffectDate = mainRatePlanEffectDate,
         subscription = subscription,
-        oldPrice = 95.0,
-        estimatedNewPrice = 101.0
+        commsPrice = 101.0
       ),
       Right(
         ZuoraAmendmentOrderPayload(

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
@@ -725,7 +725,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
           currency = "AUD",
           oldPrice = BigDecimal(150.0),
           estimatedNewPrice = BigDecimal(200.0),
-          commsPrice = BigDecimal(200.0),
+          commsPrice = BigDecimal(190.50),
           billingPeriod = "Annual"
         )
       )

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2024MigrationTest.scala
@@ -761,8 +761,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
         mainChargeEffectDate = LocalDate.of(2024, 11, 27),
         subscription = subscription,
         oldPrice = 10,
-        estimatedNewPrice = 12,
-        priceCap = 1.27
+        estimatedNewPrice = 12
       ),
       Right(
         ZuoraAmendmentOrderPayload(
@@ -856,8 +855,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
         mainChargeEffectDate = LocalDate.of(2024, 11, 27),
         subscription = subscription,
         oldPrice = 10,
-        estimatedNewPrice = 12,
-        priceCap = 1.1
+        estimatedNewPrice = 11
       ),
       Right(
         ZuoraAmendmentOrderPayload(
@@ -951,8 +949,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
         mainChargeEffectDate = LocalDate.of(2023, 11, 11),
         subscription = subscription,
         oldPrice = 150,
-        estimatedNewPrice = 200,
-        priceCap = 1.27
+        estimatedNewPrice = 200
       ),
       Right(
         ZuoraAmendmentOrderPayload(
@@ -1344,8 +1341,7 @@ class SupporterPlus2024MigrationTest extends munit.FunSuite {
         mainChargeEffectDate = mainRatePlanEffectDate,
         subscription = subscription,
         oldPrice = 95.0,
-        estimatedNewPrice = 101.0,
-        priceCap = 1.2
+        estimatedNewPrice = 101.0
       ),
       Right(
         ZuoraAmendmentOrderPayload(

--- a/lambda/src/test/scala/pricemigrationengine/model/PriceCapTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/PriceCapTest.scala
@@ -10,7 +10,7 @@ class PriceCapTest extends munit.FunSuite {
       PriceCap.cappedPrice(
         oldPrice,
         uncappedNewPrice,
-        priceCappingMultiplier
+        Some(priceCappingMultiplier)
       ),
       BigDecimal(120)
     )
@@ -19,9 +19,9 @@ class PriceCapTest extends munit.FunSuite {
   test("priceCapNotification (no need to apply)") {
     val oldPrice = BigDecimal(100)
     val newPrice = BigDecimal(110)
-    val cap = 1.25
+    val cap = BigDecimal(1.25)
     assertEquals(
-      PriceCap.cappedPrice(oldPrice, newPrice, cap),
+      PriceCap.cappedPrice(oldPrice, newPrice, Some(cap)),
       BigDecimal(110)
     )
   }
@@ -29,9 +29,9 @@ class PriceCapTest extends munit.FunSuite {
   test("priceCapNotification (need to apply)") {
     val oldPrice = BigDecimal(100)
     val newPrice = BigDecimal(250)
-    val cap = 1.25
+    val cap = BigDecimal(1.25)
     assertEquals(
-      PriceCap.cappedPrice(oldPrice, newPrice, cap),
+      PriceCap.cappedPrice(oldPrice, newPrice, Some(cap)),
       BigDecimal(125)
     )
   }


### PR DESCRIPTION
### Introduction

The engine currently has this peculiarity that the price we communicate to the users (at the notification step), the price we communicate to Salesforce (at the Salesforce price rise creation step) as well as the price we mark the subscription with (during the Zuora amendment step) is not actually recorded anywhere. It is always (re)computed on the fly, every time needed, from the old price, the new price and an optional capping. 

The above was the result of a decision I made more than 2 years ago as part of this change: https://github.com/guardian/price-migration-engine/pull/781 , but interestingly at the very bottom of the description of that PR, I wrote:

_Alternative solutions: We could expand the Dynamo table schema to have one field for the capped estimated price and one for the uncapped one. The capped one to be used in communications and the uncapped one used during the Amendment step to compute the price correction factor._

Today we are making a variation of this happen. The motivation was the somehow awkward change I made recently https://github.com/guardian/price-migration-engine/pull/1246 , to adapt the new post migration price check to the case of capped prices.

###  Introducing commsPrice

We expand the CohortItem with an attribute called `commsPrice`, which is computed during the Estimation step, stored in the cohort item, and then used for user comms, Salesforce notification, the Amendment step (both for the Zuora amendment and the post amendment price check.)

### Misc

- Note the introduction of `EstimationHandlerHelper`, which carries the centralised information on migration price cappings. 
- Note that we no longer need to pass `estimatedNewPrice` and `priceCap` to the migrations amendment functions, replacing them with the `commsPrice`
  (i) In the case of Guardian Weekly, we are now only passing `commsPrice` due to its unique charge.  
  (ii) For the summer print migrations, we still need to pass the `oldPrice`, that is to compute the price rise ratio used in the computation of the multi charge price increases.
- I will update all the cohort tables to add the new `commsPrice` attribute before merging this. 
