### PR TITLE
fix email extra attributes in the case of the N* subscriptions

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
@@ -207,6 +207,23 @@ object SupporterPlus2026Migration {
     } yield price
   }
 
+  def buildEmailExtraAttributes(
+      cohortItem: CohortItem,
+      subscription: ZuoraSubscription
+  ): Option[SP2026EmailExtraAttributes] = {
+    for {
+      currentBaseAmount <- subscriptionToSupporterBaseAmount(subscription)
+      contributionAmount <- subscriptionToContributionAmount(subscription)
+      currentCombinedAmount = currentBaseAmount + contributionAmount
+      futureBaseAmount <- cohortItem.commsPrice // new base price
+      futureCombinedAmount = futureBaseAmount + contributionAmount
+    } yield SP2026EmailExtraAttributes(
+      contributionAmount.toString(),
+      currentCombinedAmount.toString(),
+      futureCombinedAmount.toString()
+    )
+  }
+
   def extractEmailExtraAttributes(
       cohortSpec: CohortSpec,
       cohortItem: CohortItem,
@@ -214,20 +231,12 @@ object SupporterPlus2026Migration {
   ): Option[SP2026EmailExtraAttributes] = {
 
     MigrationType(cohortSpec) match {
-      case SupporterPlus2026 => {
-        for {
-          currentBaseAmount <- subscriptionToSupporterBaseAmount(subscription)
-          contributionAmount <- subscriptionToContributionAmount(subscription)
-          currentCombinedAmount = currentBaseAmount + contributionAmount
-          futureBaseAmount <- cohortItem.commsPrice // new base price
-          futureCombinedAmount = futureBaseAmount + contributionAmount
-        } yield SP2026EmailExtraAttributes(
-          contributionAmount.toString(),
-          currentCombinedAmount.toString(),
-          futureCombinedAmount.toString()
-        )
-      }
-      case _ =>
+      case SupporterPlus2026   => buildEmailExtraAttributes(cohortItem, subscription)
+      case SupporterPlus2026N2 => buildEmailExtraAttributes(cohortItem, subscription)
+      case SupporterPlus2026N3 => buildEmailExtraAttributes(cohortItem, subscription)
+      case SupporterPlus2026N4 => buildEmailExtraAttributes(cohortItem, subscription)
+      case SupporterPlus2026N5 => buildEmailExtraAttributes(cohortItem, subscription)
+      case _                   =>
         Some(
           // Date: 9th July 2026
           // For Tom reading this... Same as usual, I can't return a None


### PR DESCRIPTION
We received a CSR notification that (at least) 2 customers had a missing contribution field in their price rise email. The problem affected a few emails sent after the Dispatch (https://github.com/guardian/price-migration-engine/pull/1500) change a few days ago.