### PR TITLE
pre-commit-hook for gu:sanitised

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: local
+    hooks:
+      - id: check-fixtures-anonymization
+        name: check-fixtures-anonymization.rb
+        entry: tools/check-fixtures-anonymization.rb
+        language: script

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Everyday/Account.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Everyday/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Everyday/Catalogue.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Everyday/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Everyday/InvoicePreview.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Everyday/InvoicePreview.json
@@ -443,5 +443,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Everyday/Subscription.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Everyday/Subscription.json
@@ -1813,5 +1813,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Monthly/Account.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Monthly/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Monthly/Catalogue.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Monthly/Catalogue.json
@@ -13212,5 +13212,6 @@
     }
   ],
   "nextPage": "/v1/catalog/products?page=2&pageSize=10",
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Monthly/InvoicePreview.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Monthly/InvoicePreview.json
@@ -149,5 +149,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Monthly/Subscription.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Monthly/Subscription.json
@@ -544,5 +544,6 @@
       ],
       "subscriptionProductFeatures": []
     }
-  ]
+  ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/QuarterlyVoucher/Account.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/QuarterlyVoucher/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/QuarterlyVoucher/Catalogue.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/QuarterlyVoucher/Catalogue.json
@@ -13212,5 +13212,6 @@
     }
   ],
   "nextPage": "/v1/catalog/products?page=2&pageSize=10",
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/QuarterlyVoucher/InvoicePreview.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/QuarterlyVoucher/InvoicePreview.json
@@ -170,5 +170,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/QuarterlyVoucher/Subscription.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/QuarterlyVoucher/Subscription.json
@@ -185,5 +185,6 @@
       ],
       "subscriptionProductFeatures": []
     }
-  ]
+  ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Sixday+/Account.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Sixday+/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Sixday+/Catalogue.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Sixday+/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Sixday+/InvoicePreview.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Sixday+/InvoicePreview.json
@@ -443,5 +443,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Sixday+/Subscription.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Sixday+/Subscription.json
@@ -1585,5 +1585,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Waitrose25%Discount/Account.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Waitrose25%Discount/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Waitrose25%Discount/Catalogue.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Waitrose25%Discount/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Waitrose25%Discount/InvoicePreview.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Waitrose25%Discount/InvoicePreview.json
@@ -926,5 +926,6 @@
       "appliedToItemId": "912751afbf304419a44bf62d8fae1f6c"
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Handlers/EstimationHandler/Waitrose25%Discount/Subscription.json
+++ b/lambda/src/test/resources/Handlers/EstimationHandler/Waitrose25%Discount/Subscription.json
@@ -281,5 +281,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/01/account.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/01/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/01/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/01/invoice-preview.json
@@ -357,5 +357,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/01/subscription.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/01/subscription.json
@@ -286,5 +286,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/02/account.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/02/account.json
@@ -59,5 +59,6 @@
     "country": "Malaysia"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/02/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/02/invoice-preview.json
@@ -137,5 +137,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/02/subscription.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/02/subscription.json
@@ -286,5 +286,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/03/account.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/03/account.json
@@ -70,5 +70,6 @@
     "companyCode": null,
     "VATId": null
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/03/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/03/invoice-preview.json
@@ -27,5 +27,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/03/subscription.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/03/subscription.json
@@ -190,5 +190,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/04/account.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/04/account.json
@@ -70,5 +70,6 @@
     "companyCode": null,
     "VATId": null
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/04/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/04/invoice-preview.json
@@ -379,5 +379,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/DigiSubs2025/04/subscription.json
+++ b/lambda/src/test/resources/Migrations/DigiSubs2025/04/subscription.json
@@ -190,5 +190,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/6801-Discount/account.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/6801-Discount/account.json
@@ -59,5 +59,6 @@
     "country": "New Zealand"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/6801-Discount/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/6801-Discount/invoice-preview.json
@@ -49,5 +49,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/6801-Discount/subscription.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/6801-Discount/subscription.json
@@ -474,5 +474,6 @@
   "updateTime": "2025-03-23 04:09:16",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/73291-GW-ROW-EUR/account.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/73291-GW-ROW-EUR/account.json
@@ -70,5 +70,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/73291-GW-ROW-EUR/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/73291-GW-ROW-EUR/invoice-preview.json
@@ -115,5 +115,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/73291-GW-ROW-EUR/subscription.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/73291-GW-ROW-EUR/subscription.json
@@ -569,5 +569,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S00531704/account.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S00531704/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S00531704/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S00531704/invoice-preview.json
@@ -159,5 +159,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S00531704/subscription.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S00531704/subscription.json
@@ -472,5 +472,6 @@
   "updateTime": "2025-06-24 10:13:19",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S01332827/account.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S01332827/account.json
