### PR TITLE
date calculations for SupporterPlus2026

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
@@ -7,6 +7,8 @@ import ujson._
 import upickle.default._
 import zio.ZIO
 
+import scala.util.Random
+
 object SupporterPlus2026Migration {
 
   // ------------------------------------------------
@@ -15,6 +17,30 @@ object SupporterPlus2026Migration {
 
   val maxLeadTime = 35
   val minLeadTime = 33
+
+  // ------------------------------------------------
+  // Helpers
+  // ------------------------------------------------
+
+  def monthliesOverSixWeeks(migrationDate: LocalDate, billingPeriod: BillingPeriod): LocalDate = {
+    // This function takes a migration date and  billing period and either return the same
+    // migration date, or return the migration date plus a number of months randomly chosen between
+    // 0 and 1. This is to ensure that the migration of monthlies is done over 6 weeks.
+
+    // The notifications are starting on 15 July. If we migrated all the monthlies over 1 month,
+    // the monthly price rise dates would be between 19 August and 18th September
+    // If the migration date falls between 19 August and 30th August, we make a random choice and then
+    // possibly add one month.
+
+    (migrationDate, billingPeriod) match {
+      case (_, Annual)                                          => migrationDate
+      case (date, _) if date.isAfter(LocalDate.of(2026, 8, 31)) => date
+      case (date, _)                                            => {
+        val shift = Random.nextInt(2) // decide a random integer in the interval [0, 1]
+        date.plusMonths(shift)
+      }
+    }
+  }
 
   // ------------------------------------------------
   // Primary Functions:

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculator.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculator.scala
@@ -1,7 +1,12 @@
 package pricemigrationengine.model
 
 import pricemigrationengine.handlers.NotificationHandler
-import pricemigrationengine.migrations.{GuardianWeekly2025Migration, Newspaper2025P1Migration, Newspaper2025P3Migration}
+import pricemigrationengine.migrations.{
+  GuardianWeekly2025Migration,
+  Newspaper2025P1Migration,
+  Newspaper2025P3Migration,
+  SupporterPlus2026Migration
+}
 import scala.util.Random
 import java.time.LocalDate
 
@@ -159,6 +164,20 @@ object AmendmentEffectiveDateCalculator {
     // Decides an integer in the interval [0, spreadPeriod-1]
     // The default spread period is 1
 
-    lowerBound4.plusMonths(randomDelayInMonths)
+    var lowerBound5 = lowerBound4.plusMonths(randomDelayInMonths)
+
+    // Special SupporterPlus2026
+    // For this migration we have the requirement to migrate the monthlies over 6 weeks,
+    // which is a non standard calculation. The main function is implemented in
+    // SupporterPlus2026Migration.monthliesOverSixWeeks
+    // and here we call it just for that migration
+
+    MigrationType(cohortSpec) match {
+      case SupporterPlus2026 =>
+        item.billingPeriod
+          .map(bp => SupporterPlus2026Migration.monthliesOverSixWeeks(lowerBound5, BillingPeriod.fromString(bp)))
+          .getOrElse(lowerBound5)
+      case _ => lowerBound5
+    }
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
@@ -1,0 +1,24 @@
+package pricemigrationengine.migrations
+
+import pricemigrationengine.model.CohortTableFilter.ReadyForEstimation
+import pricemigrationengine.model._
+import pricemigrationengine.Fixtures
+
+import java.time.LocalDate
+
+class SupporterPlus2026Test extends munit.FunSuite {
+  test("date calculation") {
+    assertEquals(
+      SupporterPlus2026Migration.monthliesOverSixWeeks(LocalDate.of(2026, 7, 20), Annual),
+      LocalDate.of(2026, 7, 20)
+    )
+    assertEquals(
+      SupporterPlus2026Migration.monthliesOverSixWeeks(LocalDate.of(2026, 9, 1), Monthly),
+      LocalDate.of(2026, 9, 1)
+    )
+    assert(
+      List(LocalDate.of(2026, 7, 21), LocalDate.of(2026, 8, 21))
+        .contains(SupporterPlus2026Migration.monthliesOverSixWeeks(LocalDate.of(2026, 7, 21), Monthly))
+    )
+  }
+}


### PR DESCRIPTION
Here we implement the non standard date calculations for SupporterPlus2026. Notably the novel idea of migrating the monthlies over 6 weeks.