### PR TITLE
SP2026: add curency symbol to extra email attributes

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -277,9 +277,10 @@ object NotificationHandler extends CohortHandler {
 
               // -------------------------------------------------------------
               // SupporterPlus2026 extension
-              sp2026_contribution_amount = Some(supporterPlus2026ExtraData.contributionAmount),
-              sp2026_current_combined_amount = Some(supporterPlus2026ExtraData.currentCombinedAmount),
-              sp2026_new_combined_amount = Some(supporterPlus2026ExtraData.newCombinedAmount)
+              sp2026_contribution_amount = Some(s"${currencySymbol}${supporterPlus2026ExtraData.contributionAmount}"),
+              sp2026_current_combined_amount =
+                Some(s"${currencySymbol}${supporterPlus2026ExtraData.currentCombinedAmount}"),
+              sp2026_new_combined_amount = Some(s"${currencySymbol}${supporterPlus2026ExtraData.newCombinedAmount}")
               // -------------------------------------------------------------
             )
           )


### PR DESCRIPTION
Request from marketing to generate payloads like this

```
{
  "To": {
    "Address": "[removed]",
    "ContactAttributes": {
      "SubscriberAttributes": {
        "title": "Mr",
        "first_name": "Miles",
        "last_name": "Cooper",
        "billing_address_1": "[removed]",
        "billing_address_2": null,
        "billing_city": "Manchester",
        "billing_postal_code": "[removed]",
        "billing_state": null,
        "billing_country": "United States",
        "payment_amount": "$140",
        "next_payment_date": "1 December 2026",
        "payment_frequency": "annually",
        "subscription_id": "[removed]",
        "product_type": "Supporter Plus",
        "sp2026_contribution_amount": "$30",
        "sp2026_current_combined_amount": "$150",
        "sp2026_new_combined_amount": "$170"
      }
    }
  },
  "DataExtensionName": "SV_SP_PriceRiseAnnualWithCont2026",
  "IdentityUserId": "[removed]"
}
```