### PR TITLE
decommission brazeName from CohortSpec

### DIFF
--- a/docs/amendment-effective-date-computation.md
+++ b/docs/amendment-effective-date-computation.md
@@ -15,7 +15,6 @@ First we need a cohort spec. Let's assume that the cohort spec is
 ```
 {
     "cohortName":"GW2024",
-    "brazeName":"SV_GW_PriceRise2024",
     "earliestAmendmentEffectiveDate":"2024-05-20" 
 }
 ```

--- a/docs/cohort-specs.md
+++ b/docs/cohort-specs.md
@@ -1,9 +1,7 @@
 
 ## CohortSpec
 
-CohortSpec is the object that lambdas of the state machine take as input. They mostly specify the particular cohort that the lambda is going to run against (`cohortName`) and the name of the Braze canvas or campaign attached to it (`brazeName`).
-
-Note that `brazeName` is not always specified. For migrations using more than one braze canvases, the dispatch to the right name is hardcoded in the migration code and we can submit empty string to `brazeName`.
+CohortSpec is the object that lambdas of the state machine take as input. They mostly specify the particular cohort that the lambda is going to run against (`cohortName`).
 
 An additional mandatory attribute is the earliest amendment effective date, which is used as the starting point of the notifications and amendment dates. See [amendment-effective-date-computation.md](./amendment-effective-date-computation.md) for details.
 

--- a/docs/lambdas-code-structure.md
+++ b/docs/lambdas-code-structure.md
@@ -52,7 +52,6 @@ Individual lambdas like the `EstimationLambda` and the `AmendmentLambda` can be 
 ``` 
 {
   "cohortName": "EchoLegacyTesting",
-  "brazeName": "cmp123",
   "earliestAmendmentEffectiveDate": "2022-08-02"
 }
 ```

