### PR TITLE
SupporterPlus2026 Dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ It currently consists in
 - [Cohort Items](docs/cohort-items.md)
 - [Troubleshooting document](docs/troubleshooting.md)
 - [Quirks of the Engine](docs/quirks.md)
+- [Dispatch, dealing with unusually large migration](docs/dispatch.md)
 
 ### Android Price Rises
 

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -1,7 +1,9 @@
 
 ## Dispatch, dealing with unusually large migrations
 
-SupporterPlus2026 was a record breaking price migration with a cohort table containing more than 350,000 items, which is more than 3 times the previous largest migration. One interesting side effect of this large number is that at the moment (and this will continue for an entire month) the daily load of Braze user notification and Zuora amendments takes more than 24 hours. This is due to the fact that we process cohort items one by one.
+30 July 2026
+
+SupporterPlus2026 is a record breaking price migration with a cohort table containing more than 350,000 items, which is more than 3 times the previous largest migration. One interesting side effect of this large number is that at the moment (and this will continue for an entire month) the daily load of Braze user notification and Zuora amendments takes more than 24 hours. This is due to the fact that we process cohort items one by one.
 
 Here is a possible solution of how to deal with those [https://github.com/guardian/price-migration-engine/pull/1500](https://github.com/guardian/price-migration-engine/pull/1500).
 

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -1,0 +1,8 @@
+
+## Dispatch, dealing with unusually large migrations
+
+SupporterPlus2026 was a record breaking price migration with a cohort table containing more than 350,000 items, which is more than 3 times the previous largest migration. One interesting side effect of this large number is that at the moment (and this will continue for an entire month) the daily load of Braze user notification and Zuora amendments takes more than 24 hours. This is due to the fact that we process cohort items one by one.
+
+Here is a possible solution of how to deal with those [https://github.com/guardian/price-migration-engine/pull/1500](https://github.com/guardian/price-migration-engine/pull/1500).
+
+Note that this is a better solution than spliting the cohort table (what was referred to as Solution 2 in the PR description), because we regularly perform adhoc tasks for Marketing that would be more difficult to perform is the items of a single migration were split in several tables.

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -49,6 +49,7 @@ object AmendmentHandler extends CohortHandler {
           case None =>
             CohortTable
               .fetch(NotificationSendDateWrittenToSalesforce, None)
+              .filter(item => Dispatch.belongs(cohortSpec, item))
               .take(batchSize)
           case Some(subscriptionNumber) =>
             CohortTable

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -379,6 +379,26 @@ object AmendmentHandler extends CohortHandler {
           cohortSpec: CohortSpec,
           item: CohortItem
         )
+      case SupporterPlus2026N2 =>
+        doAmendmentUsingOrdersApiWithJsonValues(
+          cohortSpec: CohortSpec,
+          item: CohortItem
+        )
+      case SupporterPlus2026N3 =>
+        doAmendmentUsingOrdersApiWithJsonValues(
+          cohortSpec: CohortSpec,
+          item: CohortItem
+        )
+      case SupporterPlus2026N4 =>
+        doAmendmentUsingOrdersApiWithJsonValues(
+          cohortSpec: CohortSpec,
+          item: CohortItem
+        )
+      case SupporterPlus2026N5 =>
+        doAmendmentUsingOrdersApiWithJsonValues(
+          cohortSpec: CohortSpec,
+          item: CohortItem
+        )
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -54,6 +54,7 @@ object NotificationHandler extends CohortHandler {
           case None =>
             CohortTable
               .fetch(SalesforcePriceRiseCreationComplete, Some(today.plusDays(maxLeadTime(cohortSpec))))
+              .filter(item => Dispatch.belongs(cohortSpec, item))
               .take(batchSize)
           case Some(subscriptionNumber) =>
             CohortTable

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -368,6 +368,10 @@ object NotificationHandler extends CohortHandler {
       case Membership2025         => Membership2025Migration.maxLeadTime
       case DigiSubs2025           => DigiSubs2025Migration.maxLeadTime
       case SupporterPlus2026      => SupporterPlus2026Migration.maxLeadTime
+      case SupporterPlus2026N2    => SupporterPlus2026Migration.maxLeadTime
+      case SupporterPlus2026N3    => SupporterPlus2026Migration.maxLeadTime
+      case SupporterPlus2026N4    => SupporterPlus2026Migration.maxLeadTime
+      case SupporterPlus2026N5    => SupporterPlus2026Migration.maxLeadTime
     }
   }
 
@@ -381,6 +385,10 @@ object NotificationHandler extends CohortHandler {
       case Membership2025         => Membership2025Migration.minLeadTime
       case DigiSubs2025           => DigiSubs2025Migration.minLeadTime
       case SupporterPlus2026      => SupporterPlus2026Migration.minLeadTime
+      case SupporterPlus2026N2    => SupporterPlus2026Migration.minLeadTime
+      case SupporterPlus2026N3    => SupporterPlus2026Migration.minLeadTime
+      case SupporterPlus2026N4    => SupporterPlus2026Migration.minLeadTime
+      case SupporterPlus2026N5    => SupporterPlus2026Migration.minLeadTime
     }
   }
 
@@ -623,6 +631,30 @@ object NotificationHandler extends CohortHandler {
             DataExtractionFailure(s"[e3f83ac4] could not determine brazeName for DigiSubs2025, item: ${item}")
           )
       case SupporterPlus2026 =>
+        ZIO
+          .fromOption(SupporterPlus2026Migration.brazeName(item, zuoraSubscription))
+          .orElseFail(
+            DataExtractionFailure(s"[15ecdf55] could not determine brazeName for SupporterPlus2026, item: ${item}")
+          )
+      case SupporterPlus2026N2 =>
+        ZIO
+          .fromOption(SupporterPlus2026Migration.brazeName(item, zuoraSubscription))
+          .orElseFail(
+            DataExtractionFailure(s"[15ecdf55] could not determine brazeName for SupporterPlus2026, item: ${item}")
+          )
+      case SupporterPlus2026N3 =>
+        ZIO
+          .fromOption(SupporterPlus2026Migration.brazeName(item, zuoraSubscription))
+          .orElseFail(
+            DataExtractionFailure(s"[15ecdf55] could not determine brazeName for SupporterPlus2026, item: ${item}")
+          )
+      case SupporterPlus2026N4 =>
+        ZIO
+          .fromOption(SupporterPlus2026Migration.brazeName(item, zuoraSubscription))
+          .orElseFail(
+            DataExtractionFailure(s"[15ecdf55] could not determine brazeName for SupporterPlus2026, item: ${item}")
+          )
+      case SupporterPlus2026N5 =>
         ZIO
           .fromOption(SupporterPlus2026Migration.brazeName(item, zuoraSubscription))
           .orElseFail(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceAmendmentUpdateHandler.scala
@@ -16,6 +16,7 @@ object SalesforceAmendmentUpdateHandler extends CohortHandler {
     for {
       count <- CohortTable
         .fetch(AmendmentComplete, None)
+        .filter(item => Dispatch.belongs(cohortSpec, item))
         .take(batchSize)
         .mapZIO(item =>
           updateSfWithNewSubscriptionId(cohortSpec, item).tapBoth(

--- a/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandler.scala
@@ -15,6 +15,7 @@ object SalesforceNotificationDateUpdateHandler extends CohortHandler {
     for {
       count <- CohortTable
         .fetch(NotificationSendComplete, None)
+        .filter(item => Dispatch.belongs(cohortSpec, item))
         .take(batchSize)
         .mapZIO(item => updateDateLetterSentInSF(cohortSpec, item))
         .runCount

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentData.scala
@@ -104,6 +104,10 @@ object AmendmentData {
       case Membership2025         => Membership2025Migration.priceData(subscription, invoiceList)
       case DigiSubs2025           => DigiSubs2025Migration.priceData(subscription, invoiceList)
       case SupporterPlus2026      => SupporterPlus2026Migration.priceData(subscription, invoiceList)
+      case SupporterPlus2026N2    => SupporterPlus2026Migration.priceData(subscription, invoiceList)
+      case SupporterPlus2026N3    => SupporterPlus2026Migration.priceData(subscription, invoiceList)
+      case SupporterPlus2026N4    => SupporterPlus2026Migration.priceData(subscription, invoiceList)
+      case SupporterPlus2026N5    => SupporterPlus2026Migration.priceData(subscription, invoiceList)
     }
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculator.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculator.scala
@@ -41,6 +41,10 @@ object AmendmentEffectiveDateCalculator {
       case Membership2025         => None
       case DigiSubs2025           => None
       case SupporterPlus2026      => None
+      case SupporterPlus2026N2    => None
+      case SupporterPlus2026N3    => None
+      case SupporterPlus2026N4    => None
+      case SupporterPlus2026N5    => None
     }
   }
 
@@ -104,6 +108,10 @@ object AmendmentEffectiveDateCalculator {
         case Membership2025         => 1
         case DigiSubs2025           => 3 // 3 Months for DigiSubs2025
         case SupporterPlus2026      => 1 // no spread for SupporterPlus2026
+        case SupporterPlus2026N2    => 1 // no spread for SupporterPlus2026
+        case SupporterPlus2026N3    => 1 // no spread for SupporterPlus2026
+        case SupporterPlus2026N4    => 1 // no spread for SupporterPlus2026
+        case SupporterPlus2026N5    => 1 // no spread for SupporterPlus2026
       }
     } else 1
   }
@@ -144,6 +152,14 @@ object AmendmentEffectiveDateCalculator {
       case Membership2025         => lowerBound3
       case DigiSubs2025           => lowerBound3
       case SupporterPlus2026      =>
+        SupporterPlus2026Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, item, subscription)
+      case SupporterPlus2026N2 =>
+        SupporterPlus2026Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, item, subscription)
+      case SupporterPlus2026N3 =>
+        SupporterPlus2026Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, item, subscription)
+      case SupporterPlus2026N4 =>
+        SupporterPlus2026Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, item, subscription)
+      case SupporterPlus2026N5 =>
         SupporterPlus2026Migration.computeAmendmentEffectiveDateLowerBound(lowerBound3, item, subscription)
     }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentHandlerHelper.scala
@@ -70,6 +70,10 @@ object AmendmentHandlerHelper {
       case Membership2025         => true
       case DigiSubs2025           => true
       case SupporterPlus2026      => false
+      case SupporterPlus2026N2    => false
+      case SupporterPlus2026N3    => false
+      case SupporterPlus2026N4    => false
+      case SupporterPlus2026N5    => false
     }
   }
 
@@ -198,6 +202,50 @@ object AmendmentHandlerHelper {
           invoiceList
         )
       case SupporterPlus2026 =>
+        SupporterPlus2026Migration.amendmentOrderPayload(
+          cohortItem,
+          orderDate,
+          accountNumber,
+          subscriptionNumber,
+          effectDate,
+          zuora_subscription,
+          commsPrice,
+          invoiceList
+        )
+      case SupporterPlus2026N2 =>
+        SupporterPlus2026Migration.amendmentOrderPayload(
+          cohortItem,
+          orderDate,
+          accountNumber,
+          subscriptionNumber,
+          effectDate,
+          zuora_subscription,
+          commsPrice,
+          invoiceList
+        )
+      case SupporterPlus2026N3 =>
+        SupporterPlus2026Migration.amendmentOrderPayload(
+          cohortItem,
+          orderDate,
+          accountNumber,
+          subscriptionNumber,
+          effectDate,
+          zuora_subscription,
+          commsPrice,
+          invoiceList
+        )
+      case SupporterPlus2026N4 =>
+        SupporterPlus2026Migration.amendmentOrderPayload(
+          cohortItem,
+          orderDate,
+          accountNumber,
+          subscriptionNumber,
+          effectDate,
+          zuora_subscription,
+          commsPrice,
+          invoiceList
+        )
+      case SupporterPlus2026N5 =>
         SupporterPlus2026Migration.amendmentOrderPayload(
           cohortItem,
           orderDate,

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -43,7 +43,15 @@ case class CohortSpec(
     subscriptionNumber: Option[String] = None,
     forceNotifications: Option[Boolean] = None,
 ) {
-  def tableName(stage: String): String = s"PriceMigration-${stage}-${cohortName}"
+  def tableName(stage: String): String = {
+    cohortName match {
+      case "SupporterPlus2026N2" => s"PriceMigration-${stage}-SupporterPlus2026"
+      case "SupporterPlus2026N3" => s"PriceMigration-${stage}-SupporterPlus2026"
+      case "SupporterPlus2026N4" => s"PriceMigration-${stage}-SupporterPlus2026"
+      case "SupporterPlus2026N5" => s"PriceMigration-${stage}-SupporterPlus2026"
+      case _                     => s"PriceMigration-${stage}-${cohortName}"
+    }
+  }
 }
 
 object CohortSpec {

--- a/lambda/src/main/scala/pricemigrationengine/model/Dispatch.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Dispatch.scala
@@ -1,0 +1,43 @@
+package pricemigrationengine.model
+
+import scala.util.hashing.MurmurHash3
+
+object Dispatch {
+
+  /*
+    The Displach functionality was introduced to help with SupporterPlus2026
+    https://github.com/guardian/price-migration-engine/pull/1500
+
+    ... and the `evaluate` function is the core of it. It takes a string (essentially a subscription number)
+    and an integer between 1 and 5 (we have 5 names for SupporterPlus2026) and return a boolean.
+
+    The requirements are
+    1. For any string, there must be an integer n such that evaluate(string, n) is true
+    2. For any string, there is a unique integer n such evaluate(string, n) is true
+
+    This implies that the space of strings is partitioned into 5 subsets
+   */
+  def evaluate(s: String, n: Int): Boolean = {
+    require(n >= 1 && n <= 5, "n must be between 1 and 5")
+    val bucket = Math.abs(MurmurHash3.stringHash(s) % 5)
+    bucket == n - 1
+  }
+
+  /*
+    This function returns whether the cohort item "belongs" to the migration type
+    It defaults to true for non SupporterPlus2026 migrations, but induces a partition
+    in 5 subsets for SupporterPlus2026
+   */
+  def belongs(cohortSpec: CohortSpec, cohortItem: CohortItem): Boolean = {
+    MigrationType(cohortSpec) match {
+      case SupporterPlus2026   => evaluate(cohortItem.subscriptionName, 1)
+      case SupporterPlus2026N2 => evaluate(cohortItem.subscriptionName, 2)
+      case SupporterPlus2026N3 => evaluate(cohortItem.subscriptionName, 3)
+      case SupporterPlus2026N4 => evaluate(cohortItem.subscriptionName, 4)
+      case SupporterPlus2026N5 => evaluate(cohortItem.subscriptionName, 5)
+      // default to true for the others
+      case _ => true
+    }
+  }
+
+}

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
@@ -15,6 +15,10 @@ object EstimationHandlerHelper {
       case Membership2025         => Some(1.43)
       case DigiSubs2025           => Some(1.25)
       case SupporterPlus2026      => None
+      case SupporterPlus2026N2    => None
+      case SupporterPlus2026N3    => None
+      case SupporterPlus2026N4    => None
+      case SupporterPlus2026N5    => None
     }
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/MigrationType.scala
@@ -9,6 +9,10 @@ object ProductMigration2025N4 extends MigrationType
 object Membership2025 extends MigrationType
 object DigiSubs2025 extends MigrationType
 object SupporterPlus2026 extends MigrationType
+object SupporterPlus2026N2 extends MigrationType
+object SupporterPlus2026N3 extends MigrationType
+object SupporterPlus2026N4 extends MigrationType
+object SupporterPlus2026N5 extends MigrationType
 
 object MigrationType {
   def apply(cohortSpec: CohortSpec): MigrationType = cohortSpec.cohortName match {
@@ -20,5 +24,9 @@ object MigrationType {
     case "Membership2025"         => Membership2025
     case "DigiSubs2025"           => DigiSubs2025
     case "SupporterPlus2026"      => SupporterPlus2026
+    case "SupporterPlus2026N2"    => SupporterPlus2026N2
+    case "SupporterPlus2026N3"    => SupporterPlus2026N3
+    case "SupporterPlus2026N4"    => SupporterPlus2026N4
+    case "SupporterPlus2026N5"    => SupporterPlus2026N5
   }
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/NotificationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/NotificationHandlerHelper.scala
@@ -45,9 +45,13 @@ object NotificationHandlerHelper {
           ),
         ).forall(identity)
       }
-      case Membership2025    => true
-      case DigiSubs2025      => true
-      case SupporterPlus2026 => true
+      case Membership2025      => true
+      case DigiSubs2025        => true
+      case SupporterPlus2026   => true
+      case SupporterPlus2026N2 => true
+      case SupporterPlus2026N3 => true
+      case SupporterPlus2026N4 => true
+      case SupporterPlus2026N5 => true
     }
   }
 
@@ -61,6 +65,10 @@ object NotificationHandlerHelper {
       case Membership2025         => None
       case DigiSubs2025           => None
       case SupporterPlus2026      => Some("Supporter Plus")
+      case SupporterPlus2026N2    => Some("Supporter Plus")
+      case SupporterPlus2026N3    => Some("Supporter Plus")
+      case SupporterPlus2026N4    => Some("Supporter Plus")
+      case SupporterPlus2026N5    => Some("Supporter Plus")
     }
   }
 

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -85,7 +85,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
     val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
 
     val cohortSpec: CohortSpec =
