### PR TITLE
Move the earliestAmendmentEffectiveDate to the migrations

### DIFF
--- a/docs/amendment-effective-date-computation.md
+++ b/docs/amendment-effective-date-computation.md
@@ -15,13 +15,13 @@ First we need a cohort spec. Let's assume that the cohort spec is
 ```
 {
     "cohortName":"GW2024",
-    "earliestAmendmentEffectiveDate":"2024-05-20" 
+    "active": true 
 }
 ```
 
-The only relevant bit of cohort spec we need for the computation of a subscription's effective date is the `earliestAmendmentEffectiveDate`. 
+From the cohort spec we can derive the `earliestAmendmentEffectiveDate` by calling `EstimationHandlerHelper.earliestAmendmentEffectiveDate`
 
-Let us assume thay the notification period for this migration is `[-49, -36]`. This is Pascal's notation for the fact that we start notifying at -49 days and alarm at -36.
+Let us assume that the notification period for this migration is `[-49, -36]`. This is Pascal's notation for the fact that we start notifying at -49 days and alarm at -36.
 
 Let us assume that our subscription is a monthly subscription paying on the 27th of each month, and let us assume that it was created on 8th July 2023.
 

--- a/docs/lambdas-code-structure.md
+++ b/docs/lambdas-code-structure.md
@@ -52,7 +52,7 @@ Individual lambdas like the `EstimationLambda` and the `AmendmentLambda` can be 
 ``` 
 {
   "cohortName": "EchoLegacyTesting",
-  "earliestAmendmentEffectiveDate": "2022-08-02"
+  "active" : true
 }
 ```
 

--- a/docs/migration-implementation-manual.md
+++ b/docs/migration-implementation-manual.md
@@ -19,23 +19,21 @@ As part of setting up a migration you will want to run some of the lambdas on de
 ```
 {
     "cohortName":"GW2024",
-    "earliestAmendmentEffectiveDate":"2024-05-20"
+    "active": true
 }
 
 {
     "cohortSpec": {
         "cohortName":"GW2024",
-        "earliestAmendmentEffectiveDate":"2024-05-20"
+        "active": true
     }
 }
 ```
 
 The difference between the two is that the former is used to run specific lambdas and the latter used to run the state machine itself. They both carry the same information.
 
-* **cohortName**: A unique name to identify the cohort. Must consist of alphanumeric, '-' and '_' characters (without space(s)). [1]
-* **earliestAmendmentEffectiveDate**: Earliest date on which a subscription can have its price increased, or will move to another rate plan (with or without price increase). Increases will always begin on the first day of a billing period on or after this date. Format is `yyyy-mm-dd`.
-
-[1] Pascal always sticks to alphanumerical names, for instance "HomeDelivery2025" (where the year the migration has started appears in the name)
+* **cohortName**: A unique name to identify the cohort. Must consist of alphanumeric characters (without space(s)).
+* **active**: A boolean that indicates whether the related state machine is started in the morning ot not.
 
 ## Subscription numbers upload to the DynamoDB tables
 