@@ -59,5 +59,6 @@
     "country": "Pakistan"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S01332827/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S01332827/invoice-preview.json
@@ -137,5 +137,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S01332827/subscription.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/A-S01332827/subscription.json
@@ -944,5 +944,6 @@
   "updateTime": "2025-07-04 14:11:36",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/EUR-annual1/account.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/EUR-annual1/account.json
@@ -59,5 +59,6 @@
     "country": "Belgium"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/EUR-annual1/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/EUR-annual1/invoice-preview.json
@@ -27,5 +27,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/EUR-annual1/subscription.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/EUR-annual1/subscription.json
@@ -471,5 +471,6 @@
   "updateTime": "2024-12-24 04:14:51",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/GBP-monthly1/account.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/GBP-monthly1/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/GBP-monthly1/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/GBP-monthly1/invoice-preview.json
@@ -357,5 +357,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/GBP-monthly1/subscription.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/GBP-monthly1/subscription.json
@@ -378,5 +378,6 @@
   "updateTime": "2025-05-29 04:15:53",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription1/account.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription1/account.json
@@ -44,5 +44,6 @@
     "country" : "United States"
   },
   "taxInfo" : null,
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription1/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription1/invoice-preview.json
@@ -86,5 +86,6 @@
     "numberOfDeliveries" : 0.000000000
   } ],
   "creditMemoItems" : [ ],
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription1/subscription.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription1/subscription.json
@@ -359,5 +359,6 @@
   "updateTime" : "2025-05-18 04:49:18",
   "scheduledCancelDate" : null,
   "scheduledSuspendDate" : null,
-  "scheduledResumeDate" : null
+  "scheduledResumeDate" : null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription2/account.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription2/account.json
@@ -44,5 +44,6 @@
     "country" : "France"
   },
   "taxInfo" : null,
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription2/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription2/invoice-preview.json
@@ -86,5 +86,6 @@
     "numberOfDeliveries" : 0.000000000
   } ],
   "creditMemoItems" : [ ],
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription2/subscription.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription2/subscription.json
@@ -359,5 +359,6 @@
   "updateTime" : "2025-05-18 04:49:18",
   "scheduledCancelDate" : null,
   "scheduledSuspendDate" : null,
-  "scheduledResumeDate" : null
+  "scheduledResumeDate" : null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription3/account.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription3/account.json
@@ -44,5 +44,6 @@
     "country" : "France"
   },
   "taxInfo" : null,
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription3/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription3/invoice-preview.json
@@ -86,5 +86,6 @@
     "numberOfDeliveries" : 0.000000000
   } ],
   "creditMemoItems" : [ ],
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription3/subscription.json
+++ b/lambda/src/test/resources/Migrations/GuardianWeekly2025/SubscriptionLocalisation/subscription3/subscription.json
@@ -359,5 +359,6 @@
   "updateTime" : "2025-05-18 04:49:18",
   "scheduledCancelDate" : null,
   "scheduledSuspendDate" : null,
-  "scheduledResumeDate" : null
+  "scheduledResumeDate" : null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub1/account.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub1/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub1/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub1/invoice-preview.json
@@ -379,5 +379,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub1/subscription.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub1/subscription.json
@@ -474,5 +474,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub2/account.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub2/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub2/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub2/invoice-preview.json
@@ -379,5 +379,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub2/subscription.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub2/subscription.json
@@ -474,5 +474,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub3/account.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub3/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub3/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub3/invoice-preview.json
@@ -27,5 +27,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub3/subscription.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub3/subscription.json
@@ -476,5 +476,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub4/account.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub4/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub4/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub4/invoice-preview.json
@@ -379,5 +379,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Membership2025/sub4/subscription.json
+++ b/lambda/src/test/resources/Migrations/Membership2025/sub4/subscription.json
@@ -382,5 +382,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/276579/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/276579/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/276579/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/276579/invoice-preview.json
@@ -2623,5 +2623,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/276579/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/276579/subscription.json
@@ -7480,5 +7480,6 @@
   "updateTime": "2025-06-08 04:37:00",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/277526-Discounts-Adjustment/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/277526-Discounts-Adjustment/account.json
@@ -57,5 +57,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/277526-Discounts-Adjustment/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/277526-Discounts-Adjustment/invoice-preview.json
@@ -3369,5 +3369,6 @@
     }
   ],
   "creditMemoItems": [],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/277526-Discounts-Adjustment/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/277526-Discounts-Adjustment/subscription.json
@@ -2778,5 +2778,6 @@
   "updateTime": "2025-06-26 04:29:10",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/280828/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/280828/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/280828/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/280828/invoice-preview.json
