### PR TITLE
update state machine to rerun UpdatingSalesforceWithNotifications when not done

### DIFF
--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -322,7 +322,7 @@ Resources:
                 "Resource": "${UpdatingSalesforceWithNotificationsLambdaArn}",
                 "InputPath": "$.cohortSpec",
                 "ResultPath": "$.result",
-                "Next": "Amending",
+                "Next": "IsUpdatingSalesforceWithNotificationsComplete",
                 "Retry": [
                   {
                     "ErrorEquals": [
@@ -335,6 +335,18 @@ Resources:
                     "BackoffRate": 2
                   }
                 ]
+              },
+              "IsUpdatingSalesforceWithNotificationsComplete": {
+                "Type": "Choice",
+                "Comment": "Is the notifications Salesforce update step complete?",
+                "Choices": [
+                  {
+                    "Variable": "$.result.isComplete",
+                    "BooleanEquals": false,
+                    "Next": "UpdatingSalesforceWithNotifications"
+                  }
+                ],
+                "Default": "Amending"
               },
               "Amending": {
                 "Type": "Task",


### PR DESCRIPTION
Before SupporterPlus2026 we never had a migration that sends more than 1000 user notification per day and we have a hard coded limit here: https://github.com/guardian/price-migration-engine/blob/2a7691dd6dd9f3831b684a43d2dc9b0785d0993b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala#L12 for one single run of the SalesforceNotificationDateUpdateHandler , and I never noticed that the state machine doesn't restart that lambda if it  has not done all the records for the day.

.

BEFORE (Current PROD):

.

<img width="654" height="434" alt="Screenshot 2026-07-19 at 23 36 56" src="https://github.com/user-attachments/assets/ec495055-d4cc-4b1d-9927-815c948421ee" />

.

AFTER (CODE with the change):

.

<img width="507" height="603" alt="Screenshot 2026-07-19 at 23 43 57" src="https://github.com/user-attachments/assets/43847392-d346-440d-97c0-f3a09c1f3ffc" />




