### PR TITLE
Introduce CohortSpec `status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ It currently consists in
 - [An introduction to the general principles of price migrations](docs/price-migrations-from-first-principles.md)
 - [The journey of a cohort item](docs/the-journey-of-a-cohort-item.md)
 - [Coding directives](docs/coding-directives.md)
-- [Operational Directives](docs/operational-directives.md)
+- [Operational directives](docs/operational-directives.md)
+- [Morning startup](docs/morning-startup.md)
 
 ### Future price migrations special directives
 
@@ -34,9 +35,9 @@ It currently consists in
 - [Notes on the Zuora Order API](docs/zuora-order-api.md)
 - [Communication with braze](docs/communication-with-braze.md)
 - [Notes on prices](docs/notes-on-prices.md)
-- [Cohort Items](docs/cohort-items.md)
+- [Cohort items](docs/cohort-items.md)
 - [Troubleshooting document](docs/troubleshooting.md)
-- [Quirks of the Engine](docs/quirks.md)
+- [Quirks of the engine](docs/quirks.md)
 - [Dispatch, dealing with unusually large migration](docs/dispatch.md)
 
 ### Android Price Rises

--- a/docs/morning-startup.md
+++ b/docs/morning-startup.md
@@ -1,0 +1,18 @@
+
+### How does the engine starts in the morning ?
+
+The starting point is specified in the file: stateMachine/cfn/cfn.yaml. At 7am UTC, the lambda `price-migration-lambda-PROD` is fired up.
+
+The lambda takes all the items in the Dynamo table `price-migration-engine-cohort-spec-PROD` and starts a price migration state machine passing in an object of the form
+
+```
+{
+  "cohortSpec": {
+    "cohortName": "Membership2025",
+    "earliestAmendmentEffectiveDate": "2025-12-01",
+    "active": true
+  }
+}
+```
+
+Note that only cohort specs with `active` set to `true` will be fired up.

--- a/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/MigrationHandler.scala
@@ -11,8 +11,11 @@ object MigrationHandler extends ZIOAppDefault with RequestHandler[Unit, Unit] {
 
   private val migrateActiveCohorts: ZIO[CohortSpecTable with CohortStateMachine with Logging, Failure, Unit] =
     (for {
-      cohortSpecs <- CohortSpecTable.fetchAll.tap(specs => Logging.info(s"Currently ${specs.size} active cohorts"))
-      _ <- ZIO.foreachDiscard(cohortSpecs)(CohortStateMachine.startExecution)
+      cohortSpecs <- CohortSpecTable.fetchAll
+      _ <- Logging.info(s"Starting with ${cohortSpecs.size} cohort specs")
+      activeSpecs = cohortSpecs.filter(_.active)
+      _ <- Logging.info(s"Working with ${activeSpecs.size} active cohort specs")
+      _ <- ZIO.foreachDiscard(activeSpecs)(CohortStateMachine.startExecution)
     } yield ()).tapError(e => Logging.error(s"Migration run failed: $e"))
 
   override def run: ZIO[ZIOAppArgs, Any, Any] =

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -40,6 +40,7 @@ import java.util
 case class CohortSpec(
     cohortName: String,
     earliestAmendmentEffectiveDate: LocalDate,
+    active: Boolean,
     subscriptionNumber: Option[String] = None,
     forceNotifications: Option[Boolean] = None,
 ) {
@@ -66,9 +67,11 @@ object CohortSpec {
   def fromDynamoDbItem(values: util.Map[String, AttributeValue]): Either[CohortSpecFetchFailure, CohortSpec] =
     (for {
       cohortName <- getStringFromResults(values, "cohortName")
+      status <- getBooleanFromResults(values, "active")
       earliestAmendmentEffectiveDate <- getDateFromResults(values, "earliestAmendmentEffectiveDate")
     } yield CohortSpec(
       cohortName,
-      earliestAmendmentEffectiveDate
+      earliestAmendmentEffectiveDate,
+      status
     )).left.map(e => CohortSpecFetchFailure(e))
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -59,7 +59,7 @@ object CohortSpec {
   implicit val rw: ReadWriter[CohortSpec] = macroRW
 
   def isValid(spec: CohortSpec): Boolean = {
-    def isValidStringValue(s: String) = s.trim == s && s.nonEmpty && s.matches("[A-Za-z0-9-_ ]+")
+    def isValidStringValue(s: String) = s.trim == s && s.nonEmpty && s.matches("[A-Za-z0-9-_]+")
     isValidStringValue(spec.cohortName)
   }
 

--- a/lambda/src/main/scala/pricemigrationengine/model/dynamodb/Conversions.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/dynamodb/Conversions.scala
@@ -124,4 +124,20 @@ object Conversions {
         )
       }
     } yield optionalDecimal
+
+  def getBooleanFromResults(result: util.Map[String, AttributeValue], fieldName: String): Either[String, Boolean] =
+    for {
+      optionalBoolean <- getOptionalBooleanFromResults(result, fieldName)
+      boolean <- optionalBoolean.toRight(s"The '$fieldName' field did not exist in the record '$result'")
+    } yield boolean
+
+  def getOptionalBooleanFromResults(
+      result: util.Map[String, AttributeValue],
+      fieldName: String
+  ): Either[String, Option[Boolean]] =
+    result.asScala
+      .get(fieldName)
+      .fold[Either[String, Option[Boolean]]](Right(None)) { attributeValue =>
+        Right(Option(attributeValue.bool()))
+      }
 }

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -85,7 +85,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
     val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
 
     val cohortSpec: CohortSpec =
-      CohortSpec("Test1", LocalDate.of(2022, 1, 1))
+      CohortSpec("Test1", LocalDate.of(2022, 1, 1), active = true)
 
     val cohortItem = CohortItem(
       subscriptionName = subscriptionName,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -68,6 +68,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
           .main(
             CohortSpec(
               cohortName = "cohortName",
+              active = true,
               earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 1)
             )
           )

--- a/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2025MigrationTest.scala
@@ -83,7 +83,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/01/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25))
+    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25), active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -109,7 +109,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/02/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25))
+    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25), active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -135,7 +135,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/03/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25))
+    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25), active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -161,7 +161,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/04/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25))
+    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25), active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
@@ -331,7 +331,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     // val account = Fixtures.accountFromJson("Migrations/SupporterPlus2026/01/account.json")
     // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01/invoice-preview.json")
 
-    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 7, 1))
+    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 7, 1), active = true)
 
     // Note that we are defining the CohortItem only with the attributes we need
     // That particular value would not happen in the wild.
@@ -367,7 +367,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     // val account = Fixtures.accountFromJson("Migrations/SupporterPlus2026/01-variant1-non-zero-contribution/account.json")
     // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01-variant1-non-zero-contribution/invoice-preview.json"
 
-    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 7, 1))
+    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 7, 1), active = true)
 
     // Note that we are defining the CohortItem only with the attributes we need
     // That particular value would not happen in the wild.
@@ -639,7 +639,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 8, 1)
-    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 8, 19))
+    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 8, 19), active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -674,7 +674,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     )
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 8, 1)
-    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 8, 19))
+    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 8, 19), active = true)
 
     // Here the Estimation is identical to that of '[01]', because the extra contribution amount
     // is not affecting it

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -187,6 +187,7 @@ class AmendmentDataTest extends munit.FunSuite {
     val today = LocalDate.of(2025, 7, 1) // 1 July 2025
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
+      active = true,
       earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculatorTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculatorTest.scala
@@ -19,6 +19,7 @@ class AmendmentEffectiveDateCalculatorTest extends munit.FunSuite {
     val today = LocalDate.of(2025, 7, 1) // 1 July 2025
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
+      active = true,
       earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 
@@ -119,6 +120,7 @@ class AmendmentEffectiveDateCalculatorTest extends munit.FunSuite {
     val today = LocalDate.of(2025, 7, 1) // 1 July 2025
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
+      active = true,
       earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
     )
 

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -9,7 +9,8 @@ import scala.jdk.CollectionConverters._
 class CohortSpecTest extends munit.FunSuite {
 
   private val cohortSpec = CohortSpec(
-    cohortName = "Home Delivery 2018",
+    cohortName = "HomeDelivery2018",
+    active = true,
     earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 2)
   )
 
@@ -18,7 +19,8 @@ class CohortSpecTest extends munit.FunSuite {
 
   test("fromDynamoDbItem: should include all fields") {
     val item = Map(
-      "cohortName" -> AttributeValue.builder.s("Home Delivery 2018").build(),
+      "cohortName" -> AttributeValue.builder.s("HomeDelivery2018").build(),
+      "active" -> AttributeValue.builder.bool(true).build(),
       "earliestAmendmentEffectiveDate" -> AttributeValue.builder.s("2020-01-02").build()
     ).asJava
     assertEquals(
@@ -32,6 +34,6 @@ class CohortSpecTest extends munit.FunSuite {
   }
 
   test("isValid: should be false when the cohort name has trailing whitespace") {
-    assertFalse(isValid(cohortSpec.copy(cohortName = "Home Delivery 2018 ")))
+    assertFalse(isValid(cohortSpec.copy(cohortName = "HomeDelivery 2018")))
   }
 }

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -18,6 +18,7 @@ class CohortTableLiveTest extends munit.FunSuite {
 
   private val cohortSpec = CohortSpec(
     cohortName = "name",
+    active = true,
     earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 1)
   )
 

--- a/lambda/src/test/scala/pricemigrationengine/model/DispatchTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/DispatchTest.scala
@@ -6,6 +6,7 @@ class DispatchTest extends munit.FunSuite {
   test("Dispatch (1)") {
     val cohortSpec = CohortSpec(
       cohortName = "DigiSubs2025",
+      active = true,
       earliestAmendmentEffectiveDate = LocalDate.of(2026, 2, 1)
     )
 
@@ -28,6 +29,7 @@ class DispatchTest extends munit.FunSuite {
   test("Dispatch (2)") {
     val cohortSpec = CohortSpec(
       cohortName = "SupporterPlus2026",
+      active = true,
       earliestAmendmentEffectiveDate = LocalDate.of(2026, 8, 1)
     )
 
@@ -53,6 +55,7 @@ class DispatchTest extends munit.FunSuite {
 
     val cohortSpec = CohortSpec(
       cohortName = "SupporterPlus2026N4",
+      active = true,
       earliestAmendmentEffectiveDate = LocalDate.of(2026, 8, 1)
     )
 

--- a/stateMachine/cfn/cfn.yaml
+++ b/stateMachine/cfn/cfn.yaml
@@ -442,7 +442,7 @@ Resources:
       - PriceMigrationLambda
     Condition: IsProd
     Properties:
-      AlarmName: "URGENT 9-5 - PROD: Price-rise engine: Failure to kick-off process"
+      AlarmName: "Price-rise engine (PROD): Failure to kick-off process"
       AlarmDescription: >
         IMPACT: If this is not dealt with, no price-rise processes will run.
         For troubleshooting tips, see https://github.com/guardian/price-migration-engine/blob/main/docs/troubleshooting.md
@@ -466,7 +466,7 @@ Resources:
       - CohortStateMachine
     Condition: IsProd
     Properties:
-      AlarmName: "URGENT 9-5 - PROD: Price-rise engine: Failure to complete process"
+      AlarmName: "Price-rise engine (PROD): Failure to complete process"
       AlarmDescription: >
         IMPACT: If this is not dealt with, the price rise may be unable to continue.
         For troubleshooting tips, see https://github.com/guardian/price-migration-engine/blob/main/docs/troubleshooting.md


### PR DESCRIPTION
In some specific instances I need to prevent a given cohort spec from firing up at 7am and the only solution for it until now was to delete the record from the `price-migration-engine-cohort-spec-PROD` table and then put it back later. This is tedious and error prone. 

Here we introduce a new attribute `active` to cohort Specs. Which indicates whether the cohort specs is active (and should be fired up) or not.  This is a native DynamoDB boolean.

All existing records of the table have been updated

<img width="705" height="664" alt="Screenshot 2026-08-13 at 13 09 23" src="https://github.com/user-attachments/assets/935829d3-dce6-4117-ad25-02d0d96a3746" />

Note that we also took the occasion to tighten the rules for the cohort names (no space, no underscore, only alphabetical). 