@@ -885,5 +885,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/280828/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/280828/subscription.json
@@ -2600,5 +2600,6 @@
   "updateTime": "2025-07-05 04:07:42",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/296144/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/296144/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/296144/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/296144/invoice-preview.json
@@ -2623,5 +2623,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/296144/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/296144/subscription.json
@@ -2768,5 +2768,6 @@
   "updateTime": "2025-06-11 04:25:06",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/344070-EstimationFailed/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/344070-EstimationFailed/account.json
@@ -57,5 +57,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/344070-EstimationFailed/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/344070-EstimationFailed/invoice-preview.json
@@ -2489,5 +2489,6 @@
     }
   ],
   "creditMemoItems": [],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/344070-EstimationFailed/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/344070-EstimationFailed/subscription.json
@@ -1742,5 +1742,6 @@
   "updateTime": "2025-07-06 04:46:23",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/A-S00553498/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/A-S00553498/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/A-S00553498/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/A-S00553498/invoice-preview.json
@@ -2997,5 +2997,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P1/A-S00553498/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P1/A-S00553498/subscription.json
@@ -18520,5 +18520,6 @@
   "updateTime": "2025-07-03 01:07:51",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/277291-everyday-annual/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/277291-everyday-annual/account.json
@@ -57,5 +57,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/277291-everyday-annual/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/277291-everyday-annual/invoice-preview.json
@@ -157,5 +157,6 @@
     }
   ],
   "creditMemoItems": [],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/277291-everyday-annual/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/277291-everyday-annual/subscription.json
@@ -2290,5 +2290,6 @@
   "updateTime": "2025-01-06 04:42:21",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/277750-everyday-month/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/277750-everyday-month/account.json
@@ -57,5 +57,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/277750-everyday-month/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/277750-everyday-month/invoice-preview.json
@@ -2621,5 +2621,6 @@
     }
   ],
   "creditMemoItems": [],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/277750-everyday-month/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/277750-everyday-month/subscription.json
@@ -2290,5 +2290,6 @@
   "updateTime": "2025-06-26 04:14:21",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/412032-sixday-annual/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/412032-sixday-annual/account.json
@@ -57,5 +57,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/412032-sixday-annual/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/412032-sixday-annual/invoice-preview.json
@@ -267,5 +267,6 @@
     }
   ],
   "creditMemoItems": [],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/412032-sixday-annual/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/412032-sixday-annual/subscription.json
@@ -1986,5 +1986,6 @@
   "updateTime": "2024-09-21 04:16:42",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/A-S02075439-saturday-month/account.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/A-S02075439-saturday-month/account.json
@@ -57,5 +57,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/A-S02075439-saturday-month/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/A-S02075439-saturday-month/invoice-preview.json
@@ -355,5 +355,6 @@
     }
   ],
   "creditMemoItems": [],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/Newspaper2025P3/A-S02075439-saturday-month/subscription.json
+++ b/lambda/src/test/resources/Migrations/Newspaper2025P3/A-S02075439-saturday-month/subscription.json
@@ -281,5 +281,6 @@
   "updateTime": "2025-07-02 04:35:29",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/01/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/01/account.json