--- a/docs/migration-implementation-manual.md
+++ b/docs/migration-implementation-manual.md
@@ -19,14 +19,12 @@ As part of setting up a migration you will want to run some of the lambdas on de
 ```
 {
     "cohortName":"GW2024",
-    "brazeName":"SV_GW_PriceRise2024Email",
     "earliestAmendmentEffectiveDate":"2024-05-20"
 }
 
 {
     "cohortSpec": {
         "cohortName":"GW2024",
-        "brazeName":"SV_GW_PriceRise2024Email",
         "earliestAmendmentEffectiveDate":"2024-05-20"
     }
 }
@@ -35,7 +33,6 @@ As part of setting up a migration you will want to run some of the lambdas on de
 The difference between the two is that the former is used to run specific lambdas and the latter used to run the state machine itself. They both carry the same information.
 
 * **cohortName**: A unique name to identify the cohort. Must consist of alphanumeric, '-' and '_' characters (without space(s)). [1]
-* **brazeName**: The name that membership-workflow uses to refer to the Braze campaign or canvas for notifying subscribers. Must consist of alphanumeric, whitespace, '-' and '_' characters. This name is given to us by Marketing after they have set up the campaign or canvas in Braze.
 * **earliestAmendmentEffectiveDate**: Earliest date on which a subscription can have its price increased, or will move to another rate plan (with or without price increase). Increases will always begin on the first day of a billing period on or after this date. Format is `yyyy-mm-dd`.
 
 [1] Pascal always sticks to alphanumerical names, for instance "HomeDelivery2025" (where the year the migration has started appears in the name)

--- a/docs/subscription-numbers-upload.md
+++ b/docs/subscription-numbers-upload.md
@@ -37,7 +37,6 @@ Do not forget to set the correct cohort specifications (see example below, but u
 ```
 {
     "cohortName":"migration-name",
-    "brazeName":"any-name",
     "earliestAmendmentEffectiveDate":"2024-05-20" 
 }
 ```

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -580,10 +580,6 @@ object NotificationHandler extends CohortHandler {
   // -------------------------------------------------------------------
   // Braze names
 
-  // Traditionally the name of the campaign or canvas has been part of the CohortSpec, making
-  // `cohortSpec.brazeName` the default carrier of this information, but for some migrations
-  // we have several canvases and we want to select one depending on the subscription.
-
   def brazeName(
       cohortSpec: CohortSpec,
       item: CohortItem,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -590,6 +590,10 @@ object NotificationHandler extends CohortHandler {
       zuoraSubscription: ZuoraSubscription
   ): ZIO[Zuora, Failure, String] = {
     MigrationType(cohortSpec) match {
+      case Test1                  => ZIO.succeed("unspecified")
+      case GuardianWeekly2025     => ZIO.succeed("SV_GW_PriceRise2025")
+      case Newspaper2025P1        => ZIO.succeed("SV_NP_PriceRise_2025")
+      case Newspaper2025P3        => ZIO.succeed("SV_NP_PriceRise_VoucherSubCard2025")
       case ProductMigration2025N4 =>
         ZIO
           .fromOption(ProductMigration2025N4Migration.brazeName(item))
@@ -614,7 +618,6 @@ object NotificationHandler extends CohortHandler {
           .orElseFail(
             DataExtractionFailure(s"[15ecdf55] could not determine brazeName for SupporterPlus2026, item: ${item}")
           )
-      case _ => ZIO.succeed(cohortSpec.brazeName)
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -12,11 +12,6 @@ import java.util
   * @param cohortName
   *   Name that uniquely identifies a cohort, eg. "Vouchers2020"
   *
-  * @param brazeName
-  *   Name of the Braze campaign, or Braze canvas for this cohort.
-  *   Mapping to environment-specific Braze campaign ID is provided by membership-workflow:
-  *   See https://github.com/guardian/membership-workflow/blob/master/conf/PROD.public.conf#L39
-  *
   * @param earliestAmendmentEffectiveDate
   *   Earliest date on which any sub in the cohort can have price migrated. The actual date for any sub will depend on
   *   its billing dates.
@@ -44,7 +39,6 @@ import java.util
 
 case class CohortSpec(
     cohortName: String,
-    brazeName: String,
     earliestAmendmentEffectiveDate: LocalDate,
     subscriptionNumber: Option[String] = None,
     forceNotifications: Option[Boolean] = None,
@@ -58,18 +52,15 @@ object CohortSpec {
 
   def isValid(spec: CohortSpec): Boolean = {
     def isValidStringValue(s: String) = s.trim == s && s.nonEmpty && s.matches("[A-Za-z0-9-_ ]+")
-    isValidStringValue(spec.cohortName) &&
-    isValidStringValue(spec.brazeName)
+    isValidStringValue(spec.cohortName)
   }
 
   def fromDynamoDbItem(values: util.Map[String, AttributeValue]): Either[CohortSpecFetchFailure, CohortSpec] =
     (for {
       cohortName <- getStringFromResults(values, "cohortName")
-      brazeName <- getStringFromResults(values, "brazeName")
       earliestAmendmentEffectiveDate <- getDateFromResults(values, "earliestAmendmentEffectiveDate")
     } yield CohortSpec(
       cohortName,
-      brazeName,
       earliestAmendmentEffectiveDate
     )).left.map(e => CohortSpecFetchFailure(e))
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -85,7 +85,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
     val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
 
     val cohortSpec: CohortSpec =
-      CohortSpec("cohortName", "brazeName", LocalDate.of(2022, 1, 1))
+      CohortSpec("cohortName", LocalDate.of(2022, 1, 1))
 
     val cohortItem = CohortItem(
       subscriptionName = subscriptionName,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -68,7 +68,6 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
           .main(
             CohortSpec(
               cohortName = "cohortName",
-              brazeName = "cmp123",
               earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 1)
             )
           )

--- a/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2025MigrationTest.scala
@@ -83,7 +83,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/01/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", "unspecified", LocalDate.of(2025, 11, 25))
+    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25))
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -109,7 +109,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/02/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", "unspecified", LocalDate.of(2025, 11, 25))
+    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25))
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -135,7 +135,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/03/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", "unspecified", LocalDate.of(2025, 11, 25))
+    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25))
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -161,7 +161,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/04/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", "unspecified", LocalDate.of(2025, 11, 25))
+    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25))
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
@@ -52,7 +52,6 @@ class SupporterPlus2026Test extends munit.FunSuite {
 
     val cohortSpec = CohortSpec(
       "SupporterPlus2026",
-      "",
       LocalDate.of(2026, 9, 19),
     )
 
@@ -183,7 +182,6 @@ class SupporterPlus2026Test extends munit.FunSuite {
 
     val cohortSpec = CohortSpec(
       "SupporterPlus2026",
-      "",
       LocalDate.of(2026, 9, 19),
     )
 
@@ -237,7 +235,6 @@ class SupporterPlus2026Test extends munit.FunSuite {
 
     val cohortSpec = CohortSpec(
       "SupporterPlus2026",
-      "",
       LocalDate.of(2026, 9, 19),
     )
 
@@ -292,7 +289,6 @@ class SupporterPlus2026Test extends munit.FunSuite {
 
     val cohortSpec = CohortSpec(
       "SupporterPlus2026",
-      "",
       LocalDate.of(2026, 9, 19),
     )
 
@@ -347,7 +343,6 @@ class SupporterPlus2026Test extends munit.FunSuite {
 
     val cohortSpec = CohortSpec(
       "SupporterPlus2026",
-      "",
       LocalDate.of(2026, 9, 19),
     )
 
@@ -401,7 +396,6 @@ class SupporterPlus2026Test extends munit.FunSuite {
 
     val cohortSpec = CohortSpec(
       "SupporterPlus2026",
-      "",
       LocalDate.of(2026, 9, 19),
     )
 
@@ -575,7 +569,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     // val account = Fixtures.accountFromJson("Migrations/SupporterPlus2026/01/account.json")
     // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01/invoice-preview.json")
 
-    val cohortSpec = CohortSpec("SupporterPlus2026", "unspecified", LocalDate.of(2026, 7, 1))
+    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 7, 1))
 
     // Note that we are defining the CohortItem only with the attributes we need
     // That particular value would not happen in the wild.
@@ -613,7 +607,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     // val account = Fixtures.accountFromJson("Migrations/SupporterPlus2026/01-variant1-non-zero-contribution/account.json")
     // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01-variant1-non-zero-contribution/invoice-preview.json"
 
-    val cohortSpec = CohortSpec("SupporterPlus2026", "unspecified", LocalDate.of(2026, 7, 1))
+    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 7, 1))
 
     // Note that we are defining the CohortItem only with the attributes we need
     // That particular value would not happen in the wild.

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -187,7 +187,6 @@ class AmendmentDataTest extends munit.FunSuite {
     val today = LocalDate.of(2025, 7, 1) // 1 July 2025
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
-      brazeName = "BrazeName",
       earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculatorTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculatorTest.scala
@@ -19,7 +19,6 @@ class AmendmentEffectiveDateCalculatorTest extends munit.FunSuite {
     val today = LocalDate.of(2025, 7, 1) // 1 July 2025
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
-      brazeName = "BrazeName",
       earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 
@@ -120,7 +119,6 @@ class AmendmentEffectiveDateCalculatorTest extends munit.FunSuite {
     val today = LocalDate.of(2025, 7, 1) // 1 July 2025
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
-      brazeName = "BrazeName",
       earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -10,7 +10,6 @@ class CohortSpecTest extends munit.FunSuite {
 
   private val cohortSpec = CohortSpec(
     cohortName = "Home Delivery 2018",
-    brazeName = "cmp123",
     earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 2)
   )
 
@@ -20,7 +19,6 @@ class CohortSpecTest extends munit.FunSuite {
   test("fromDynamoDbItem: should include all fields") {
     val item = Map(
       "cohortName" -> AttributeValue.builder.s("Home Delivery 2018").build(),
-      "brazeName" -> AttributeValue.builder.s("cmp123").build(),
       "earliestAmendmentEffectiveDate" -> AttributeValue.builder.s("2020-01-02").build()
     ).asJava
     assertEquals(
@@ -35,9 +33,5 @@ class CohortSpecTest extends munit.FunSuite {
 
   test("isValid: should be false when the cohort name has trailing whitespace") {
     assertFalse(isValid(cohortSpec.copy(cohortName = "Home Delivery 2018 ")))
-  }
-
-  test("isValid: should be false when the campaign name contains an illegal character") {
-    assertFalse(isValid(cohortSpec.copy(brazeName = "vc:ppr321")))
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -18,7 +18,6 @@ class CohortTableLiveTest extends munit.FunSuite {
 
   private val cohortSpec = CohortSpec(
     cohortName = "name",
-    brazeName = "cmp123",
     earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 1)
   )
 


### PR DESCRIPTION
The fact that cohort specs carry a field called braze name is a vestige from an old era before the modern style of defining migrations (nowadays we put the parameters in the migration's own module -- for instance price grids, notification windows etc). Moreover we no longer use just one canvas template in Braze that led to the introduction of brazeName ( https://github.com/guardian/price-migration-engine/blob/8ee3463489064e5ce3bcee348488ecd2b7d53677/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala#L565 ) in the Notification handler. 

Here we decommission brazeName from the cohort specs and to do so in a backward compatible way we record the names for the three oldest currently running migrations `GuardianWeekly2025`, `Newspaper2025P1`  and `Newspaper2025P3`