### PR TITLE
Configure notification step for SP2026

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -117,7 +117,7 @@ object NotificationHandler extends CohortHandler {
         )
       result <-
         if (hasCorrectProductName) {
-          sendNotification(cohortSpec)(item, date)
+          sendNotification(cohortSpec, subscription)(item, date)
         } else {
           CohortTable
             .update(
@@ -132,7 +132,7 @@ object NotificationHandler extends CohortHandler {
     } yield result
   }
 
-  def sendNotification(cohortSpec: CohortSpec)(
+  def sendNotification(cohortSpec: CohortSpec, zuoraSubscription: ZuoraSubscription)(
       cohortItem: CohortItem,
       today: LocalDate
   ): ZIO[EmailSender with SalesforceClient with CohortTable with Logging with Zuora, Failure, Unit] = {
@@ -158,7 +158,7 @@ object NotificationHandler extends CohortHandler {
         if (sfSubscription.Status__c == Cancelled_Status) {
           updateCohortItemForZuoraCancellation(cohortSpec, cohortItem)
         } else {
-          sendNotification(cohortSpec, cohortItem, sfSubscription)
+          sendNotification(cohortSpec, cohortItem, sfSubscription, zuoraSubscription)
         }
     } yield ()
   }
@@ -166,7 +166,8 @@ object NotificationHandler extends CohortHandler {
   def sendNotification(
       cohortSpec: CohortSpec,
       cohortItem: CohortItem,
-      sfSubscription: SalesforceSubscription
+      sfSubscription: SalesforceSubscription,
+      zuoraSubscription: ZuoraSubscription
   ): ZIO[Zuora with EmailSender with SalesforceClient with CohortTable with Logging, Failure, Unit] =
     for {
       _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
@@ -217,7 +218,21 @@ object NotificationHandler extends CohortHandler {
           .orElseFail(DataExtractionFailure(s"[c20f44b1] How did we get here ? 🤔"))
       // ----------------------------------------------------
 
-      brazeName <- brazeName(cohortSpec, cohortItem)
+      // ----------------------------------------------------
+      // Data for SupporterPlus2026
+      supporterPlus2026ExtraData <-
+        ZIO
+          .fromOption(
+            SupporterPlus2026Migration.extractEmailExtraAttributes(
+              cohortSpec,
+              cohortItem,
+              zuoraSubscription,
+            )
+          )
+          .orElseFail(DataExtractionFailure(s"[2ae40ea0] How did we get here ? 🤔"))
+      // ----------------------------------------------------
+
+      brazeName <- brazeName(cohortSpec, cohortItem, zuoraSubscription)
 
       message = EmailMessage(
         EmailPayload(
@@ -258,6 +273,13 @@ object NotificationHandler extends CohortHandler {
               // ProductMigration2025N4 extension
               newspaper2025_phase4_brand_title = Some(productMigration2025N4NotificationData.brandTitle),
               newspaper2025_phase4_formstack_url = Some(productMigration2025N4NotificationData.formstackUrl),
+              // -------------------------------------------------------------
+
+              // -------------------------------------------------------------
+              // SupporterPlus2026 extension
+              sp2026_contribution_amount = Some(supporterPlus2026ExtraData.contributionAmount),
+              sp2026_current_combined_amount = Some(supporterPlus2026ExtraData.currentCombinedAmount),
+              sp2026_new_combined_amount = Some(supporterPlus2026ExtraData.newCombinedAmount)
               // -------------------------------------------------------------
             )
           )
@@ -562,7 +584,11 @@ object NotificationHandler extends CohortHandler {
   // `cohortSpec.brazeName` the default carrier of this information, but for some migrations
   // we have several canvases and we want to select one depending on the subscription.
 
-  def brazeName(cohortSpec: CohortSpec, item: CohortItem): ZIO[Zuora, Failure, String] = {
+  def brazeName(
+      cohortSpec: CohortSpec,
+      item: CohortItem,
+      zuoraSubscription: ZuoraSubscription
+  ): ZIO[Zuora, Failure, String] = {
     MigrationType(cohortSpec) match {
       case ProductMigration2025N4 =>
         ZIO
@@ -581,6 +607,12 @@ object NotificationHandler extends CohortHandler {
           .fromOption(DigiSubs2025Migration.brazeName(item))
           .orElseFail(
             DataExtractionFailure(s"[e3f83ac4] could not determine brazeName for DigiSubs2025, item: ${item}")
+          )
+      case SupporterPlus2026 =>
+        ZIO
+          .fromOption(SupporterPlus2026Migration.brazeName(item, zuoraSubscription))
+          .orElseFail(
+            DataExtractionFailure(s"[15ecdf55] could not determine brazeName for SupporterPlus2026, item: ${item}")
           )
       case _ => ZIO.succeed(cohortSpec.brazeName)
     }

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
@@ -10,9 +10,9 @@ import zio.ZIO
 import scala.util.Random
 
 case class SP2026EmailExtraAttributes(
-    contributionAmount: BigDecimal,
-    currentCombinedAmount: BigDecimal,
-    newCombinedAmount: BigDecimal
+    contributionAmount: String,
+    currentCombinedAmount: String,
+    newCombinedAmount: String
 )
 
 object SupporterPlus2026Migration {
@@ -94,20 +94,75 @@ object SupporterPlus2026Migration {
   }
 
   def extractEmailExtraAttributes(
+      cohortSpec: CohortSpec,
+      cohortItem: CohortItem,
       subscription: ZuoraSubscription,
-      cohortItem: CohortItem
   ): Option[SP2026EmailExtraAttributes] = {
+
+    MigrationType(cohortSpec) match {
+      case SupporterPlus2026 => {
+        for {
+          contributionAmount <- subscriptionToContributionAmount(subscription)
+          currentBaseAmount <- cohortItem.oldPrice
+          currentCombinedAmount = currentBaseAmount + contributionAmount
+          futureBaseAmount <- cohortItem.commsPrice
+          futureCombinedAmount = futureBaseAmount + contributionAmount
+        } yield SP2026EmailExtraAttributes(
+          contributionAmount.toString(),
+          currentCombinedAmount.toString(),
+          futureCombinedAmount.toString()
+        )
+      }
+      case _ =>
+        Some(
+          // Date: 9th July 2026
+          // For Tom reading this... Same as usual, I can't return a None
+          // and the case class cannot have its fields defined as Options :)
+          SP2026EmailExtraAttributes(
+            "",
+            "",
+            ""
+          )
+        )
+    }
+
+  }
+
+  def brazeName(cohortItem: CohortItem, subscription: ZuoraSubscription): Option[String] = {
+    /*
+        Canvases:
+
+        Name       : SV_SP_PriceRiseMonthlyNoCont2026
+        ID         : d7181793-e2b4-45fc-a3fa-2fdd274d6ca7
+        Description: Monthly S+ without a contribution
+
+        Name       : SV_SP_PriceRiseAnnualNoCont2026
+        ID         : 302c16dd-a3a9-4d01-a01e-324fadee6d7c
+        Description: Annual S+ without a contribution
+
+        Name       : SV_SP_PriceRiseMonthlyWithCont2026
+        ID         : 725a9aab-45d4-481f-aa91-ca539c3e6ffc
+        Description: Monthly S+ with contribution
+
+        Name       : SV_SP_PriceRiseAnnualWithCont2026
+        ID         : 293edcd5-2db9-4296-bcac-c07b69b8fe8c
+        Description: Annual S+ with contribution
+     */
+
     for {
+      billingPeriod <- cohortItem.billingPeriod
       contributionAmount <- subscriptionToContributionAmount(subscription)
-      currentBaseAmount <- cohortItem.oldPrice
-      currentCombinedAmount = currentBaseAmount + contributionAmount
-      futureBaseAmount <- cohortItem.commsPrice
-      futureCombinedAmount = futureBaseAmount + contributionAmount
-    } yield SP2026EmailExtraAttributes(
-      contributionAmount,
-      currentCombinedAmount,
-      futureCombinedAmount
-    )
+      hasNonZeroContribution = contributionAmount > 0
+    } yield {
+      (billingPeriod, hasNonZeroContribution) match {
+        case ("Month", false)  => "SV_SP_PriceRiseMonthlyNoCont2026"
+        case ("Month", true)   => "SV_SP_PriceRiseMonthlyWithCont2026"
+        case ("Annual", false) => "SV_SP_PriceRiseAnnualNoCont2026"
+        case ("Annual", true)  => "SV_SP_PriceRiseAnnualWithCont2026"
+        case _                 =>
+          throw new Exception(s"[fb8cdf0e] unexpected case, cohort item: ${cohortItem}, subscription: ${subscription}")
+      }
+    }
   }
 
   // ------------------------------------------------

--- a/lambda/src/main/scala/pricemigrationengine/model/membershipworkflow/EmailMessage.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/membershipworkflow/EmailMessage.scala
@@ -36,6 +36,13 @@ case class EmailPayloadSubscriberAttributes(
     newspaper2025_phase4_brand_title: Option[String] = None,
     newspaper2025_phase4_formstack_url: Option[String] = None,
     // -----------------------------------------------
+
+    // -----------------------------------------------
+    // SupporterPlus2026 (extension)
+    sp2026_contribution_amount: Option[String] = None,
+    sp2026_current_combined_amount: Option[String] = None,
+    sp2026_new_combined_amount: Option[String] = None,
+    // -----------------------------------------------
 )
 
 object EmailPayloadSubscriberAttributes {

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
@@ -575,6 +575,8 @@ class SupporterPlus2026Test extends munit.FunSuite {
     // val account = Fixtures.accountFromJson("Migrations/SupporterPlus2026/01/account.json")
     // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01/invoice-preview.json")
 
+    val cohortSpec = CohortSpec("SupporterPlus2026", "unspecified", LocalDate.of(2026, 7, 1))
+
     // Note that we are defining the CohortItem only with the attributes we need
     // That particular value would not happen in the wild.
     val cohortItem = CohortItem(
@@ -587,12 +589,12 @@ class SupporterPlus2026Test extends munit.FunSuite {
     val contribution = BigDecimal(0.0) // 01 carries 0.0
 
     assertEquals(
-      SupporterPlus2026Migration.extractEmailExtraAttributes(subscription, cohortItem),
+      SupporterPlus2026Migration.extractEmailExtraAttributes(cohortSpec, cohortItem, subscription),
       Some(
         SP2026EmailExtraAttributes(
-          contribution,
-          BigDecimal(12.0),
-          BigDecimal(14.0)
+          contribution.toString(),
+          "12.0",
+          "14.0"
         )
       )
     )
@@ -611,6 +613,8 @@ class SupporterPlus2026Test extends munit.FunSuite {
     // val account = Fixtures.accountFromJson("Migrations/SupporterPlus2026/01-variant1-non-zero-contribution/account.json")
     // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01-variant1-non-zero-contribution/invoice-preview.json"
 
+    val cohortSpec = CohortSpec("SupporterPlus2026", "unspecified", LocalDate.of(2026, 7, 1))
+
     // Note that we are defining the CohortItem only with the attributes we need
     // That particular value would not happen in the wild.
     val cohortItem = CohortItem(
@@ -623,12 +627,12 @@ class SupporterPlus2026Test extends munit.FunSuite {
     val contribution = BigDecimal(89.0) // 01 carries 89.0
 
     assertEquals(
-      SupporterPlus2026Migration.extractEmailExtraAttributes(subscription, cohortItem),
+      SupporterPlus2026Migration.extractEmailExtraAttributes(cohortSpec, cohortItem, subscription),
       Some(
         SP2026EmailExtraAttributes(
-          contribution,
-          BigDecimal(12.0 + 89.0),
-          BigDecimal(14.0 + 89.0)
+          contribution.toString(),
+          "101.0",
+          "103.0"
         )
       )
     )


### PR DESCRIPTION
The email payload for SupporterPlus2026, uses 3 non standard attributes

```
sp2026_contribution_amount
sp2026_current_combined_amount
sp2026_new_combined_amount
```

Based on the work we did to introduce the class `SP2026EmailExtraAttributes` ( yesterday: https://github.com/guardian/price-migration-engine/pull/1470 ), we now extends the email payload. 

Note that

1. I modified `SP2026EmailExtraAttributes` to carry strings, it's then much more natural and easier to use the data for the payload, and also aligned with previous convention of doing so.

2. `brazeName` also now takes a Zuora subscription, this is somehow a departure from what I would have done last couple of year, pre compute the values and add them to the cohort item itself as extra attributes. 

3. The comment "For Tom reading this..." is now a tradition, it's to prevent another discussion about why I can't use optional values, for the fields of `SP2026EmailExtraAttributes` and returning empty strings) for when the function `extractEmailExtraAttributes` is called from other migrations). ( prior art: https://github.com/guardian/price-migration-engine/blob/8ee3463489064e5ce3bcee348488ecd2b7d53677/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala#L52 )