@@ -70,5 +70,6 @@
     "companyCode": null,
     "VATId": null
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/01/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/01/invoice-preview.json
@@ -379,5 +379,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/01/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/01/subscription.json
@@ -1788,5 +1788,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/02/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/02/account.json
@@ -70,5 +70,6 @@
     "companyCode": null,
     "VATId": null
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/02/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/02/invoice-preview.json
@@ -753,5 +753,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/02/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/02/subscription.json
@@ -626,5 +626,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/03/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/03/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/03/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/03/invoice-preview.json
@@ -2469,5 +2469,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/03/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/03/subscription.json
@@ -3050,5 +3050,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/04/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/04/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/04/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/04/invoice-preview.json
@@ -2249,5 +2249,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/04/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/04/subscription.json
@@ -10540,5 +10540,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/05/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/05/account.json
@@ -70,5 +70,6 @@
     "companyCode": null,
     "VATId": null
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/05/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/05/invoice-preview.json
@@ -709,5 +709,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/05/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/05/subscription.json
@@ -2223,5 +2223,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/06/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/06/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/06/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/06/invoice-preview.json
@@ -2249,5 +2249,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/06/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/06/subscription.json
@@ -7997,5 +7997,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/07/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/07/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/07/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/07/invoice-preview.json
@@ -2931,5 +2931,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/07/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/07/subscription.json
@@ -1587,5 +1587,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/08/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/08/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/08/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/08/invoice-preview.json
@@ -709,5 +709,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/08/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/08/subscription.json
@@ -965,5 +965,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/09/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/09/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/09/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/09/invoice-preview.json
@@ -379,5 +379,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/09/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/09/subscription.json
@@ -755,5 +755,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/10/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/10/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/10/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/10/invoice-preview.json
@@ -2249,5 +2249,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/10/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/10/subscription.json
@@ -2468,5 +2468,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/11/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/11/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/11/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/11/invoice-preview.json
@@ -775,5 +775,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/11/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/11/subscription.json
@@ -2848,5 +2848,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/12/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/12/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/12/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/12/invoice-preview.json
@@ -379,5 +379,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/12/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/12/subscription.json
@@ -380,5 +380,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/13/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/13/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/13/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/13/invoice-preview.json
@@ -753,5 +753,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/13/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/13/subscription.json
@@ -778,5 +778,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/14/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/14/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/14/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/14/invoice-preview.json
@@ -2249,5 +2249,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/14/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/14/subscription.json
@@ -2942,5 +2942,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/15/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/15/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/15/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/15/invoice-preview.json
@@ -2469,5 +2469,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/15/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/15/subscription.json
@@ -3398,5 +3398,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/16/account.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/16/account.json
@@ -59,5 +59,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/16/invoice-preview.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/16/invoice-preview.json
@@ -313,5 +313,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/16/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/16/subscription.json
@@ -2942,5 +2942,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/Tegridy-Farms/01-before/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/Tegridy-Farms/01-before/subscription.json
@@ -965,5 +965,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/Tegridy-Farms/02-after-correct/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/Tegridy-Farms/02-after-correct/subscription.json
@@ -1041,5 +1041,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/Tegridy-Farms/03-after-incorrect-number-of-charges/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/Tegridy-Farms/03-after-incorrect-number-of-charges/subscription.json
@@ -965,5 +965,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/Migrations/ProductMigration2025N4/Tegridy-Farms/04-after-incorrect-extra-name/subscription.json
+++ b/lambda/src/test/resources/Migrations/ProductMigration2025N4/Tegridy-Farms/04-after-incorrect-extra-name/subscription.json
@@ -1041,5 +1041,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/A-S02059070/account.json
+++ b/lambda/src/test/resources/model/AmendmentData/A-S02059070/account.json
@@ -70,5 +70,6 @@
     "companyCode": null,
     "VATId": null
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/A-S02059070/invoice-preview.json
+++ b/lambda/src/test/resources/model/AmendmentData/A-S02059070/invoice-preview.json
@@ -357,5 +357,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/A-S02059070/subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/A-S02059070/subscription.json
@@ -661,5 +661,6 @@
   "updateTime": "2025-06-19 04:01:27",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Discount25%/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Discount25%/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Discount25%/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Discount25%/Catalogue.json
@@ -13212,5 +13212,6 @@
     }
   ],
   "nextPage": "/v1/catalog/products?page=2&pageSize=10",
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Discount25%/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Discount25%/InvoicePreview.json
@@ -170,5 +170,6 @@
       "appliedToItemId": "bc7e90ba471a480f93eacbd6176892f0"
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Discount25%/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Discount25%/Subscription.json
@@ -884,5 +884,6 @@
       ],
       "subscriptionProductFeatures": []
     }
-  ]
+  ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Everyday+/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Everyday+/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Everyday+/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Everyday+/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Everyday+/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Everyday+/InvoicePreview.json
@@ -506,5 +506,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Everyday+/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Everyday+/Subscription.json
@@ -2636,5 +2636,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Everyday+Discounted/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Everyday+Discounted/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Everyday+Discounted/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Everyday+Discounted/InvoicePreview.json
@@ -338,5 +338,6 @@
       "appliedToItemId": "f38e5bfd23c149f991e6800347d69c3a"
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Everyday+Discounted/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Everyday+Discounted/Subscription.json
@@ -603,5 +603,6 @@
       ],
       "subscriptionProductFeatures": []
     }
-  ]
+  ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/InvoicePreviewWithMultipleSubs/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/InvoicePreviewWithMultipleSubs/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/InvoicePreviewWithMultipleSubs/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/InvoicePreviewWithMultipleSubs/InvoicePreview.json
@@ -2312,5 +2312,6 @@
       "appliedToItemId": "b3e5667bf9da4cfdbc25cdf235e86bcb"
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/InvoicePreviewWithMultipleSubs/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/InvoicePreviewWithMultipleSubs/Subscription.json
@@ -684,5 +684,6 @@
       ],
       "subscriptionProductFeatures": []
     }
-  ]
+  ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Misc/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Misc/InvoicePreview.json
@@ -275,5 +275,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Misc/InvoicePreviewTermEndsBeforeMigration.json
+++ b/lambda/src/test/resources/model/AmendmentData/Misc/InvoicePreviewTermEndsBeforeMigration.json
@@ -1178,5 +1178,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Monthly/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Monthly/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Monthly/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Monthly/Catalogue.json
@@ -13212,5 +13212,6 @@
     }
   ],
   "nextPage": "/v1/catalog/products?page=2&pageSize=10",
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Monthly/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Monthly/InvoicePreview.json
@@ -149,5 +149,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Monthly/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Monthly/Subscription.json
@@ -544,5 +544,6 @@
       ],
       "subscriptionProductFeatures": []
     }
