### PR TITLE
prevent post amendment price check for SP2026

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentHandlerHelper.scala
@@ -69,7 +69,7 @@ object AmendmentHandlerHelper {
       case ProductMigration2025N4 => false
       case Membership2025         => true
       case DigiSubs2025           => true
-      case SupporterPlus2026      => true
+      case SupporterPlus2026      => false
     }
   }
 


### PR DESCRIPTION
The post amendment price check is being disabled for SupporterPlus2026 because that check compares the comms price (which in this case is the base price) and the post amendment price, but that doesn't work in the case of supporter plus subs with non zero extra contribution.

(For subscriptions with extra contribution the final price is the comms price plus the extra contribution)