--- a/docs/morning-startup.md
+++ b/docs/morning-startup.md
@@ -9,7 +9,6 @@ The lambda takes all the items in the Dynamo table `price-migration-engine-cohor
 {
   "cohortSpec": {
     "cohortName": "Membership2025",
-    "earliestAmendmentEffectiveDate": "2025-12-01",
     "active": true
   }
 }

--- a/docs/subscription-numbers-upload.md
+++ b/docs/subscription-numbers-upload.md
@@ -37,7 +37,7 @@ Do not forget to set the correct cohort specifications (see example below, but u
 ```
 {
     "cohortName":"migration-name",
-    "earliestAmendmentEffectiveDate":"2024-05-20" 
+    "active": true
 }
 ```
 

--- a/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/CohortHandler.scala
@@ -61,8 +61,7 @@ trait CohortHandler extends ZIOAppDefault with RequestStreamHandler {
     * {
     *     "cohortSpec":{
     *         "cohortName":"M2023",
-    *         "brazeName":"SV_MB_M2023",
-    *         "earliestAmendmentEffectiveDate":"2023-01-02"
+    *         "active": true
     *     }
     * }
     */

--- a/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
+++ b/lambda/src/main/scala/pricemigrationengine/handlers/EstimationHandler.scala
@@ -106,7 +106,7 @@ object EstimationHandler extends CohortHandler {
             SubscriptionAutoRenewIsFalseFailure(s"subscription ${item.subscriptionName} autoRenew flag is false")
           )
       account <- Zuora.fetchAccount(subscription.accountNumber, subscription.subscriptionNumber)
-      invoicePreviewTargetDate = cohortSpec.earliestAmendmentEffectiveDate.plusMonths(16)
+      invoicePreviewTargetDate = EstimationHandlerHelper.earliestAmendmentEffectiveDate(cohortSpec).plusMonths(16)
       invoicePreview <- Zuora
         .fetchInvoicePreview(subscription.accountId, invoicePreviewTargetDate)
       amendmentEffectiveDateLowerBound <- ZIO.succeed(

--- a/lambda/src/main/scala/pricemigrationengine/migrations/DigiSubs2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/DigiSubs2025Migration.scala
@@ -11,6 +11,8 @@ import scala.math.BigDecimal.RoundingMode
 
 object DigiSubs2025Migration {
 
+  val earliestAmendmentEffectiveDate = LocalDate.of(2026, 1, 12)
+
   val maxLeadTime = 35
   val minLeadTime = 33
 

--- a/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/GuardianWeekly2025Migration.scala
@@ -30,6 +30,8 @@ object GuardianWeekly2025ExtraAttributes {
 
 object GuardianWeekly2025Migration {
 
+  val earliestAmendmentEffectiveDate = LocalDate.of(2025, 8, 4)
+
   // ------------------------------------------------
   // Notification Timings
   // ------------------------------------------------

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Membership2025Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Membership2025Migration.scala
@@ -9,6 +9,8 @@ import ujson._
 
 object Membership2025Migration {
 
+  val earliestAmendmentEffectiveDate = LocalDate.of(2025, 12, 1)
+
   val maxLeadTime = 35
   val minLeadTime = 33
 

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P1Migration.scala
@@ -43,6 +43,8 @@ case class Newspaper2025P1NotificationData(
 
 object Newspaper2025P1Migration {
 
+  val earliestAmendmentEffectiveDate = LocalDate.of(2025, 8, 13)
+
   // ------------------------------------------------
   // Notification Timings
   // ------------------------------------------------

--- a/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/Newspaper2025P3Migration.scala
@@ -43,6 +43,8 @@ case class Newspaper2025P3NotificationData(
 
 object Newspaper2025P3Migration {
 
+  val earliestAmendmentEffectiveDate = LocalDate.of(2025, 8, 28)
+
   // ------------------------------------------------
   // Notification Timings
   // ------------------------------------------------

--- a/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/ProductMigration2025N4Migration.scala
@@ -25,6 +25,8 @@ case class N4Target(
 
 object ProductMigration2025N4Migration {
 
+  val earliestAmendmentEffectiveDate = LocalDate.of(2025, 11, 6)
+
   val maxLeadTime = 1000
   val minLeadTime = 0
 

--- a/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
+++ b/lambda/src/main/scala/pricemigrationengine/migrations/SupporterPlus2026Migration.scala
@@ -17,6 +17,8 @@ case class SP2026EmailExtraAttributes(
 
 object SupporterPlus2026Migration {
 
+  val earliestAmendmentEffectiveDate = LocalDate.of(2026, 8, 19)
+
   // ------------------------------------------------
   // Notification Timings
   // ------------------------------------------------

--- a/lambda/src/main/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculator.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculator.scala
@@ -62,7 +62,7 @@ object AmendmentEffectiveDateCalculator {
     //   during a single month.
 
     Date.datesMax(
-      cohortSpec.earliestAmendmentEffectiveDate,
+      EstimationHandlerHelper.earliestAmendmentEffectiveDate(cohortSpec),
       today.plusDays(
         NotificationHandler.minLeadTime(cohortSpec: CohortSpec) + 1
       ) // +1 because we need to be strictly over minLeadTime days away. Exactly minLeadTime is not enough.

--- a/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/CohortSpec.scala
@@ -12,11 +12,7 @@ import java.util
   * @param cohortName
   *   Name that uniquely identifies a cohort, eg. "Vouchers2020"
   *
-  * @param earliestAmendmentEffectiveDate
-  *   Earliest date on which any sub in the cohort can have price migrated. The actual date for any sub will depend on
-  *   its billing dates.
-  *
-  * @param subscriptionNumber
+  * @param subscriptionNumber (optional)
   *   subscriptionNumber is an optional attribute, which, when present, and in the correct context (eg:
   *   estimation handler, notification handler and amendment handler) is going to cause the handler to run
   *   on this one specified subscription, rather than a subset of the cohort table. Note that for security,
@@ -24,7 +20,7 @@ import java.util
   *   handler. This attribute was added to CohortSpec in August 2025, to help with rescuing some print migration
   *   cohort items causing timeouts in Zuora. This attribute is not intended to be used by the state machine.
   *
-  * @param forceNotifications
+  * @param forceNotifications (optional)
   *   When present, and if true, it will
   *   1. override the Notification handler's `thereIsEnoughNotificationLeadTime` check.
   *      This allows sending notifications before the -30 days deadline, but after they have
@@ -39,7 +35,6 @@ import java.util
 
 case class CohortSpec(
     cohortName: String,
-    earliestAmendmentEffectiveDate: LocalDate,
     active: Boolean,
     subscriptionNumber: Option[String] = None,
     forceNotifications: Option[Boolean] = None,
@@ -68,10 +63,8 @@ object CohortSpec {
     (for {
       cohortName <- getStringFromResults(values, "cohortName")
       status <- getBooleanFromResults(values, "active")
-      earliestAmendmentEffectiveDate <- getDateFromResults(values, "earliestAmendmentEffectiveDate")
     } yield CohortSpec(
       cohortName,
-      earliestAmendmentEffectiveDate,
       status
     )).left.map(e => CohortSpecFetchFailure(e))
 }

--- a/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
+++ b/lambda/src/main/scala/pricemigrationengine/model/EstimationHandlerHelper.scala
@@ -1,8 +1,34 @@
 package pricemigrationengine.model
 
-import pricemigrationengine.migrations.Membership2025Migration
+import pricemigrationengine.migrations.{
+  DigiSubs2025Migration,
+  GuardianWeekly2025Migration,
+  Membership2025Migration,
+  Newspaper2025P1Migration,
+  ProductMigration2025N4Migration,
+  SupporterPlus2026Migration
+}
+
+import java.time.LocalDate
 
 object EstimationHandlerHelper {
+
+  def earliestAmendmentEffectiveDate(cohortSpec: CohortSpec): LocalDate = {
+    MigrationType(cohortSpec) match {
+      case Test1                  => LocalDate.of(2025, 9, 10)
+      case GuardianWeekly2025     => GuardianWeekly2025Migration.earliestAmendmentEffectiveDate
+      case Newspaper2025P1        => Newspaper2025P1Migration.earliestAmendmentEffectiveDate
+      case Newspaper2025P3        => Newspaper2025P1Migration.earliestAmendmentEffectiveDate
+      case ProductMigration2025N4 => ProductMigration2025N4Migration.earliestAmendmentEffectiveDate
+      case Membership2025         => Membership2025Migration.earliestAmendmentEffectiveDate
+      case DigiSubs2025           => DigiSubs2025Migration.earliestAmendmentEffectiveDate
+      case SupporterPlus2026      => SupporterPlus2026Migration.earliestAmendmentEffectiveDate
+      case SupporterPlus2026N2    => SupporterPlus2026Migration.earliestAmendmentEffectiveDate
+      case SupporterPlus2026N3    => SupporterPlus2026Migration.earliestAmendmentEffectiveDate
+      case SupporterPlus2026N4    => SupporterPlus2026Migration.earliestAmendmentEffectiveDate
+      case SupporterPlus2026N5    => SupporterPlus2026Migration.earliestAmendmentEffectiveDate
+    }
+  }
 
   def migrationCapRatio(cohortSpec: CohortSpec): Option[Double] = {
     // This is where we declare the optional capping of each migration

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SalesforceNotificationDateUpdateHandlerTest.scala
@@ -85,7 +85,7 @@ class SalesforceNotificationDateUpdateHandlerTest extends munit.FunSuite {
     val updatedResultsWrittenToCohortTable = ArrayBuffer[CohortItem]()
 
     val cohortSpec: CohortSpec =
-      CohortSpec("Test1", LocalDate.of(2022, 1, 1), active = true)
+      CohortSpec("Test1", active = true)
 
     val cohortItem = CohortItem(
       subscriptionName = subscriptionName,

--- a/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/handlers/SubscriptionIdUploadHandlerTest.scala
@@ -68,8 +68,7 @@ class SubscriptionIdUploadHandlerTest extends munit.FunSuite {
           .main(
             CohortSpec(
               cohortName = "cohortName",
-              active = true,
-              earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 1)
+              active = true
             )
           )
           .provideLayer(

--- a/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2025MigrationTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/DigiSubs2025MigrationTest.scala
@@ -83,7 +83,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/01/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25), active = true)
+    val cohortSpec = CohortSpec("DigiSubs2025", active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -109,7 +109,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/02/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25), active = true)
+    val cohortSpec = CohortSpec("DigiSubs2025", active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -135,7 +135,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/03/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25), active = true)
+    val cohortSpec = CohortSpec("DigiSubs2025", active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -161,7 +161,7 @@ class DigiSubs2025MigrationTest extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/DigiSubs2025/04/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 2, 1)
-    val cohortSpec = CohortSpec("DigiSubs2025", LocalDate.of(2025, 11, 25), active = true)
+    val cohortSpec = CohortSpec("DigiSubs2025", active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),

--- a/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
+++ b/lambda/src/test/scala/pricemigrationengine/migrations/SupporterPlus2026Test.scala
@@ -331,7 +331,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     // val account = Fixtures.accountFromJson("Migrations/SupporterPlus2026/01/account.json")
     // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01/invoice-preview.json")
 
-    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 7, 1), active = true)
+    val cohortSpec = CohortSpec("SupporterPlus2026", active = true)
 
     // Note that we are defining the CohortItem only with the attributes we need
     // That particular value would not happen in the wild.
@@ -367,7 +367,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     // val account = Fixtures.accountFromJson("Migrations/SupporterPlus2026/01-variant1-non-zero-contribution/account.json")
     // val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01-variant1-non-zero-contribution/invoice-preview.json"
 
-    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 7, 1), active = true)
+    val cohortSpec = CohortSpec("SupporterPlus2026", active = true)
 
     // Note that we are defining the CohortItem only with the attributes we need
     // That particular value would not happen in the wild.
@@ -639,7 +639,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     val invoicePreview = Fixtures.invoiceListFromJson("Migrations/SupporterPlus2026/01/invoice-preview.json")
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 8, 1)
-    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 8, 19), active = true)
+    val cohortSpec = CohortSpec("SupporterPlus2026", active = true)
 
     assertEquals(
       EstimationResult.apply(account, subscription, invoicePreview, amendmentEffectiveDateLowerBound, cohortSpec),
@@ -674,7 +674,7 @@ class SupporterPlus2026Test extends munit.FunSuite {
     )
 
     val amendmentEffectiveDateLowerBound = LocalDate.of(2026, 8, 1)
-    val cohortSpec = CohortSpec("SupporterPlus2026", LocalDate.of(2026, 8, 19), active = true)
+    val cohortSpec = CohortSpec("SupporterPlus2026", active = true)
 
     // Here the Estimation is identical to that of '[01]', because the extra contribution amount
     // is not affecting it

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentDataTest.scala
@@ -187,8 +187,7 @@ class AmendmentDataTest extends munit.FunSuite {
     val today = LocalDate.of(2025, 7, 1) // 1 July 2025
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
-      active = true,
-      earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
+      active = true
     )
 
     assertEquals(

--- a/lambda/src/test/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculatorTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/AmendmentEffectiveDateCalculatorTest.scala
@@ -19,8 +19,7 @@ class AmendmentEffectiveDateCalculatorTest extends munit.FunSuite {
     val today = LocalDate.of(2025, 7, 1) // 1 July 2025
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
-      active = true,
-      earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
+      active = true
     )
 
     // --------------------------------------------------
@@ -120,8 +119,7 @@ class AmendmentEffectiveDateCalculatorTest extends munit.FunSuite {
     val today = LocalDate.of(2025, 7, 1) // 1 July 2025
     val cohortSpec = CohortSpec(
       cohortName = "Test1",
-      active = true,
-      earliestAmendmentEffectiveDate = LocalDate.of(2025, 9, 10) // 10 Sept 2025
+      active = true
     )
 
     // --------------------------------------------------

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -11,7 +11,6 @@ class CohortSpecTest extends munit.FunSuite {
   private val cohortSpec = CohortSpec(
     cohortName = "HomeDelivery2018",
     active = true,
-    earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 2)
   )
 
   private def assertTrue(obtained: Boolean): Unit = assertEquals(obtained, true)

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortSpecTest.scala
@@ -20,7 +20,6 @@ class CohortSpecTest extends munit.FunSuite {
     val item = Map(
       "cohortName" -> AttributeValue.builder.s("HomeDelivery2018").build(),
       "active" -> AttributeValue.builder.bool(true).build(),
-      "earliestAmendmentEffectiveDate" -> AttributeValue.builder.s("2020-01-02").build()
     ).asJava
     assertEquals(
       CohortSpec.fromDynamoDbItem(item),

--- a/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/CohortTableLiveTest.scala
@@ -18,8 +18,7 @@ class CohortTableLiveTest extends munit.FunSuite {
 
   private val cohortSpec = CohortSpec(
     cohortName = "name",
-    active = true,
-    earliestAmendmentEffectiveDate = LocalDate.of(2020, 1, 1)
+    active = true
   )
 
   val stubCohortTableConfiguration = ZLayer.succeed(CohortTableConfig(10))

--- a/lambda/src/test/scala/pricemigrationengine/model/DispatchTest.scala
+++ b/lambda/src/test/scala/pricemigrationengine/model/DispatchTest.scala
@@ -6,8 +6,7 @@ class DispatchTest extends munit.FunSuite {
   test("Dispatch (1)") {
     val cohortSpec = CohortSpec(
       cohortName = "DigiSubs2025",
-      active = true,
-      earliestAmendmentEffectiveDate = LocalDate.of(2026, 2, 1)
+      active = true
     )
 
     // For DigiSubs2025 we expect the belong function to always return true
@@ -29,8 +28,7 @@ class DispatchTest extends munit.FunSuite {
   test("Dispatch (2)") {
     val cohortSpec = CohortSpec(
       cohortName = "SupporterPlus2026",
-      active = true,
-      earliestAmendmentEffectiveDate = LocalDate.of(2026, 8, 1)
+      active = true
     )
 
     // For SupporterPlus2026,
@@ -55,8 +53,7 @@ class DispatchTest extends munit.FunSuite {
 
     val cohortSpec = CohortSpec(
       cohortName = "SupporterPlus2026N4",
-      active = true,
-      earliestAmendmentEffectiveDate = LocalDate.of(2026, 8, 1)
+      active = true
     )
 
     val cohortItem1: CohortItem = CohortItem(


### PR DESCRIPTION
Here we perform the last step of the simplification of CohortSpec by moving the `earliestAmendmentEffectiveDate` attribute from the CohortSpec to the migration own's module.

1. `earliestAmendmentEffectiveDate` should be in the migration's own module because it's migration data, like the price grids or the notification windows
2. `earliestAmendmentEffectiveDate` should not be in the CohortSpec, because it's only ever used in the EstimationHandler. 