-  ]
+  ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020Everyday/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020Everyday/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020Everyday/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020Everyday/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020Everyday/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020Everyday/InvoicePreview.json
@@ -1619,6 +1619,7 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }
 

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020Everyday/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020Everyday/Subscription.json
@@ -3864,5 +3864,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020SixDay/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020SixDay/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020SixDay/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020SixDay/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020SixDay/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020SixDay/InvoicePreview.json
@@ -128,5 +128,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020SixDay/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020SixDay/Subscription.json
@@ -837,5 +837,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020Sixday2/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020Sixday2/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020Sixday2/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020Sixday2/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020Sixday2/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020Sixday2/InvoicePreview.json
@@ -128,6 +128,7 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }
 

--- a/lambda/src/test/resources/model/AmendmentData/Pre2020Sixday2/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Pre2020Sixday2/Subscription.json
@@ -3117,5 +3117,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/QuarterlyVoucher/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/QuarterlyVoucher/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/QuarterlyVoucher/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/QuarterlyVoucher/Catalogue.json
@@ -13212,5 +13212,6 @@
     }
   ],
   "nextPage": "/v1/catalog/products?page=2&pageSize=10",
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/QuarterlyVoucher/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/QuarterlyVoucher/InvoicePreview.json
@@ -170,5 +170,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/QuarterlyVoucher/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/QuarterlyVoucher/Subscription.json
@@ -185,5 +185,6 @@
       ],
       "subscriptionProductFeatures": []
     }
-  ]
+  ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Saturday/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Saturday/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Saturday/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Saturday/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Saturday/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Saturday/InvoicePreview.json
@@ -65,5 +65,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Saturday/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Saturday/Subscription.json
@@ -219,5 +219,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/SemiAnnualVoucher/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/SemiAnnualVoucher/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/SemiAnnualVoucher/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/SemiAnnualVoucher/Catalogue.json
@@ -13212,5 +13212,6 @@
     }
   ],
   "nextPage": "/v1/catalog/products?page=2&pageSize=10",
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/SemiAnnualVoucher/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/SemiAnnualVoucher/InvoicePreview.json
@@ -254,5 +254,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/SemiAnnualVoucher/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/SemiAnnualVoucher/Subscription.json
@@ -417,5 +417,6 @@
       ],
       "subscriptionProductFeatures": []
     }
-  ]
+  ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sixday+/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sixday+/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sixday+/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sixday+/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sixday+/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sixday+/InvoicePreview.json
@@ -443,5 +443,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sixday+/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sixday+/Subscription.json
@@ -1585,5 +1585,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sixday/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sixday/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sixday/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sixday/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sixday/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sixday/InvoicePreview.json
@@ -254,5 +254,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sixday/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sixday/Subscription.json
@@ -4182,5 +4182,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sunday/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sunday/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sunday/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sunday/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sunday/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sunday/InvoicePreview.json
@@ -44,5 +44,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Sunday/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Sunday/Subscription.json
@@ -295,5 +295,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Waitrose25%Discount/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Waitrose25%Discount/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Waitrose25%Discount/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Waitrose25%Discount/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Waitrose25%Discount/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Waitrose25%Discount/InvoicePreview.json
@@ -926,5 +926,6 @@
       "appliedToItemId": "912751afbf304419a44bf62d8fae1f6c"
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Waitrose25%Discount/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Waitrose25%Discount/Subscription.json
@@ -281,5 +281,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Weekend/Account.json
+++ b/lambda/src/test/resources/model/AmendmentData/Weekend/Account.json
@@ -102,5 +102,6 @@
     "companyCode": null,
     "VATId": ""
   },
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Weekend/Catalogue.json
+++ b/lambda/src/test/resources/model/AmendmentData/Weekend/Catalogue.json
@@ -24055,5 +24055,6 @@
       ]
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Weekend/InvoicePreview.json
+++ b/lambda/src/test/resources/model/AmendmentData/Weekend/InvoicePreview.json
@@ -170,5 +170,6 @@
       "appliedToItemId": null
     }
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentData/Weekend/Subscription.json
+++ b/lambda/src/test/resources/model/AmendmentData/Weekend/Subscription.json
@@ -2714,5 +2714,6 @@
       "externallyManagedPlanId": null
     }
   ],
