### PR TITLE
notification: check product name

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -60,9 +60,31 @@ object NotificationHandler extends CohortHandler {
               .fetch(SalesforcePriceRiseCreationComplete, Some(today.plusDays(maxLeadTime(cohortSpec))))
               .filter(item => item.subscriptionName == subscriptionNumber)
         }
-      )
-        .mapZIO(item => sendNotification(cohortSpec)(item, today))
-        .runCount
+      ).mapZIO { item =>
+        for {
+          subscription <- Zuora.fetchSubscription(item.subscriptionName)
+          hasCorrectProduct = SI2025RateplanFromSub
+            .uniquelyDeterminedActiveNonDiscountNonExpiredRatePlanHasGivenProductNameDefaultToTrue(
+              subscription,
+              today,
+              NotificationHandlerHelper.expectedProductNameOpt(cohortSpec)
+            )
+          result <-
+            if (hasCorrectProduct) {
+              sendNotification(cohortSpec)(item, today)
+            } else {
+              CohortTable
+                .update(
+                  CohortItem(
+                    item.subscriptionName,
+                    processingStage = ExcludedFromMigration,
+                    cancellationReason = Some("excluded from migration due to unexpected product name")
+                  )
+                )
+                .as(())
+            }
+        } yield result
+      }.runCount
     } yield HandlerOutput(isComplete = count < batchSize)
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortTableFilter.scala
@@ -28,6 +28,7 @@ object CohortTableFilter {
   case object NoPriceIncrease extends CohortTableFilter { override val value: String = "NoPriceIncrease" }
   case object ZuoraCancellation extends CohortTableFilter { override val value: String = "ZuoraCancellation" }
   case object EstimationNotPossible extends CohortTableFilter { override val value: String = "EstimationNotPossible" }
+  case object ExcludedFromMigration extends CohortTableFilter { override val value: String = "ExcludedFromMigration" }
 
   // exceptional states
 

--- a/lambda/src/main/scala/pricemigrationengine/model/NotificationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/NotificationHandlerHelper.scala
@@ -49,4 +49,17 @@ object NotificationHandlerHelper {
       case SupporterPlus2026 => true
     }
   }
+
+  def expectedProductNameOpt(cohortSpec: CohortSpec): Option[String] = {
+    MigrationType(cohortSpec) match {
+      case Test1                  => None
+      case GuardianWeekly2025     => None
+      case Newspaper2025P1        => None
+      case Newspaper2025P3        => None
+      case ProductMigration2025N4 => None
+      case Membership2025         => None
+      case DigiSubs2025           => None
+      case SupporterPlus2026      => Some("Supporter Plus")
+    }
+  }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/SubscriptionIntrospection2025.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SubscriptionIntrospection2025.scala
@@ -102,6 +102,32 @@ object SI2025RateplanFromSub {
         )
     }
   }
+
+  def uniquelyDeterminedActiveNonDiscountNonExpiredRatePlanHasGivenProductNameDefaultToTrue(
+      subscription: ZuoraSubscription,
+      today: LocalDate,
+      productNameOpt: Option[String]
+  ): Boolean = {
+    // This function essentially returns `true` if the uniquely contextual
+    // rate plan product name is what we expect. This was introduced to
+    // ensure that at Notification time or Amendment time the subscription
+    // has not moved to a different product. This can happen to, for instance,
+    // to Supporter Plus subs that can be transmuted to Digital Packs
+
+    productNameOpt match {
+      case Some(productName) => {
+        val ratePlanOpt = uniquelyDeterminedActiveNonDiscountNonExpiredRatePlan(
+          subscription: ZuoraSubscription,
+          today: LocalDate
+        )
+        ratePlanOpt match {
+          case Some(ratePlan) => ratePlan.productName == productName
+          case None           => false
+        }
+      }
+      case None => true // for backward compatibility when the information is not available for previous subs
+    }
+  }
 }
 
 object SI2025Extractions {


### PR DESCRIPTION
There currently is a problem with the Notification handler: if the subscription's active rate plan has moved from one product to another, then the notification would happen erroneously. This can happen with Supporter Plus transmuting to Digital Packs

So we introduce a few functions  

1. `expectedProductNameOpt` in the NotificationHandlerHelper indicate which product name we are expecting a subscription active rate plan to have at the time of notification. Note that it is likely that we are going to slightly update the signature of this function in the future to return a list of names instead of just one. 

2. We add a function in SubscriptionIntrospection2025 to simplify the lookup.

3. Modify the Notification handler `main` function to perform the check and if the subscription fails it, it's moved to a new terminal processing stage called `ExcludedFromMigration`.

Note that there will be another PR where we do the same for the Amendment handler. 


