### PR TITLE
check for cancellation before calling performProductNameCheckAndSendNotification

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -60,7 +60,12 @@ object NotificationHandler extends CohortHandler {
               .fetch(SalesforcePriceRiseCreationComplete, Some(today.plusDays(maxLeadTime(cohortSpec))))
               .filter(item => item.subscriptionName == subscriptionNumber)
         }
-      ).mapZIO { item => performProductNameCheckAndSendNotification(cohortSpec, item, today) }.runCount
+      ).mapZIO { item =>
+        for {
+          subscription <- Zuora.fetchSubscription(item.subscriptionName)
+          _ <- performProductNameCheckAndSendNotification(cohortSpec, item, subscription, today)
+        } yield ()
+      }.runCount
     } yield HandlerOutput(isComplete = count < batchSize)
   }
 
@@ -87,10 +92,10 @@ object NotificationHandler extends CohortHandler {
   def performProductNameCheckAndSendNotification(
       cohortSpec: CohortSpec,
       item: CohortItem,
+      subscription: ZuoraSubscription,
       date: LocalDate
   ): ZIO[CohortTable with SalesforceClient with EmailSender with Zuora with Logging, Failure, Unit] = {
     for {
-      subscription <- Zuora.fetchSubscription(item.subscriptionName)
       ratePlan <- ZIO
         .fromOption(
           SI2025RateplanFromSub.uniquelyDeterminedActiveNonDiscountNonExpiredRatePlan(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -63,7 +63,12 @@ object NotificationHandler extends CohortHandler {
       ).mapZIO { item =>
         for {
           subscription <- Zuora.fetchSubscription(item.subscriptionName)
-          _ <- performProductNameCheckAndSendNotification(cohortSpec, item, subscription, today)
+          _ <-
+            if (subscription.status == "Cancelled") {
+              updateCohortItemForZuoraCancellation(cohortSpec, item)
+            } else {
+              performProductNameCheckAndSendNotification(cohortSpec, item, subscription, today)
+            }
         } yield ()
       }.runCount
     } yield HandlerOutput(isComplete = count < batchSize)


### PR DESCRIPTION
Two days ago I added a product name check to the notification handler: https://github.com/guardian/price-migration-engine/pull/1465 , but just realised that it fails if the subscription has been cancelled 🙃

This adds the subscription cancellation check. 