-  "externallyManagedBy": null
+  "externallyManagedBy": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription-03/subscription.json
+++ b/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription-03/subscription.json
@@ -190,5 +190,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription-04/subscription.json
+++ b/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription-04/subscription.json
@@ -190,5 +190,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription1/account.json
+++ b/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription1/account.json
@@ -59,5 +59,6 @@
     "country": "Belgium"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription1/invoice-preview.json
+++ b/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription1/invoice-preview.json
@@ -27,5 +27,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription1/subscription.json
+++ b/lambda/src/test/resources/model/AmendmentEffectiveDateCalculator/subscription1/subscription.json
@@ -471,5 +471,6 @@
   "updateTime": "2024-12-24 04:14:51",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentHandlerHelper/1761090945067/invoice-preview.json
+++ b/lambda/src/test/resources/model/AmendmentHandlerHelper/1761090945067/invoice-preview.json
@@ -797,5 +797,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentHandlerHelper/1761090945067/subscription.json
+++ b/lambda/src/test/resources/model/AmendmentHandlerHelper/1761090945067/subscription.json
@@ -628,5 +628,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentHandlerHelper/277291-everyday-annual/account.json
+++ b/lambda/src/test/resources/model/AmendmentHandlerHelper/277291-everyday-annual/account.json
@@ -57,5 +57,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentHandlerHelper/277291-everyday-annual/invoice-preview.json
+++ b/lambda/src/test/resources/model/AmendmentHandlerHelper/277291-everyday-annual/invoice-preview.json
@@ -157,5 +157,6 @@
     }
   ],
   "creditMemoItems": [],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentHandlerHelper/277291-everyday-annual/subscription.json
+++ b/lambda/src/test/resources/model/AmendmentHandlerHelper/277291-everyday-annual/subscription.json
@@ -2290,5 +2290,6 @@
   "updateTime": "2025-01-06 04:42:21",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentHandlerHelper/277750-everyday-month/account.json
+++ b/lambda/src/test/resources/model/AmendmentHandlerHelper/277750-everyday-month/account.json
@@ -57,5 +57,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentHandlerHelper/277750-everyday-month/invoice-preview.json
+++ b/lambda/src/test/resources/model/AmendmentHandlerHelper/277750-everyday-month/invoice-preview.json
@@ -2621,5 +2621,6 @@
     }
   ],
   "creditMemoItems": [],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/AmendmentHandlerHelper/277750-everyday-month/subscription.json
+++ b/lambda/src/test/resources/model/AmendmentHandlerHelper/277750-everyday-month/subscription.json
@@ -2290,5 +2290,6 @@
   "updateTime": "2025-06-26 04:14:21",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/RatePlanProbe/NewspaperHomeDelivery-Quarterly-Cancelled/subscription.json
+++ b/lambda/src/test/resources/model/RatePlanProbe/NewspaperHomeDelivery-Quarterly-Cancelled/subscription.json
@@ -3785,5 +3785,6 @@
     "startDate" : "2024-11-05",
     "endDate" : null,
     "status" : "OutOfTerm"
-  } ]
+  } ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/RatePlanProbe/NewspaperHomeDelivery-Quarterly/subscription.json
+++ b/lambda/src/test/resources/model/RatePlanProbe/NewspaperHomeDelivery-Quarterly/subscription.json
@@ -3785,5 +3785,6 @@
     "startDate" : "2024-11-05",
     "endDate" : null,
     "status" : "OutOfTerm"
-  } ]
+  } ],
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription1/account.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription1/account.json
@@ -44,5 +44,6 @@
     "country" : "United States"
   },
   "taxInfo" : null,
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription1/invoice-preview.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription1/invoice-preview.json
@@ -86,5 +86,6 @@
     "numberOfDeliveries" : 0.000000000
   } ],
   "creditMemoItems" : [ ],
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription1/product.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription1/product.json
@@ -18781,5 +18781,6 @@
     "productFeatures" : [ ]
   } ],
   "nextPage" : "/v1/catalog/products?page=2&pageSize=10",
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription1/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription1/subscription.json
@@ -359,5 +359,6 @@
   "updateTime" : "2025-05-18 04:49:18",
   "scheduledCancelDate" : null,
   "scheduledSuspendDate" : null,
-  "scheduledResumeDate" : null
+  "scheduledResumeDate" : null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription2/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription2/subscription.json
@@ -471,5 +471,6 @@
   "updateTime": "2024-12-24 04:14:51",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription3-with-discount/account.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription3-with-discount/account.json
@@ -59,5 +59,6 @@
     "country": "New Zealand"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription3-with-discount/invoice-preview.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription3-with-discount/invoice-preview.json
@@ -49,5 +49,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription3-with-discount/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription3-with-discount/subscription.json
@@ -472,5 +472,6 @@
   "updateTime": "2025-03-23 04:09:16",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription4-511760-Discount-Adjustment/account.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription4-511760-Discount-Adjustment/account.json
