### PR TITLE
SP2026: remove street requirement

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -424,9 +424,10 @@ object NotificationHandler extends CohortHandler {
 
   def targetStreet(cohortSpec: CohortSpec, street: Option[String]): Either[NotificationHandlerFailure, String] = {
     MigrationType(cohortSpec) match {
-      case Membership2025 => Right(street.getOrElse(""))
-      case DigiSubs2025   => Right(street.getOrElse(""))
-      case _              => requiredField(street, "Contact.OtherAddress.street")
+      case Membership2025    => Right(street.getOrElse(""))
+      case DigiSubs2025      => Right(street.getOrElse(""))
+      case SupporterPlus2026 => Right(street.getOrElse(""))
+      case _                 => requiredField(street, "Contact.OtherAddress.street")
     }
   }
 


### PR DESCRIPTION
This is a similar requirements relaxation than the mailing address we did a bit earlier today ( https://github.com/guardian/price-migration-engine/pull/1484 )