### PR TITLE
remove unused code (zuora catalogue)

### DIFF
--- a/docs/downloading-fixtures.md
+++ b/docs/downloading-fixtures.md
@@ -135,7 +135,7 @@ The schedule will be printed to the standard output (your terminal), just redire
 
 ### The product catalogue 
 
-The last file we use is the zuora producr catalogue. It was actually used in in the test of legacy code because legacy code was using the product catalogue to retrieve information that we are now hardcoding in migration specific code.
+The last file we use is the Zuora product catalogue. It was actually used in in the test of legacy code because legacy code was using the product catalogue to retrieve information that we are now hardcoding in migration specific code.
 
 The curl is
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -63,7 +63,7 @@ object AmendmentHandler extends CohortHandler {
             Clock.nanoTime.map(_ < deadline)
           )
           .mapZIO(item =>
-            performAmendmentAttempt(cohortSpec, catalogue, item)
+            performAmendmentAttempt(cohortSpec, item)
               .tapBoth(Logging.logFailure(item), Logging.logSuccess(item))
           )
           .runCount
@@ -106,13 +106,12 @@ object AmendmentHandler extends CohortHandler {
 
   private def performAmendmentAttempt(
       cohortSpec: CohortSpec,
-      catalogue: ZuoraProductCatalogue,
       item: CohortItem
   ): ZIO[CohortTable with Zuora with Logging with SalesforceClient, Failure, Unit] = {
     // This function performs the amendment (through the migration dispatch)
     // and updates the Cohort Item.
     (for {
-      result <- performAmendmentAttemptWithResult(cohortSpec, catalogue, item)
+      result <- performAmendmentAttemptWithResult(cohortSpec, item)
       _ <- result match {
         case r: AARSuccessfulAmendment => {
           CohortTable.update(
@@ -198,7 +197,6 @@ object AmendmentHandler extends CohortHandler {
 
   private def doAmendmentUsingOrdersApiWithJsonValues(
       cohortSpec: CohortSpec,
-      catalogue: ZuoraProductCatalogue,
       item: CohortItem
   ): ZIO[Zuora with Logging, Failure, AARSuccessfulAmendment] = {
     for {
@@ -323,7 +321,6 @@ object AmendmentHandler extends CohortHandler {
 
   private def performAmendmentAttemptWithResult(
       cohortSpec: CohortSpec,
-      catalogue: ZuoraProductCatalogue,
       item: CohortItem
   ): ZIO[Zuora with Logging with SalesforceClient, Failure, AmendmentAttemptResult] = {
     MigrationType(cohortSpec) match {
@@ -331,19 +328,16 @@ object AmendmentHandler extends CohortHandler {
       case GuardianWeekly2025 =>
         doAmendmentUsingOrdersApiWithJsonValues(
           cohortSpec: CohortSpec,
-          catalogue: ZuoraProductCatalogue,
           item: CohortItem
         )
       case Newspaper2025P1 =>
         doAmendmentUsingOrdersApiWithJsonValues(
           cohortSpec: CohortSpec,
-          catalogue: ZuoraProductCatalogue,
           item: CohortItem
         )
       case Newspaper2025P3 =>
         doAmendmentUsingOrdersApiWithJsonValues(
           cohortSpec: CohortSpec,
-          catalogue: ZuoraProductCatalogue,
           item: CohortItem
         )
       case ProductMigration2025N4 => {
@@ -365,7 +359,6 @@ object AmendmentHandler extends CohortHandler {
             else
               doAmendmentUsingOrdersApiWithJsonValues(
                 cohortSpec,
-                catalogue,
                 item
               )
         } yield result
@@ -374,19 +367,16 @@ object AmendmentHandler extends CohortHandler {
       case Membership2025 =>
         doAmendmentUsingOrdersApiWithJsonValues(
           cohortSpec: CohortSpec,
-          catalogue: ZuoraProductCatalogue,
           item: CohortItem
         )
       case DigiSubs2025 =>
         doAmendmentUsingOrdersApiWithJsonValues(
           cohortSpec: CohortSpec,
-          catalogue: ZuoraProductCatalogue,
           item: CohortItem
         )
       case SupporterPlus2026 =>
         doAmendmentUsingOrdersApiWithJsonValues(
           cohortSpec: CohortSpec,
-          catalogue: ZuoraProductCatalogue,
           item: CohortItem
         )
     }

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -20,7 +20,6 @@ object EstimationHandler extends CohortHandler {
   def main(cohortSpec: CohortSpec): ZIO[Logging with CohortTable with Zuora, Failure, HandlerOutput] =
     for {
       today <- Clock.currentDateTime.map(_.toLocalDate)
-      catalogue <- Zuora.fetchProductCatalogue
       count <- (
         cohortSpec.subscriptionNumber match {
           case None =>
@@ -33,21 +32,18 @@ object EstimationHandler extends CohortHandler {
               .filter(item => item.subscriptionName == subscriptionNumber)
         }
       )
-        .mapZIO(item =>
-          estimate(catalogue, cohortSpec)(today, item).tapBoth(Logging.logFailure(item), Logging.logSuccess(item))
-        )
+        .mapZIO(item => estimate(cohortSpec)(today, item).tapBoth(Logging.logFailure(item), Logging.logSuccess(item)))
         .runCount
         .tapError(e => Logging.error(e.toString))
     } yield HandlerOutput(isComplete = count < batchSize)
 
   private[handlers] def estimate(
-      catalogue: ZuoraProductCatalogue,
       cohortSpec: CohortSpec
   )(
       today: LocalDate,
       item: CohortItem,
   ): ZIO[CohortTable with Zuora with Logging, Failure, EstimationResult] =
-    doEstimation(catalogue, item, cohortSpec, today).foldZIO(
+    doEstimation(item, cohortSpec, today).foldZIO(
       failure = {
         case _: SubscriptionCancelledInZuoraFailure =>
           val result = SubscriptionCancelledInZuoraEstimationResult(item.subscriptionName)
@@ -92,7 +88,6 @@ object EstimationHandler extends CohortHandler {
     )
 
   private def doEstimation(
-      catalogue: ZuoraProductCatalogue,
       item: CohortItem,
       cohortSpec: CohortSpec,
       today: LocalDate,

--- a/lambda/src/main/scala/pricemigrationengine/model/ZuoraProductCatalogue.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/ZuoraProductCatalogue.scala
@@ -5,40 +5,8 @@ import upickle.default.{ReadWriter, macroRW}
 case class ZuoraProductCatalogue(products: Set[ZuoraProduct], nextPage: Option[String] = None)
 
 object ZuoraProductCatalogue {
-
   implicit val rw: ReadWriter[ZuoraProductCatalogue] = macroRW
-
   def empty: ZuoraProductCatalogue = ZuoraProductCatalogue(products = Set.empty)
-
-  private val gwRatePlanNames = List("Guardian Weekly - Domestic", "Guardian Weekly - ROW")
-
-  def homeDeliveryRatePlans(catalogue: ZuoraProductCatalogue): Seq[ZuoraProductRatePlan] = {
-    val prices = for {
-      product <- catalogue.products.filter(_.name == "Newspaper Delivery")
-      productRatePlan <- product.productRatePlans.filter(_.status != "Expired")
-    } yield productRatePlan
-
-    prices.toSeq
-  }
-
-  def newGuardianWeeklyRatePlans(catalogue: ZuoraProductCatalogue): Seq[ZuoraProductRatePlan] = {
-    val prices = for {
-      product <- catalogue.products.filter(gwRatePlanNames contains _.name)
-      productRatePlan <- product.productRatePlans
-    } yield productRatePlan
-
-    prices.toSeq
-  }
-
-  def productPricingMap(catalogue: ZuoraProductCatalogue): ZuoraPricingData = {
-    val priceMapping = for {
-      product <- catalogue.products
-      productRatePlan <- product.productRatePlans.filter(x => x.status != "Expired" || x.name == "Echo-Legacy")
-      productRatePlanCharge <- productRatePlan.productRatePlanCharges
-    } yield productRatePlanCharge.id -> productRatePlanCharge
-
-    priceMapping.toMap
-  }
 }
 
 case class ZuoraProduct(
@@ -75,7 +43,4 @@ case class ZuoraPricing(currency: Currency, price: Option[BigDecimal], hasBeenPr
 
 object ZuoraPricing {
   implicit val rw: ReadWriter[ZuoraPricing] = macroRW
-
-  def pricing(productRatePlanCharge: ZuoraProductRatePlanCharge, currency: Currency): Option[ZuoraPricing] =
-    productRatePlanCharge.pricing.find(_.currency == currency)
 }


### PR DESCRIPTION
The Zuora catalogue has not been used as part of migrations for years. Here we stop downloading it from Zuora.