@@ -57,5 +57,6 @@
     "country": "United Kingdom"
   },
   "taxInfo": null,
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription4-511760-Discount-Adjustment/invoice-preview.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription4-511760-Discount-Adjustment/invoice-preview.json
@@ -1059,5 +1059,6 @@
     }
   ],
   "creditMemoItems": [],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription4-511760-Discount-Adjustment/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription4-511760-Discount-Adjustment/subscription.json
@@ -1045,5 +1045,6 @@
   "updateTime": "2025-07-04 04:05:53",
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
-  "scheduledResumeDate": null
+  "scheduledResumeDate": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription5-multiple-products-in-invoice-preview/invoice-preview.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription5-multiple-products-in-invoice-preview/invoice-preview.json
@@ -797,5 +797,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription5-multiple-products-in-invoice-preview/readme.md
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription5-multiple-products-in-invoice-preview/readme.md
@@ -21,7 +21,8 @@ This subscription has the property that at the time it was captured (17 October 
   "chargeType": "Recurring",
   "processingType": "Charge",
   "appliedToItemId": null,
-  "numberOfDeliveries": 0.0
+  "numberOfDeliveries": 0.0,
+  "gu:sanitised": true
 }
 ```
 
@@ -54,6 +55,7 @@ A latter invoice preview items was the one we were looking for, and the charge n
   "chargeType": "Recurring",
   "processingType": "Charge",
   "appliedToItemId": null,
-  "numberOfDeliveries": 0.0
+  "numberOfDeliveries": 0.0,
+  "gu:sanitised": true
 }
 ```

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription5-multiple-products-in-invoice-preview/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription5-multiple-products-in-invoice-preview/subscription.json
@@ -288,5 +288,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription6-multiple-products-in-invoice-preview/invoice-preview.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription6-multiple-products-in-invoice-preview/invoice-preview.json
@@ -753,5 +753,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription6-multiple-products-in-invoice-preview/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription6-multiple-products-in-invoice-preview/subscription.json
@@ -382,5 +382,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription7-product-and-discount-in-invoice-preview/invoice-preview.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription7-product-and-discount-in-invoice-preview/invoice-preview.json
@@ -71,5 +71,6 @@
   "creditMemoItems": [
 
   ],
-  "success": true
+  "success": true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription7-product-and-discount-in-invoice-preview/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription7-product-and-discount-in-invoice-preview/subscription.json
@@ -382,5 +382,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription8-two-active-rate-plans-one-zombie/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionIntrospection2025/subscription8-two-active-rate-plans-one-zombie/subscription.json
@@ -474,5 +474,6 @@
   "scheduledCancelDate": null,
   "scheduledSuspendDate": null,
   "scheduledResumeDate": null,
-  "communicationProfileId": null
+  "communicationProfileId": null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionLocalisation/subscription1/account.json
+++ b/lambda/src/test/resources/model/SubscriptionLocalisation/subscription1/account.json
@@ -44,5 +44,6 @@
     "country" : "United States"
   },
   "taxInfo" : null,
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionLocalisation/subscription1/invoice-preview.json
+++ b/lambda/src/test/resources/model/SubscriptionLocalisation/subscription1/invoice-preview.json
@@ -86,5 +86,6 @@
     "numberOfDeliveries" : 0.000000000
   } ],
   "creditMemoItems" : [ ],
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionLocalisation/subscription1/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionLocalisation/subscription1/subscription.json
@@ -359,5 +359,6 @@
   "updateTime" : "2025-05-18 04:49:18",
   "scheduledCancelDate" : null,
   "scheduledSuspendDate" : null,
-  "scheduledResumeDate" : null
+  "scheduledResumeDate" : null,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionLocalisation/subscription2/account.json
+++ b/lambda/src/test/resources/model/SubscriptionLocalisation/subscription2/account.json
@@ -44,5 +44,6 @@
     "country" : "France"
   },
   "taxInfo" : null,
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionLocalisation/subscription2/invoice-preview.json
+++ b/lambda/src/test/resources/model/SubscriptionLocalisation/subscription2/invoice-preview.json
@@ -86,5 +86,6 @@
     "numberOfDeliveries" : 0.000000000
   } ],
   "creditMemoItems" : [ ],
-  "success" : true
+  "success" : true,
+  "gu:sanitised": true
 }

--- a/lambda/src/test/resources/model/SubscriptionLocalisation/subscription2/subscription.json
+++ b/lambda/src/test/resources/model/SubscriptionLocalisation/subscription2/subscription.json
@@ -359,5 +359,6 @@
   "updateTime" : "2025-05-18 04:49:18",
   "scheduledCancelDate" : null,
   "scheduledSuspendDate" : null,
