### PR TITLE
notification handler update

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -24,9 +24,9 @@ object NotificationHandler extends CohortHandler {
 
   private val batchSize = 150
 
-  val Successful = 1
-  val Unsuccessful = 0
-  val Cancelled_Status = "Cancelled"
+  // -----------------------------------------
+  // Primary Logic
+  // -----------------------------------------
 
   def handle(input: CohortSpec): ZIO[Logging, Failure, HandlerOutput] = {
     main(input).provideSome[Logging](
@@ -64,18 +64,82 @@ object NotificationHandler extends CohortHandler {
       ).mapZIO { item =>
         for {
           subscription <- Zuora.fetchSubscription(item.subscriptionName)
-          _ <-
-            if (subscription.status == "Cancelled") {
-              updateCohortItemForZuoraCancellation(cohortSpec, item)
-            } else {
-              performProductNameCheckAndSendNotification(cohortSpec, item, subscription, today)
-            }
+          estimationInstant <- ZIO
+            .fromOption(item.whenEstimationDone)
+            .mapError(ex => DataExtractionFailure(s"[3026515c] Could not extract whenEstimationDone from item ${item}"))
+          ratePlanProbeResult <- ZIO.succeed(
+            RatePlanProbe.probe(subscription: ZuoraSubscription, LocalDate.from(estimationInstant))
+          )
+          analyseResult <- ZIO
+            .fromOption(
+              SubscriptionNotificationAnalyseResult.analyseSubscriptionForNotification(
+                cohortSpec,
+                subscription,
+                item,
+                today,
+                ratePlanProbeResult
+              )
+            )
+            .orElseFail(
+              DataExtractionFailure(
+                s"[0c1a6fc5] could not determine SubscriptionNotificationAnalyseResult for item $item"
+              )
+            )
+          _ <- evaluateAnalyseResult(
+            cohortSpec,
+            item,
+            subscription,
+            analyseResult
+          )
+
         } yield ()
       }.runCount
     } yield HandlerOutput(isComplete = count < batchSize)
   }
 
-  private def updateCohortItemForZuoraCancellation(
+  def evaluateAnalyseResult(
+      cohortSpec: CohortSpec,
+      item: CohortItem,
+      zuoraSubscription: ZuoraSubscription,
+      analyseResult: SubscriptionNotificationAnalyseResult
+  ): ZIO[CohortTable with SalesforceClient with Logging with EmailSender with Zuora, Failure, Unit] = {
+    analyseResult match {
+      case SNARReadyToNotify             => sendNotification(cohortSpec, zuoraSubscription, item)
+      case SNARCancelledInZuora          => updateCohortItemToReflectZuoraCancellation(cohortSpec, item)
+      case SNARExcludeFromMigration      => updateCohortItemToExcludeFromMigration(item)
+      case SNARMissingNotificationWindow =>
+        ZIO.fail(
+          NotificationHandlerFailure(
+            s"[71edb83e] we are missing the notification window for ${item} (SubscriptionNotificationAnalyseResult). Please investigate."
+          )
+        )
+    }
+  }
+
+  // -----------------------------------------
+  // Helpers
+  // -----------------------------------------
+
+  private def updateCohortItemToExcludeFromMigration(
+      item: CohortItem
+  ): ZIO[CohortTable with SalesforceClient with Logging, Failure, Unit] = {
+    for {
+      _ <- CohortTable
+        .update(
+          CohortItem(
+            item.subscriptionName,
+            processingStage = ExcludedFromMigration,
+            cancellationReason =
+              Some("(cause: fae335fc) excluded from migration by SubscriptionNotificationAnalyseResult")
+          )
+        )
+      _ <- Logging.info(
+        s"Subscription ${item.subscriptionName} has been excluded from migration by SubscriptionNotificationAnalyseResult"
+      )
+    } yield ()
+  }
+
+  private def updateCohortItemToReflectZuoraCancellation(
       cohortSpec: CohortSpec,
       item: CohortItem
   ): ZIO[CohortTable with SalesforceClient with Logging, Failure, Unit] = {
@@ -95,82 +159,15 @@ object NotificationHandler extends CohortHandler {
     } yield ()
   }
 
-  def performProductNameCheckAndSendNotification(
+  def sendNotification(
       cohortSpec: CohortSpec,
-      item: CohortItem,
-      subscription: ZuoraSubscription,
-      date: LocalDate
-  ): ZIO[CohortTable with SalesforceClient with EmailSender with Zuora with Logging, Failure, Unit] = {
-    for {
-      ratePlan <- ZIO
-        .fromOption(
-          SI2025RateplanFromSub.uniquelyDeterminedActiveNonDiscountNonExpiredRatePlan(
-            subscription,
-            date
-          )
-        )
-        .orElseFail(DataExtractionFailure(s"[cd6e6562] could not determine rate plan for item $item"))
-      hasCorrectProductName = NotificationHandlerHelper
-        .checkProductName(
-          ratePlan,
-          date,
-          NotificationHandlerHelper.expectedProductNameOpt(cohortSpec)
-        )
-      result <-
-        if (hasCorrectProductName) {
-          sendNotification(cohortSpec, subscription)(item, date)
-        } else {
-          CohortTable
-            .update(
-              CohortItem(
-                item.subscriptionName,
-                processingStage = ExcludedFromMigration,
-                cancellationReason = Some(s"item $item excluded from migration due to unexpected product name")
-              )
-            )
-            .as(())
-        }
-    } yield result
-  }
-
-  def sendNotification(cohortSpec: CohortSpec, zuoraSubscription: ZuoraSubscription)(
+      zuoraSubscription: ZuoraSubscription,
       cohortItem: CohortItem,
-      today: LocalDate
-  ): ZIO[EmailSender with SalesforceClient with CohortTable with Logging with Zuora, Failure, Unit] = {
+  ): ZIO[Zuora with EmailSender with SalesforceClient with CohortTable with Logging, Failure, Unit] =
     for {
-      _ <- ZIO.when(!cohortSpec.forceNotifications.contains(true))(
-        if (thereIsEnoughNotificationLeadTime(cohortSpec, today, cohortItem)) {
-          ZIO.succeed(())
-        } else {
-          ZIO.fail(
-            NotificationNotEnoughLeadTimeFailure(
-              s"[notification] The start date of item ${cohortItem.subscriptionName} (startDate: ${cohortItem.amendmentEffectiveDate}) is too close to today ${today}"
-            )
-          )
-        }
-      )
-      _ <- ZIO.when(!cohortSpec.forceNotifications.contains(true))(cohortItemRatePlansChecks(cohortSpec, cohortItem))
       sfSubscription <-
         SalesforceClient
           .getSubscriptionByName(cohortItem.subscriptionName)
-      // Interestingly, here we do not check whether the subscription has been
-      // cancelled in Zuora, but in Salesforce.
-      _ <-
-        if (sfSubscription.Status__c == Cancelled_Status) {
-          updateCohortItemForZuoraCancellation(cohortSpec, cohortItem)
-        } else {
-          sendNotification(cohortSpec, cohortItem, sfSubscription, zuoraSubscription)
-        }
-    } yield ()
-  }
-
-  def sendNotification(
-      cohortSpec: CohortSpec,
-      cohortItem: CohortItem,
-      sfSubscription: SalesforceSubscription,
-      zuoraSubscription: ZuoraSubscription
-  ): ZIO[Zuora with EmailSender with SalesforceClient with CohortTable with Logging, Failure, Unit] =
-    for {
       _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
       contact <- SalesforceClient.getContact(sfSubscription.Buyer__c)
       firstName <- ZIO.fromEither(firstName(contact))
@@ -303,51 +300,6 @@ object NotificationHandler extends CohortHandler {
     } yield ()
 
   // -------------------------------------------------------------------
-  // Subscription Rate Plan Checks
-
-  private def subscriptionRatePlansCheck(
-      cohortSpec: CohortSpec,
-      item: CohortItem,
-      subscription: ZuoraSubscription,
-      date: LocalDate
-  ): ZIO[CohortTable with Zuora with SalesforceClient with Logging, Failure, Unit] = {
-    for {
-      _ <- RatePlanProbe.probe(subscription: ZuoraSubscription, date) match {
-        case RPPShouldProceed    => ZIO.succeed(())
-        case RPPCancelledInZuora =>
-          updateCohortItemForZuoraCancellation(
-            cohortSpec,
-            item
-          )
-        case IndeterminateConclusion =>
-          ZIO.fail(
-            RatePlanProbeFailure(
-              s"[4f7589ea] NotificationHandler probeRatePlans could not determine a probe outcome for cohort item ${item}. Please investigate."
-            )
-          )
-      }
-    } yield ()
-  }
-
-  private def cohortItemRatePlansChecks(
-      cohortSpec: CohortSpec,
-      item: CohortItem
-  ): ZIO[CohortTable with Zuora with SalesforceClient with Logging, Failure, Unit] = {
-    for {
-      subscription <- Zuora.fetchSubscription(item.subscriptionName)
-      estimationInstant <- ZIO
-        .fromOption(item.whenEstimationDone)
-        .mapError(ex => DataExtractionFailure(s"[3026515c] Could not extract whenEstimationDone from item ${item}"))
-      _ <- subscriptionRatePlansCheck(
-        cohortSpec,
-        item,
-        subscription,
-        estimationInstant.atZone(ZoneId.of("Europe/London")).toLocalDate
-      )
-    } yield ()
-  }
-
-  // -------------------------------------------------------------------
   // Notification Windows
 
   // For general information about the notification period see the docs/notification-periods.md
@@ -393,20 +345,8 @@ object NotificationHandler extends CohortHandler {
     }
   }
 
-  def thereIsEnoughNotificationLeadTime(cohortSpec: CohortSpec, today: LocalDate, cohortItem: CohortItem): Boolean = {
-    // To help with backward compatibility with existing tests, we apply this condition from 1st Dec 2020.
-    if (today.isBefore(LocalDate.of(2020, 12, 1))) {
-      true
-    } else {
-      cohortItem.amendmentEffectiveDate match {
-        case Some(sd) => today.plusDays(minLeadTime(cohortSpec)).isBefore(sd)
-        case _        => false
-      }
-    }
-  }
-
   // -------------------------------------------------------------------
-  // Support Functions
+  // Data Extraction Functions
 
   def currencyISOtoSymbol(iso: String): ZIO[Any, Nothing, String] = {
     ZIO.succeed(i18n.Currency.fromString(iso: String).map(_.identifier).getOrElse(""))

--- a/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/NotificationHandler.scala
@@ -82,7 +82,7 @@ object NotificationHandler extends CohortHandler {
             )
             .orElseFail(
               DataExtractionFailure(
-                s"[0c1a6fc5] could not determine SubscriptionNotificationAnalyseResult for item $item"
+                s"[0c1a6fc5] could not determine SubscriptionNotificationAnalyseResult for item {$item}"
               )
             )
           _ <- evaluateAnalyseResult(
@@ -165,10 +165,10 @@ object NotificationHandler extends CohortHandler {
       cohortItem: CohortItem,
   ): ZIO[Zuora with EmailSender with SalesforceClient with CohortTable with Logging, Failure, Unit] =
     for {
+      _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
       sfSubscription <-
         SalesforceClient
           .getSubscriptionByName(cohortItem.subscriptionName)
-      _ <- Logging.info(s"Processing subscription: ${cohortItem.subscriptionName}")
       contact <- SalesforceClient.getContact(sfSubscription.Buyer__c)
       firstName <- ZIO.fromEither(firstName(contact))
       lastName <- ZIO.fromEither(requiredField(contact.LastName, "Contact.LastName"))

--- a/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/Failure.scala
@@ -41,5 +41,4 @@ case class S3Failure(reason: String) extends Failure
 case class SubscriptionIdUploadFailure(reason: String) extends Failure
 
 case class NotificationHandlerFailure(reason: String) extends Failure
-case class NotificationNotEnoughLeadTimeFailure(reason: String) extends Failure
 case class EmailSenderFailure(reason: String) extends Failure

--- a/lambda/src/main/scala/pricemigrationengine/model/NotificationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/NotificationHandlerHelper.scala
@@ -1,5 +1,7 @@
 package pricemigrationengine.model
 
+import pricemigrationengine.handlers.NotificationHandler.minLeadTime
+
 import java.time.LocalDate
 import pricemigrationengine.model.membershipworkflow.EmailMessage
 
@@ -55,23 +57,6 @@ object NotificationHandlerHelper {
     }
   }
 
-  def expectedProductNameOpt(cohortSpec: CohortSpec): Option[String] = {
-    MigrationType(cohortSpec) match {
-      case Test1                  => None
-      case GuardianWeekly2025     => None
-      case Newspaper2025P1        => None
-      case Newspaper2025P3        => None
-      case ProductMigration2025N4 => None
-      case Membership2025         => None
-      case DigiSubs2025           => None
-      case SupporterPlus2026      => Some("Supporter Plus")
-      case SupporterPlus2026N2    => Some("Supporter Plus")
-      case SupporterPlus2026N3    => Some("Supporter Plus")
-      case SupporterPlus2026N4    => Some("Supporter Plus")
-      case SupporterPlus2026N5    => Some("Supporter Plus")
-    }
-  }
-
   def checkProductName(
       ratePlan: ZuoraRatePlan,
       today: LocalDate,
@@ -87,6 +72,108 @@ object NotificationHandlerHelper {
         ratePlan.productName == productName
       }
       case None => true // for backward compatibility when the information is not available for previous subs
+    }
+  }
+
+  def thereIsEnoughNotificationLeadTime(cohortSpec: CohortSpec, today: LocalDate, cohortItem: CohortItem): Boolean = {
+    // To help with backward compatibility with existing tests, we apply this condition from 1st Dec 2020.
+    if (today.isBefore(LocalDate.of(2020, 12, 1))) {
+      true
+    } else {
+      cohortItem.amendmentEffectiveDate match {
+        case Some(sd) => today.plusDays(minLeadTime(cohortSpec)).isBefore(sd)
+        case _        => false
+      }
+    }
+  }
+}
+
+sealed trait SubscriptionNotificationAnalyseResult
+
+// "SNAR" means "Subscription Notification Analyse Result"
+
+object SNARReadyToNotify extends SubscriptionNotificationAnalyseResult
+object SNARCancelledInZuora extends SubscriptionNotificationAnalyseResult
+object SNARExcludeFromMigration extends SubscriptionNotificationAnalyseResult
+object SNARMissingNotificationWindow extends SubscriptionNotificationAnalyseResult
+
+object SubscriptionNotificationAnalyseResult {
+
+  def analyseSubscriptionForNotification_Legacy(
+      ratePlanProbeResult: RatePlanProbeResult
+  ): Option[SubscriptionNotificationAnalyseResult] = {
+    ratePlanProbeResult match {
+      case RPPShouldProceed        => Some(SNARReadyToNotify)
+      case RPPCancelledInZuora     => Some(SNARCancelledInZuora)
+      case IndeterminateConclusion => None
+    }
+  }
+
+  def analyseSubscriptionForNotification_SupporterPlus2026(
+      subscription: ZuoraSubscription,
+      cohortItem: CohortItem,
+      date: LocalDate
+  ): Option[SubscriptionNotificationAnalyseResult] = {
+    // The check here consists in verifying that the product name is "Supporter Plus" [1] and that
+    // The billing period of the subscription's active rate plan is the same as the cohort item [2]
+
+    // [1] The first discrepancy happens when the customer has upgraded to DigitalPack
+    // [2] The second discrepancy happens when the customer migrated from Monthly to Annual
+
+    for {
+      ratePlan <- SI2025RateplanFromSub.uniquelyDeterminedActiveNonDiscountNonExpiredRatePlan(
+        subscription,
+        date
+      )
+      subscriptionBillingPeriod <- ZuoraRatePlan.ratePlanToOptionalUniquelyDeterminedBillingPeriod(ratePlan)
+      cohortItemBillingPeriod <- cohortItem.billingPeriod
+    } yield {
+      if (
+        ratePlan.productName == "Supporter Plus" &&
+        BillingPeriod.toString(subscriptionBillingPeriod) == cohortItemBillingPeriod
+      ) {
+        SNARReadyToNotify
+      } else {
+        SNARExcludeFromMigration
+      }
+    }
+  }
+
+  def analyseSubscriptionForNotification(
+      cohortSpec: CohortSpec,
+      subscription: ZuoraSubscription,
+      cohortItem: CohortItem,
+      date: LocalDate,
+      ratePlanProbeResult: RatePlanProbeResult
+  ): Option[SubscriptionNotificationAnalyseResult] = {
+
+    if (subscription.status == "Cancelled") {
+      Some(SNARCancelledInZuora)
+    } else if (
+      !cohortSpec.forceNotifications
+        .contains(true) && !NotificationHandlerHelper.thereIsEnoughNotificationLeadTime(cohortSpec, date, cohortItem)
+    ) {
+      Some(SNARMissingNotificationWindow)
+    } else {
+      MigrationType(cohortSpec) match {
+        case Test1                  => analyseSubscriptionForNotification_Legacy(ratePlanProbeResult)
+        case GuardianWeekly2025     => analyseSubscriptionForNotification_Legacy(ratePlanProbeResult)
+        case Newspaper2025P1        => analyseSubscriptionForNotification_Legacy(ratePlanProbeResult)
+        case Newspaper2025P3        => analyseSubscriptionForNotification_Legacy(ratePlanProbeResult)
+        case ProductMigration2025N4 => analyseSubscriptionForNotification_Legacy(ratePlanProbeResult)
+        case Membership2025         => analyseSubscriptionForNotification_Legacy(ratePlanProbeResult)
+        case DigiSubs2025           => analyseSubscriptionForNotification_Legacy(ratePlanProbeResult)
+        case SupporterPlus2026      =>
+          analyseSubscriptionForNotification_SupporterPlus2026(subscription, cohortItem, date)
+        case SupporterPlus2026N2 =>
+          analyseSubscriptionForNotification_SupporterPlus2026(subscription, cohortItem, date)
+        case SupporterPlus2026N3 =>
+          analyseSubscriptionForNotification_SupporterPlus2026(subscription, cohortItem, date)
+        case SupporterPlus2026N4 =>
+          analyseSubscriptionForNotification_SupporterPlus2026(subscription, cohortItem, date)
+        case SupporterPlus2026N5 =>
+          analyseSubscriptionForNotification_SupporterPlus2026(subscription, cohortItem, date)
+      }
     }
   }
 }


### PR DESCRIPTION
### The Notification handler's prelude

Essentially we want to ensure a certain number of things at the top of the notification handler. 

1. That if the subscription has been Cancelled in Zuora, then we want to notify Salesforce and update the cohort item with the right processing stage.

2. That we have not missed the notification window, except if as specified in the Cohort Spec.

3. We then want to run the rate plan probe check, which is a default process that checks whether the subscription has been updated after its estimation timestamp (that is almost certainly the sign that the migration of that subscription should interrupt)

4. In the case of SupporterPlus2026, the rate plan probe check, is slightly different, we are just checking that the product name is the expected one (otherwise the user probably upgraded to DigitalPack), and that the billing period has not been updated (happens when they upgrade from Monthly to Annual).

### So what is the problem then ?

The code is very unwieldy, from adding adhoc logic bit by bit when needed over the last few years, and is now more difficult to follow than what should be. Today we simplify that. 

This change was actually prompted by an error we had this morning [1]

```
[4f7589ea] NotificationHandler probeRatePlans could not determine a probe outcome for cohort CohortItem
``` 

Which is the natural way the notification handler deal with those (the handler detected that this sub cannot be price risen after a recent user change), but in the case of SupporterPlus2026 (because it happens more often that a user upgrades their subscription), it's better to return a `SNARExcludeFromMigration` instead of a `ZIO.fail`.

[1]  ... and I found myself having to think "where should I had the SupporterPlus2026 support code for that case ? 🤔"

### This change

The Notification handler's prelude logic is now much simpler

1. We collect data
2. We call `SubscriptionNotificationAnalyseResult.analyseSubscriptionForNotification` (located alongside the `NotificationHandlerHelper`) which encapsulate all the general, or migration specific, checks we want to perform
3. The previous step returns a `SubscriptionNotificationAnalyseResult` which is then evaluated and the right action is taken

Simple, no fuss. 

### Advertisement

Interestingly this refactoring is exactly the way the Rust folks would do it, except that in Rust, it's even more nicely done. 