### PR TITLE
extract the cohort table update logic

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -152,9 +152,7 @@ object AmendmentHandler extends CohortHandler {
   private def performAmendmentAttempt(
       cohortSpec: CohortSpec,
       item: CohortItem
-  ): ZIO[Zuora with Logging with SalesforceClient, Failure, Option[CohortItem]] = {
-    // This function performs the amendment (through the migration dispatch)
-    // and updates the Cohort Item.
+  ): ZIO[Zuora with Logging with SalesforceClient, Failure, Option[CohortItem]] =
     (for {
       result <- performAmendmentAttemptWithResult(cohortSpec, item)
       updatedItem <- result match {
@@ -190,8 +188,8 @@ object AmendmentHandler extends CohortHandler {
       failure = {
         case e: ZuoraUpdateFailure => {
           // If the failure was a lock competition, we do not want to alarm by reporting a
-          // ZIO.fail. Instead, we return a ZIO.succeed, and the item will be retried
-          // in the next run of the lambda.
+          // ZIO.fail. Instead, we return a ZIO.none to leave the item untouched in dynamo,
+          // and the item will be retried in the next run of the lambda.
           if (e.reason.contains("lock competition")) {
             ZIO.none
           } else {
@@ -202,7 +200,6 @@ object AmendmentHandler extends CohortHandler {
       },
       success = { update => ZIO.some(update) }
     )
-  }
 
   private def renewSubscription(
       subscription: ZuoraSubscription,

--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -55,6 +55,7 @@ object AmendmentHandler extends CohortHandler {
             Clock.nanoTime.map(_ < deadline)
           )
           .mapZIO(item => processCohortItem(cohortSpec, item))
+          .mapZIO(_.map(CohortTable.update).getOrElse(ZIO.unit))
           .runCount
       }
       endingTime <- Clock.nanoTime
@@ -68,7 +69,7 @@ object AmendmentHandler extends CohortHandler {
   def processCohortItem(
       cohortSpec: CohortSpec,
       item: CohortItem
-  ): ZIO[CohortTable with SalesforceClient with Logging with Zuora, Failure, Unit] = {
+  ): ZIO[SalesforceClient with Logging with Zuora, Failure, Option[CohortItem]] = {
     for {
       subscription <- Zuora.fetchSubscription(item.subscriptionName)
       analyseResult <- ZIO
@@ -83,43 +84,42 @@ object AmendmentHandler extends CohortHandler {
             s"[0c1a6fc5] could not determine SubscriptionAmendmentAnalyseResult for item {$item}"
           )
         )
-      _ <- evaluateAnalyseResult(
+      maybeUpdate <- evaluateAnalyseResult(
         cohortSpec,
         item,
         analyseResult
       )
-    } yield ()
+    } yield maybeUpdate
   }
 
   def evaluateAnalyseResult(
       cohortSpec: CohortSpec,
       item: CohortItem,
       analyseResult: SubscriptionAmendmentAnalyseResult
-  ): ZIO[CohortTable with SalesforceClient with Logging with Zuora, Failure, Unit] = {
-    analyseResult match {
+  ): ZIO[SalesforceClient with Logging with Zuora, Failure, Option[CohortItem]] = for {
+    maybeUpdate <- analyseResult match {
       case SAARReadyToAmend =>
         performAmendmentAttempt(
           cohortSpec,
           item
         )
       case SAARCancelledInZuora =>
-        CohortTable
-          .update(
-            CohortItem(
-              item.subscriptionName,
-              processingStage = ZuoraCancellation
-            )
+
+        ZIO.some(
+          CohortItem(
+            item.subscriptionName,
+            processingStage = ZuoraCancellation
           )
+        )
       case SAARExcludeFromMigration =>
-        CohortTable
-          .update(
-            CohortItem(
-              item.subscriptionName,
-              processingStage = ExcludedFromMigration
-            )
+        ZIO.some(
+          CohortItem(
+            item.subscriptionName,
+            processingStage = ExcludedFromMigration
           )
+        )
     }
-  }
+  } yield maybeUpdate
 
   def performN4Unlock(): ZIO[CohortTable with Logging, Failure, Unit] = {
     // This effect performs the monitoring of N4 items and unlock those for which delayN4AmendmentUntil
@@ -152,14 +152,14 @@ object AmendmentHandler extends CohortHandler {
   private def performAmendmentAttempt(
       cohortSpec: CohortSpec,
       item: CohortItem
-  ): ZIO[CohortTable with Zuora with Logging with SalesforceClient, Failure, Unit] = {
+  ): ZIO[Zuora with Logging with SalesforceClient, Failure, Option[CohortItem]] = {
     // This function performs the amendment (through the migration dispatch)
     // and updates the Cohort Item.
     (for {
       result <- performAmendmentAttemptWithResult(cohortSpec, item)
-      _ <- result match {
+      updatedItem <- result match {
         case r: AARSuccessfulAmendment => {
-          CohortTable.update(
+          ZIO.succeed(
             CohortItem(
               r.subscriptionNumber,
               processingStage = AmendmentComplete,
@@ -171,13 +171,12 @@ object AmendmentHandler extends CohortHandler {
           )
         }
         case r: AARUserOptOut => {
-          CohortTable
-            .update(
-              CohortItem(
-                r.subscriptionNumber,
-                processingStage = UserOptOut
-              )
+          ZIO.succeed(
+            CohortItem(
+              r.subscriptionNumber,
+              processingStage = UserOptOut
             )
+          )
         }
         case _ =>
           ZIO
@@ -187,21 +186,21 @@ object AmendmentHandler extends CohortHandler {
               )
             )
       }
-    } yield ()).foldZIO(
+    } yield updatedItem).foldZIO(
       failure = {
         case e: ZuoraUpdateFailure => {
           // If the failure was a lock competition, we do not want to alarm by reporting a
           // ZIO.fail. Instead, we return a ZIO.succeed, and the item will be retried
           // in the next run of the lambda.
           if (e.reason.contains("lock competition")) {
-            ZIO.succeed(())
+            ZIO.none
           } else {
             ZIO.fail(e)
           }
         }
         case e => ZIO.fail(e)
       },
-      success = { _ => ZIO.succeed(()) }
+      success = { update => ZIO.some(update) }
     )
   }
 


### PR DESCRIPTION
as per https://github.com/guardian/price-migration-engine/pull/1507#discussion_r3719350058
and this related chat thread: https://chat.google.com/room/AAAAFNJwTZs/klVkH3V68lg/JJXtN3LYqwE?cls=10

This reduces the power of the `processCohortItem` function by stopping it having arbitrary access to the cohort dynamo table.  It has the ability to take exactly one `CohortItem` (as before) but now it can return 0 or 1 `CohortItem` to update back into the table.
(note that the only reason it would return 0 would be if there's a lock contention in zuora, then it will pick it up again on the next attempt)

There are concerns that this would break with the convention of similar functions always returning `Unit` rather than a proper value, but in isolation it makes sense to constrain a function as much as possible by its signature.