### PR TITLE
SP2026: remove country requirement

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -535,6 +535,7 @@ object NotificationHandler extends CohortHandler {
       case ProductMigration2025N4 => Right(address.country.getOrElse(""))
       case Membership2025         => Right(address.country.getOrElse(""))
       case DigiSubs2025           => Right(address.country.getOrElse(""))
+      case SupporterPlus2026      => Right(address.country.getOrElse(""))
       case _                      => requiredField(address.country, "Contact.OtherAddress.country")
     }
   }


### PR DESCRIPTION
This is a similar requirements relaxation we did a bit earlier today 

mailing address: https://github.com/guardian/price-migration-engine/pull/1484 
street: https://github.com/guardian/price-migration-engine/pull/1486

Here we remove requirement for country.