### PR TITLE
refactoring

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -60,31 +60,7 @@ object NotificationHandler extends CohortHandler {
               .fetch(SalesforcePriceRiseCreationComplete, Some(today.plusDays(maxLeadTime(cohortSpec))))
               .filter(item => item.subscriptionName == subscriptionNumber)
         }
-      ).mapZIO { item =>
-        for {
-          subscription <- Zuora.fetchSubscription(item.subscriptionName)
-          hasCorrectProduct = SI2025RateplanFromSub
-            .uniquelyDeterminedActiveNonDiscountNonExpiredRatePlanHasGivenProductNameDefaultToTrue(
-              subscription,
-              today,
-              NotificationHandlerHelper.expectedProductNameOpt(cohortSpec)
-            )
-          result <-
-            if (hasCorrectProduct) {
-              sendNotification(cohortSpec)(item, today)
-            } else {
-              CohortTable
-                .update(
-                  CohortItem(
-                    item.subscriptionName,
-                    processingStage = ExcludedFromMigration,
-                    cancellationReason = Some("excluded from migration due to unexpected product name")
-                  )
-                )
-                .as(())
-            }
-        } yield result
-      }.runCount
+      ).mapZIO { item => performProductNameCheckAndSendNotification(cohortSpec, item, today) }.runCount
     } yield HandlerOutput(isComplete = count < batchSize)
   }
 
@@ -106,6 +82,44 @@ object NotificationHandler extends CohortHandler {
         s"Subscription ${item.subscriptionName} has been cancelled in Zuora, price rise notification not sent"
       )
     } yield ()
+  }
+
+  def performProductNameCheckAndSendNotification(
+      cohortSpec: CohortSpec,
+      item: CohortItem,
+      date: LocalDate
+  ): ZIO[CohortTable with SalesforceClient with EmailSender with Zuora with Logging, Failure, Unit] = {
+    for {
+      subscription <- Zuora.fetchSubscription(item.subscriptionName)
+      ratePlan <- ZIO
+        .fromOption(
+          SI2025RateplanFromSub.uniquelyDeterminedActiveNonDiscountNonExpiredRatePlan(
+            subscription,
+            date
+          )
+        )
+        .orElseFail(DataExtractionFailure(s"[cd6e6562] could not determine rate plan for item $item"))
+      hasCorrectProductName = NotificationHandlerHelper
+        .checkProductName(
+          ratePlan,
+          date,
+          NotificationHandlerHelper.expectedProductNameOpt(cohortSpec)
+        )
+      result <-
+        if (hasCorrectProductName) {
+          sendNotification(cohortSpec)(item, date)
+        } else {
+          CohortTable
+            .update(
+              CohortItem(
+                item.subscriptionName,
+                processingStage = ExcludedFromMigration,
+                cancellationReason = Some(s"item $item excluded from migration due to unexpected product name")
+              )
+            )
+            .as(())
+        }
+    } yield result
   }
 
   def sendNotification(cohortSpec: CohortSpec)(

--- a/lambda/src/main/scala/pricemigrationengine/model/NotificationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/NotificationHandlerHelper.scala
@@ -1,5 +1,6 @@
 package pricemigrationengine.model
 
+import java.time.LocalDate
 import pricemigrationengine.model.membershipworkflow.EmailMessage
 
 object NotificationHandlerHelper {
@@ -60,6 +61,24 @@ object NotificationHandlerHelper {
       case Membership2025         => None
       case DigiSubs2025           => None
       case SupporterPlus2026      => Some("Supporter Plus")
+    }
+  }
+
+  def checkProductName(
+      ratePlan: ZuoraRatePlan,
+      today: LocalDate,
+      productNameOpt: Option[String]
+  ): Boolean = {
+    // This function essentially returns `true` if the rate plan product name is
+    // what we expect. This was introduced to ensure that at Notification time
+    // the subscription has not moved to a different product. This can happen to,
+    // for instance, to Supporter Plus subs that can be transmuted to Digital Packs
+
+    productNameOpt match {
+      case Some(productName) => {
+        ratePlan.productName == productName
+      }
+      case None => true // for backward compatibility when the information is not available for previous subs
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/SubscriptionIntrospection2025.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SubscriptionIntrospection2025.scala
@@ -102,32 +102,6 @@ object SI2025RateplanFromSub {
         )
     }
   }
-
-  def uniquelyDeterminedActiveNonDiscountNonExpiredRatePlanHasGivenProductNameDefaultToTrue(
-      subscription: ZuoraSubscription,
-      today: LocalDate,
-      productNameOpt: Option[String]
-  ): Boolean = {
-    // This function essentially returns `true` if the uniquely contextual
-    // rate plan product name is what we expect. This was introduced to
-    // ensure that at Notification time or Amendment time the subscription
-    // has not moved to a different product. This can happen to, for instance,
-    // to Supporter Plus subs that can be transmuted to Digital Packs
-
-    productNameOpt match {
-      case Some(productName) => {
-        val ratePlanOpt = uniquelyDeterminedActiveNonDiscountNonExpiredRatePlan(
-          subscription: ZuoraSubscription,
-          today: LocalDate
-        )
-        ratePlanOpt match {
-          case Some(ratePlan) => ratePlan.productName == productName
-          case None           => false
-        }
-      }
-      case None => true // for backward compatibility when the information is not available for previous subs
-    }
-  }
 }
 
 object SI2025Extractions {


### PR DESCRIPTION
This is a small refactoring, follow up of https://github.com/guardian/price-migration-engine/pull/1465 , to simplify naming and structure