### PR TITLE
price grid for SupporterPlus2026

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
@@ -19,6 +19,25 @@ object SupporterPlus2026Migration {
   val minLeadTime = 33
 
   // ------------------------------------------------
+  // Price Grid
+  // ------------------------------------------------
+
+  val priceGridNewPrices: Map[(BillingPeriod, String), BigDecimal] = Map(
+    (Monthly, "GBP") -> BigDecimal(14.0),
+    (Monthly, "USD") -> BigDecimal(18.0),
+    (Monthly, "EUR") -> BigDecimal(14.0),
+    (Monthly, "AUD") -> BigDecimal(25.0),
+    (Monthly, "CAD") -> BigDecimal(18.0),
+    (Monthly, "NZD") -> BigDecimal(25.0),
+    (Annual, "GBP") -> BigDecimal(140.0),
+    (Annual, "USD") -> BigDecimal(180.0),
+    (Annual, "EUR") -> BigDecimal(140.0),
+    (Annual, "AUD") -> BigDecimal(250.0),
+    (Annual, "CAD") -> BigDecimal(180.0),
+    (Annual, "NZD") -> BigDecimal(250.0),
+  )
+
+  // ------------------------------------------------
   // Helpers
   // ------------------------------------------------
 


### PR DESCRIPTION
Marking the prices for Supporter Plus 2026

<img width="954" height="150" alt="Screenshot 2026-07-02 at 18 18 06" src="https://github.com/user-attachments/assets/5debae7e-18c7-4e64-944f-e73adbbf916d" />

<img width="949" height="144" alt="Screenshot 2026-07-02 at 18 18 13" src="https://github.com/user-attachments/assets/c7503ca3-3e11-4fdd-ba3a-b5a7db7fcd4e" />
