### PR TITLE
date calculations code refactoring

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
@@ -111,7 +111,7 @@ object GuardianWeekly2025Migration {
     flag_opt.getOrElse(false)
   }
 
-  def computeAmendmentEffectiveDateLowerBound4(lowerBound: LocalDate, item: CohortItem): LocalDate = {
+  def computeAmendmentEffectiveDateLowerBound(lowerBound: LocalDate, item: CohortItem): LocalDate = {
     val dateFromCohortItem = getEarliestMigrationDateFromMigrationExtraAttributes(item)
     dateFromCohortItem match {
       case Some(date) => Date.datesMax(lowerBound, date)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -95,7 +95,7 @@ object Newspaper2025P3Migration {
     } yield date
   }
 
-  def computeAmendmentEffectiveDateLowerBound4(lowerBound: LocalDate, item: CohortItem): LocalDate = {
+  def computeAmendmentEffectiveDateLowerBound(lowerBound: LocalDate, item: CohortItem): LocalDate = {
     val dateFromCohortItem = getEarliestMigrationDateFromMigrationExtraAttributes(item)
     dateFromCohortItem match {
       case Some(date) => Date.datesMax(lowerBound, date)

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
@@ -83,6 +83,32 @@ object SupporterPlus2026Migration {
     }
   }
 
+  def computeAmendmentEffectiveDateLowerBound(
+      lowerBound0: LocalDate,
+      item: CohortItem,
+      subscription: ZuoraSubscription
+  ): LocalDate = {
+    // For this migration we have the requirement to migrate the monthlies over 6 weeks,
+    // which is a non standard calculation. The main function is implemented in
+    // monthliesOverSixWeeks
+    // and here we call it just for that migration
+
+    val lowerBound1 = item.billingPeriod
+      .map(bp => monthliesOverSixWeeks(lowerBound0, BillingPeriod.fromString(bp)))
+      .getOrElse(lowerBound0)
+
+    // We also have the requirement to apply a one year policy to annual subs with an active discount
+    // We cannot price rise a sub within a year after the end of the discount.
+    // Implemented in annualWithDiscountOneYearPolicy
+
+    val lowerBound2 = item.billingPeriod.map(bp => BillingPeriod.fromString(bp)) match {
+      case Some(Annual) => annualWithDiscountOneYearPolicy(lowerBound1, subscription)
+      case _            => lowerBound1
+    }
+
+    lowerBound2
+  }
+
   def subscriptionToContributionAmount(subscription: ZuoraSubscription): Option[BigDecimal] = {
     for {
       ratePlan <- subscription.ratePlans

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculator.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculator.scala
@@ -133,27 +133,18 @@ object AmendmentEffectiveDateCalculator {
       case _ => noPriceRiseWithinAYearOfLastPriceRisePolicyUpdate(cohortSpec, subscription, today, lowerBound2)
     }
 
-    // With GuardianWeekly2025, we were given lower bounds in the Marketing spreadsheet
-    // that was the first use of the new cohortItem's migrationExtraAttributes. If we expect a
-    // migration to provide it own lowerbound computation, we do it here, otherwise we identity
-    // on lowerBound3
+    // Migration specific date calculations
+
     val lowerBound4 = MigrationType(cohortSpec) match {
-      // [1]
-      // Date: June 2025
-      // Author: Pascal
-      // (Comment group: ef77de28)
-      // Here I am re-using GuardianWeekly2025Migration's function, for testing.
-      // Technically this test will break when GuardianWeekly2025 is decommissioned in October 2026,
-      // but at that point if we really want to carry on testing the migration extended attributes as
-      // part of start date computations we can move the code to Test1's own migration module
-      case Test1 => GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound4(lowerBound3, item) // [1]
-      case GuardianWeekly2025 => GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound4(lowerBound3, item)
+      case Test1 => GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, item) // [1]
+      case GuardianWeekly2025 => GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, item)
       case Newspaper2025P1    => lowerBound3
-      case Newspaper2025P3    => Newspaper2025P3Migration.computeAmendmentEffectiveDateLowerBound4(lowerBound3, item)
+      case Newspaper2025P3    => Newspaper2025P3Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, item)
       case ProductMigration2025N4 => lowerBound3
       case Membership2025         => lowerBound3
       case DigiSubs2025           => lowerBound3
-      case SupporterPlus2026      => lowerBound3
+      case SupporterPlus2026      =>
+        SupporterPlus2026Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, item, subscription)
     }
 
     // Decide the spread period for this migration
@@ -164,38 +155,8 @@ object AmendmentEffectiveDateCalculator {
     // Decides an integer in the interval [0, spreadPeriod-1]
     // The default spread period is 1
 
-    var lowerBound5 = lowerBound4.plusMonths(randomDelayInMonths)
+    val lowerBound5 = lowerBound4.plusMonths(randomDelayInMonths)
 
-    // --------------------------------------------------------------------------------
-    // Special SupporterPlus2026
-
-    // For this migration we have the requirement to migrate the monthlies over 6 weeks,
-    // which is a non standard calculation. The main function is implemented in
-    // SupporterPlus2026Migration.monthliesOverSixWeeks
-    // and here we call it just for that migration
-
-    val lowerbound6 = MigrationType(cohortSpec) match {
-      case SupporterPlus2026 =>
-        item.billingPeriod
-          .map(bp => SupporterPlus2026Migration.monthliesOverSixWeeks(lowerBound5, BillingPeriod.fromString(bp)))
-          .getOrElse(lowerBound5)
-      case _ => lowerBound5
-    }
-
-    // We also have the requirement to apply a one year policy to annual subs with an active discount
-    // We cannot price rise a sub within a year after the end of the discount.
-
-    val lowerbound7 = MigrationType(cohortSpec) match {
-      case SupporterPlus2026 =>
-        item.billingPeriod.map(bp => BillingPeriod.fromString(bp)) match {
-          case Some(Annual) => SupporterPlus2026Migration.annualWithDiscountOneYearPolicy(lowerbound6, subscription)
-          case _            => lowerbound6
-        }
-      case _ => lowerbound6
-    }
-
-    // --------------------------------------------------------------------------------
-
-    lowerbound7
+    lowerBound5
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/GuardianWeekly2025MigrationTest.scala
@@ -65,7 +65,7 @@ class GuardianWeekly2025ExtraAttributesTest extends munit.FunSuite {
       migrationExtraAttributes = None,
     )
     val date =
-      GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound4(LocalDate.of(2025, 8, 9), cohortItem)
+      GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound(LocalDate.of(2025, 8, 9), cohortItem)
     assertEquals(date, LocalDate.of(2025, 8, 9))
   }
 
@@ -76,7 +76,7 @@ class GuardianWeekly2025ExtraAttributesTest extends munit.FunSuite {
       migrationExtraAttributes = Some("""{ "earliestMigrationDate": "2025-10-06" }"""),
     )
     val date =
-      GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound4(LocalDate.of(2025, 8, 9), cohortItem)
+      GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound(LocalDate.of(2025, 8, 9), cohortItem)
     assertEquals(date, LocalDate.of(2025, 10, 6))
   }
 
@@ -87,7 +87,7 @@ class GuardianWeekly2025ExtraAttributesTest extends munit.FunSuite {
       migrationExtraAttributes = Some("""{ "earliestMigrationDate": "2025-10-06" }"""),
     )
     val date =
-      GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound4(LocalDate.of(2025, 11, 9), cohortItem)
+      GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound(LocalDate.of(2025, 11, 9), cohortItem)
     assertEquals(date, LocalDate.of(2025, 11, 9))
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculatorTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculatorTest.scala
@@ -79,7 +79,7 @@ class AmendmentEffectiveDateCalculatorTest extends munit.FunSuite {
 
     // Here nothing happens because the cohort item didn't have extended attributes
 
-    val lowerBound4 = GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound4(lowerBound3, cohortItem)
+    val lowerBound4 = GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, cohortItem)
 
     assertEquals(
       lowerBound3,
@@ -188,7 +188,7 @@ class AmendmentEffectiveDateCalculatorTest extends munit.FunSuite {
 
     // Here we have extended attributes: {"earliestMigrationDate":"2026-03-19"}
 
-    val lowerBound4 = GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound4(lowerBound3, cohortItem)
+    val lowerBound4 = GuardianWeekly2025Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, cohortItem)
 
     assertEquals(
       lowerBound4,


### PR DESCRIPTION
Notably, move the SupporterPlus2026 date calculations to the migration's own module