### PR TITLE
Move SubscriptionAmendmentAnalyseResult to its own file

### DIFF
--- a/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/AmendmentHandler.scala
@@ -75,7 +75,7 @@ object AmendmentHandler extends CohortHandler {
       subscription <- Zuora.fetchSubscription(item.subscriptionName)
       analyseResult <- ZIO
         .fromOption(
-          SubscriptionAmendmentAnalyseResult.analyseSubscriptionForAmendment(
+          AmendmentHandlerHelper.analyseSubscriptionForAmendment(
             cohortSpec,
             item,
             subscription,

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentHandlerHelper.scala
@@ -287,29 +287,6 @@ object AmendmentHandlerHelper {
       case SupporterPlus2026N5    => itIsFewDaysAfterNotification(item)
     }
   }
-
-}
-
-sealed trait SubscriptionAmendmentAnalyseResult
-
-// "SAAR" means "Subscription Amendment Analyse Result"
-
-object SAARReadyToAmend extends SubscriptionAmendmentAnalyseResult
-object SAARCancelledInZuora extends SubscriptionAmendmentAnalyseResult
-object SAARExcludeFromMigration extends SubscriptionAmendmentAnalyseResult
-object SAARFailNoisily extends SubscriptionAmendmentAnalyseResult
-
-object SubscriptionAmendmentAnalyseResult {
-
-  def toString(result: SubscriptionAmendmentAnalyseResult): String = {
-    result match {
-      case SAARReadyToAmend         => "SAARReadyToAmend"
-      case SAARCancelledInZuora     => "SAARCancelledInZuora"
-      case SAARExcludeFromMigration => "SAARExcludeFromMigration"
-      case SAARFailNoisily          => "SAARFailNoisily"
-    }
-  }
-
   def subscriptionIsAmendableSupporterPlus2026(
       item: CohortItem,
       subscription: ZuoraSubscription,

--- a/lambda/src/main/scala/pricemigrationengine/model/SubscriptionAmendmentAnalyseResult.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/SubscriptionAmendmentAnalyseResult.scala
@@ -1,0 +1,24 @@
+package pricemigrationengine.model
+
+import java.time.{LocalDate}
+
+sealed trait SubscriptionAmendmentAnalyseResult
+
+// "SAAR" means "Subscription Amendment Analyse Result"
+
+object SAARReadyToAmend extends SubscriptionAmendmentAnalyseResult
+object SAARCancelledInZuora extends SubscriptionAmendmentAnalyseResult
+object SAARExcludeFromMigration extends SubscriptionAmendmentAnalyseResult
+object SAARFailNoisily extends SubscriptionAmendmentAnalyseResult
+
+object SubscriptionAmendmentAnalyseResult {
+
+  def toString(result: SubscriptionAmendmentAnalyseResult): String = {
+    result match {
+      case SAARReadyToAmend         => "SAARReadyToAmend"
+      case SAARCancelledInZuora     => "SAARCancelledInZuora"
+      case SAARExcludeFromMigration => "SAARExcludeFromMigration"
+      case SAARFailNoisily          => "SAARFailNoisily"
+    }
+  }
+}

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
@@ -1134,7 +1134,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     )
 
     assertEquals(
-      SubscriptionAmendmentAnalyseResult.subscriptionIsAmendableSupporterPlus2026(
+      AmendmentHandlerHelper.subscriptionIsAmendableSupporterPlus2026(
         cohortItem,
         subscription,
         today
@@ -1158,7 +1158,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     val today = LocalDate.of(2026, 8, 10)
 
     assertEquals(
-      SubscriptionAmendmentAnalyseResult.analyseSupporterPlus2026(
+      AmendmentHandlerHelper.analyseSupporterPlus2026(
         cohortItem,
         subscription,
         today


### PR DESCRIPTION
Makes the AmendmentHandlerHelper a bit cleaner by moving the SubscriptionAmendmentAnalyseResult to its own file