-  "scheduledResumeDate" : null
+  "scheduledResumeDate" : null,
+  "gu:sanitised": true
 }

--- a/tools/check-fixtures-anonymization.rb
+++ b/tools/check-fixtures-anonymization.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/ruby
+
+require 'json'
+require 'find'
+require 'pathname'
+
+def check_json_file(file_path)
+  begin
+    content = File.read(file_path)
+    data = JSON.parse(content)
+    
+    if data.key?('gu:sanitised') && data['gu:sanitised'] == true
+      return { valid: true, message: nil }
+    else
+      return { valid: false, message: "gu:sanitised missing or not true" }
+    end
+  rescue JSON::ParserError => e
+    return { valid: false, message: "invalid json, error: #{e.message}" }
+  rescue Errno::ENOENT => e
+    return { valid: false, message: "file not found, error: #{e.message}" }
+  rescue => e
+    return { valid: false, message: e.message }
+  end
+end
+
+repo_root = `git rev-parse --show-toplevel`.strip
+
+target_dir = Pathname.new(repo_root).join('lambda', 'src', 'test', 'resources').to_s
+
+unless Dir.exist?(target_dir)
+  puts "error: directory '#{target_dir}' not found!"
+  exit 1
+end
+
+puts "checking fixtures in #{target_dir}..."
+
+json_files = []
+invalid_files = []
+
+Find.find(target_dir) do |path|
+  next unless File.file?(path) && path.end_with?('.json')
+  json_files << path
+end
+
+if json_files.empty?
+  exit 0
+end
+
+json_files.each do |file_path|
+  result = check_json_file(file_path)
+  if !result[:valid]
+    puts "#{file_path}, error: #{result[:message]}"
+    invalid_files << file_path
+  end
+end
+
+if invalid_files.any?
+  exit 1
+else
+  puts "all json files have 'gu:sanitised' set to true!"
+  exit 0
+end

--- a/tools/engine-fixtures-anonymisation.rb
+++ b/tools/engine-fixtures-anonymisation.rb
@@ -48,6 +48,7 @@ subscription = JSON.parse(IO.read(subscription_filepath))
 subscription["billToContact"] = nil
 subscription["soldToContact"] = nil
 subscription["CreatedByCSR__c"] = nil
+subscription["gu:sanitised"] = true
 File.open(subscription_filepath, "w"){|f| f.puts(JSON.pretty_generate(subscription)) }
 
 # ----------------------------------------------------
@@ -69,6 +70,7 @@ account["billToContact"] = nil
 account["soldToContact"] = {
     "country" => account["soldToContact"]["country"]
 }
+account["gu:sanitised"] = true
 File.open(account_filepath, "w"){|f| f.puts(JSON.pretty_generate(account)) }
 
 # ----------------------------------------------------
@@ -83,4 +85,5 @@ invoice_preview["invoiceItems"] = invoice_preview["invoiceItems"]
         invoiceItem["subscriptionNumber"] = "subscriptionNumber"
         invoiceItem
     }
+invoice_preview["gu:sanitised"] = true
 File.open(invoice_preview_filepath, "w"){|f| f.puts(JSON.pretty_generate(invoice_preview)) }

--- a/tools/engine-fixtures-anonymisation.rb
+++ b/tools/engine-fixtures-anonymisation.rb
@@ -32,7 +32,7 @@ end
 # ----------------------------------------------------
 # Anonymize subscription
 puts "processing subscription"
-subscription = JSON.parse(IO.read(subscription_filepath))
+subscription = JSON.parse(File.read(subscription_filepath))
 [
     "id", 
     "accountId",
@@ -54,7 +54,7 @@ File.open(subscription_filepath, "w"){|f| f.puts(JSON.pretty_generate(subscripti
 # ----------------------------------------------------
 # Anonymize account
 puts "processing account"
-account = JSON.parse(IO.read(account_filepath))
+account = JSON.parse(File.read(account_filepath))
 [
     "id",
     "name",
@@ -76,7 +76,7 @@ File.open(account_filepath, "w"){|f| f.puts(JSON.pretty_generate(account)) }
 # ----------------------------------------------------
 # Anonymize invoice preview
 puts "processing invoice preview"
-invoice_preview = JSON.parse(IO.read(invoice_preview_filepath))
+invoice_preview = JSON.parse(File.read(invoice_preview_filepath))
 invoice_preview["accountId"] = "accountId"
 invoice_preview["invoiceItems"] = invoice_preview["invoiceItems"]
     .map{|invoiceItem|


### PR DESCRIPTION
Introduce a pre-commit hook that checks that the fixture files all carry the `gu:sanitised` marker. This is a precaution to ensure that fixtures that have not been sanitised, cannot be committed. The marker has been added to all the existing fixtures. 