-      CohortSpec("cohortName", LocalDate.of(2022, 1, 1))
+      CohortSpec("Test1", LocalDate.of(2022, 1, 1))
 
     val cohortItem = CohortItem(
       subscriptionName = subscriptionName,

--- a/lambda/src/test/scala/pricemigrationengine/model/DispatchTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/DispatchTest.scala
@@ -1,0 +1,65 @@
+package pricemigrationengine.model
+
+import java.time.LocalDate
+class DispatchTest extends munit.FunSuite {
+
+  test("Dispatch (1)") {
+    val cohortSpec = CohortSpec(
+      cohortName = "DigiSubs2025",
+      earliestAmendmentEffectiveDate = LocalDate.of(2026, 2, 1)
+    )
+
+    // For DigiSubs2025 we expect the belong function to always return true
+    // (Each cohort item belongs to it)
+
+    val cohortItem1: CohortItem = CohortItem(
+      subscriptionName = "A-00001",
+      processingStage = CohortTableFilter.NotificationSendDateWrittenToSalesforce,
+    )
+    assertEquals(Dispatch.belongs(cohortSpec, cohortItem1), true)
+
+    val cohortItem2: CohortItem = CohortItem(
+      subscriptionName = "A-00004",
+      processingStage = CohortTableFilter.NotificationSendDateWrittenToSalesforce,
+    )
+    assertEquals(Dispatch.belongs(cohortSpec, cohortItem2), true)
+  }
+
+  test("Dispatch (2)") {
+    val cohortSpec = CohortSpec(
+      cohortName = "SupporterPlus2026",
+      earliestAmendmentEffectiveDate = LocalDate.of(2026, 8, 1)
+    )
+
+    // For SupporterPlus2026,
+    // "A-00001" doesn't belong to it (instead "A-00001" belongs to SupporterPlus2026N4, as per next test)
+    // "A-00004" belongs to it
+
+    val cohortItem1: CohortItem = CohortItem(
+      subscriptionName = "A-00001",
+      processingStage = CohortTableFilter.NotificationSendDateWrittenToSalesforce,
+    )
+    assertEquals(Dispatch.belongs(cohortSpec, cohortItem1), false)
+
+    val cohortItem2: CohortItem = CohortItem(
+      subscriptionName = "A-00004",
+      processingStage = CohortTableFilter.NotificationSendDateWrittenToSalesforce,
+    )
+    assertEquals(Dispatch.belongs(cohortSpec, cohortItem2), true)
+  }
+
+  test("Dispatch (3)") {
+    // "A-00001" belongs to SupporterPlus2026N4
+
+    val cohortSpec = CohortSpec(
+      cohortName = "SupporterPlus2026N4",
+      earliestAmendmentEffectiveDate = LocalDate.of(2026, 8, 1)
+    )
+
+    val cohortItem1: CohortItem = CohortItem(
+      subscriptionName = "A-00001",
+      processingStage = CohortTableFilter.NotificationSendDateWrittenToSalesforce,
+    )
+    assertEquals(Dispatch.belongs(cohortSpec, cohortItem1), true)
+  }
+}


### PR DESCRIPTION
### Problem

SupporterPlus2026 is a record breaking price migration with a cohort table containing more than 350,000 items, which is more than 3 times the previous largest migration. One interesting side effect of this large number is that at the moment (and this will continue for an entire month) the daily load of Braze user notification and Zuora amendments takes more than 24 hours. This is due to the fact that we process cohort items one by one. 

### Solutions

There are 3 ways to deal with this problem. 

1. Modify the code to perform some operations in parallel (for instance the amendments). This is not as safe as what it may first looks like because the engine-Zuoro amendment exchange is not idempotent and the ZIO handling of failures would make it difficult to deal with.

2. Introduce new `MigrationType`s and split the existing cohort table, thereby splitting this one migrations into several. I am not doing that because I don't really want to go into the trouble to split the main table.

3. Introduce new `MigrationType`s and use a dispatch function to target the same table from different names. This has never been done before, but is a very clean solution. 

### Adopted solution

Here we are doing solution 3. I introduced 4 new migration names, namely: `SupporterPlus2026N2`, `SupporterPlus2026N3`, `SupporterPlus2026N4` and `SupporterPlus2026N5`, to bring the number of names targeting the SupporterPlus2026 dynamo table to 5. 

Then we introduce the Dispatch helper, and the `evaluate` function is the core of it. It takes a string (essentially a subscription number) and an integer between 1 and 5 (we have 5 names for SupporterPlus2026) and return a boolean. The requirements are

1. For any string, there must be an integer n such that `evaluate(string, n)` is true
2. For any string, there is a unique integer n such `evaluate(string, n)` is true

This implies that the space of strings is partitioned into 5 subsets

Note that we needed to hack the function that turn a cohort name into a table name, so that all the `SupporterPlus2026*` go to `PriceMigration-PROD-SupporterPlus2026`

The rest is then to plug the dispatch to the handlers, thereby affecting all the migrations, although the effect will only matter for SupporterPlus2026. In any case, we will now have 5 different state machines targeting the same cohort table without any conflicts.

### Deployment

Once the PR is merged, I am going to add the missing entries to the `price-migration-engine-cohort-spec-PROD` Dynamo table, to active the new state machines. 

### Future development

This is a temporary solution to help SupporterPlus2026. It is likely that I am going to decommission Dispatch in a month, but I have documented the solution for if we have another big migration at some point in the future.  